### PR TITLE
fix(teleop): locate episode buffer across LeRobot 0.5.x layouts

### DIFF
--- a/src/so101_nexus/teleop/dataset.py
+++ b/src/so101_nexus/teleop/dataset.py
@@ -145,22 +145,36 @@ def _make_reward_scalar_dataset_cls():
     (1,) arrays that ``add_frame`` accumulates triggers a NumPy deprecation
     warning when ``datasets`` coerces each element to ``float`` during
     ``save_episode``. This subclass squeezes the reward buffer to Python
-    scalars before the parent's ``np.stack``, matching how LeRobot handles
-    its own ``DEFAULT_FEATURES`` (timestamp, frame_index, etc.).
+    scalars before the ``np.stack`` that backs ``save_episode``, matching how
+    LeRobot handles its own ``DEFAULT_FEATURES`` (timestamp, frame_index, etc.).
+
+    The in-progress buffer moved between supported 0.5.x layouts: 0.5.0 keeps
+    it on the dataset (``self.episode_buffer``), while 0.5.1 routes recording
+    through a ``DatasetWriter`` reached via ``self.writer.episode_buffer``.
+    Only ``save_episode`` needs overriding: ``add_frame`` and
+    ``clear_episode_buffer`` already act on the live buffer on both layouts
+    (native in 0.5.0, writer-delegated in 0.5.1) and never stack reward.
     """
     from lerobot.datasets.lerobot_dataset import LeRobotDataset
 
     class RewardRecordingDataset(LeRobotDataset):
         """LeRobotDataset that records the reward feature without scalar coercion warnings."""
 
+        def _active_episode_buffer(self) -> dict | None:
+            """Return the in-progress episode buffer across LeRobot 0.5.x layouts."""
+            buf = getattr(self, "episode_buffer", None)
+            if buf is None:
+                buf = getattr(getattr(self, "writer", None), "episode_buffer", None)
+            return buf
+
         def save_episode(
             self,
             episode_data: dict | None = None,
             parallel_encoding: bool = True,
         ) -> None:
-            if episode_data is None and self.episode_buffer is not None:
-                buf = self.episode_buffer
-                if "reward" in buf and isinstance(buf["reward"], list):
+            if episode_data is None:
+                buf = self._active_episode_buffer()
+                if buf is not None and isinstance(buf.get("reward"), list):
                     buf["reward"] = [float(np.asarray(v).reshape(-1)[0]) for v in buf["reward"]]
             super().save_episode(episode_data, parallel_encoding)
 

--- a/tests/core/test_teleop_dataset.py
+++ b/tests/core/test_teleop_dataset.py
@@ -235,3 +235,68 @@ def test_dataset_falls_back_to_lerobot_datasets_utils(monkeypatch) -> None:
 
         assert module._hw_to_dataset_features() is sentinel
     _reload_dataset_module()
+
+
+def _reward_buffer() -> dict:
+    return {"reward": [np.array([0.25], dtype=np.float32), np.array([1.5], dtype=np.float32)]}
+
+
+def _patch_parent_save_episode(monkeypatch) -> dict:
+    """Stub ``LeRobotDataset.save_episode`` so the override is tested in isolation."""
+    from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+    seen: dict = {}
+
+    def stub(self, episode_data=None, parallel_encoding=True):
+        seen["episode_data"] = episode_data
+
+    monkeypatch.setattr(LeRobotDataset, "save_episode", stub, raising=True)
+    return seen
+
+
+def _blank_recording_obj(cls):
+    """Construct a recording instance without LeRobot's heavy ``create()``.
+
+    ``_is_finalized`` and no-op writer hooks keep ``LeRobotDataset.__del__``
+    quiet at GC time across both 0.5.x layouts.
+    """
+    obj = cls.__new__(cls)
+    obj._is_finalized = True
+    obj.writer = None
+    return obj
+
+
+def test_reward_squeeze_finds_dataset_buffer_lerobot_050(monkeypatch) -> None:
+    """0.5.0 keeps the in-progress buffer on the dataset itself."""
+    pytest.importorskip("lerobot")
+    from so101_nexus.teleop.dataset import _make_reward_scalar_dataset_cls
+
+    seen = _patch_parent_save_episode(monkeypatch)
+    obj = _blank_recording_obj(_make_reward_scalar_dataset_cls())
+    buf = _reward_buffer()
+    obj.episode_buffer = buf
+
+    obj.save_episode()
+
+    assert seen["episode_data"] is None
+    assert buf["reward"] == [pytest.approx(0.25), pytest.approx(1.5)]
+    assert all(isinstance(v, float) for v in buf["reward"])
+
+
+def test_reward_squeeze_finds_writer_buffer_lerobot_051(monkeypatch) -> None:
+    """0.5.1 routes recording through a DatasetWriter; the dataset has no episode_buffer."""
+    pytest.importorskip("lerobot")
+    from so101_nexus.teleop.dataset import _make_reward_scalar_dataset_cls
+
+    seen = _patch_parent_save_episode(monkeypatch)
+    obj = _blank_recording_obj(_make_reward_scalar_dataset_cls())
+    buf = _reward_buffer()
+    obj.writer = types.SimpleNamespace(
+        episode_buffer=buf, close=lambda: None, finalize=lambda: None
+    )
+
+    obj.save_episode()
+
+    assert seen["episode_data"] is None
+    assert buf["reward"] == [pytest.approx(0.25), pytest.approx(1.5)]
+    assert all(isinstance(v, float) for v in buf["reward"])


### PR DESCRIPTION
LeRobot 0.5.1 moved recording into a DatasetWriter, relocating the in-progress buffer from dataset.episode_buffer to
dataset.writer.episode_buffer and dropping the episode_buffer attribute from LeRobotDataset. RewardRecordingDataset.save_episode reached for self.episode_buffer directly, raising 'RewardRecordingDataset' object has no attribute 'episode_buffer' on save from teleop.

Resolve the buffer via self.episode_buffer with a fallback to self.writer.episode_buffer, covering both supported 0.5.x layouts. Add regression tests for each layout.