### PR TITLE
fix: sharpen MuJoCo render shadows and edges in menagerie scenes

### DIFF
--- a/packages/so101-nexus-core/src/so101_nexus_core/assets/SO101_menagerie/scene.xml
+++ b/packages/so101-nexus-core/src/so101_nexus_core/assets/SO101_menagerie/scene.xml
@@ -5,6 +5,8 @@
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>
     <global azimuth="160" elevation="-20"/>
+    <quality shadowsize="8192" offsamples="8"/>
+    <map shadowclip="0.5"/>
   </visual>
 
   <asset>

--- a/packages/so101-nexus-core/src/so101_nexus_core/assets/SO101_menagerie/scene_box.xml
+++ b/packages/so101-nexus-core/src/so101_nexus_core/assets/SO101_menagerie/scene_box.xml
@@ -5,6 +5,8 @@
     <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <rgba haze="0.15 0.25 0.35 1"/>
     <global azimuth="160" elevation="-20"/>
+    <quality shadowsize="8192" offsamples="8"/>
+    <map shadowclip="0.5"/>
   </visual>
 
   <asset>


### PR DESCRIPTION
The menagerie scene wrappers defined no <quality> or <map> settings, so offscreen rollout renders fell back to MuJoCo defaults. With the single scene-spanning directional light, the fixed-size shadow map stretched across the infinite floor plane, producing coarse, pixelated shadow edges, and offsamples=4 left visible aliasing on geometry silhouettes.

Add to both scene.xml and scene_box.xml:
- <quality shadowsize="8192" offsamples="8"> for higher shadow-map resolution and 2x MSAA edge anti-aliasing.
- <map shadowclip="0.5"> to concentrate the directional light's shadow frustum on the working area instead of the full model extent.