### PR TITLE
fix: resolve training-friction bugs in obs dtype and episode-length docs

### DIFF
--- a/docs/content/docs/api/configs.mdx
+++ b/docs/content/docs/api/configs.mdx
@@ -172,7 +172,7 @@ Base configuration for all environments. Task-specific configs extend this class
 ```python
 from so101_nexus import EnvironmentConfig
 
-config = EnvironmentConfig(max_episode_steps=512, obs_mode="state")
+config = EnvironmentConfig(obs_mode="state")
 ```
 
 ### Constructor Parameters
@@ -183,7 +183,6 @@ config = EnvironmentConfig(max_episode_steps=512, obs_mode="state")
 | `reward` | `RewardConfig \| None` | `None` | Reward weights. Uses `RewardConfig()` defaults when `None`. |
 | `robot` | `RobotConfig \| None` | `None` | Robot settings. Uses `RobotConfig()` defaults when `None`. |
 | `ground_colors` | `ColorConfig` | `"gray"` | Ground plane color(s) |
-| `max_episode_steps` | `int` | `1024` | Maximum steps before truncation |
 | `reset_settle_frames` | `int` | `5` | No-op environment frames advanced after reset before returning the first observation |
 | `goal_thresh` | `float` | `0.025` | Distance threshold for goal completion (meters) |
 | `spawn_half_size` | `float` | `0.05` | Half-size of object spawn region |
@@ -202,6 +201,22 @@ config = EnvironmentConfig(max_episode_steps=512, obs_mode="state")
 - `reset_settle_frames` must be a nonnegative integer
 - When `obs_mode="visual"`, `observations` must contain at least one camera component (`WristCamera` or `OverheadCamera`)
 - Duplicate camera component types are not allowed
+
+### Episode Length
+
+`max_episode_steps` is owned by the Gymnasium registration, not the config. Set it per env at construction, the same way for every task:
+
+```python
+import gymnasium as gym
+
+# MuJoCo (single env): applied via the TimeLimit wrapper
+env = gym.make("MuJoCoTouch-v1", config=config, max_episode_steps=256)
+
+# Warp (batched): forwarded to the vector env, which truncates internally
+envs = gym.make_vec("WarpTouch-v1", num_envs=4, device="cuda", config=config, max_episode_steps=256)
+```
+
+Registered defaults: PickLift and PickAndPlace 1024, Touch 512, LookAt and Move 256. They apply to both the `MuJoCo*-v1` and `Warp*-v1` ids.
 
 ---
 
@@ -374,7 +389,7 @@ config = LookAtConfig(
 | `objects` | `list[SceneObject] \| SceneObject \| None` | `None` | Target object(s). Only `CubeObject` is supported. Defaults to `[CubeObject()]`. |
 | `fov_deg` | `float \| None` | `None` | Wrist-camera vertical FOV in degrees; success = target within `fov_deg / 2` of the optical axis. `None` reads the live camera FOV. |
 
-Defaults `max_episode_steps` to 256.
+The `MuJoCoLookAt-v1` and `WarpLookAt-v1` registrations default `max_episode_steps` to 256; override it at construction via `gym.make(..., max_episode_steps=N)` (MuJoCo) or `gym.make_vec(..., max_episode_steps=N)` (Warp).
 
 ### Default Observations
 
@@ -400,7 +415,7 @@ config = MoveConfig(direction="up", target_distance=0.10)
 | `target_distance` | `float` | `0.10` | Distance in metres to travel from the initial TCP position |
 | `success_threshold` | `float` | `0.01` | Max residual distance (m) to count as success |
 
-Defaults `max_episode_steps` to 256.
+The `MuJoCoMove-v1` and `WarpMove-v1` registrations default `max_episode_steps` to 256; override it at construction via `gym.make(..., max_episode_steps=N)` (MuJoCo) or `gym.make_vec(..., max_episode_steps=N)` (Warp).
 
 ### Default Observations
 

--- a/docs/content/docs/api/environment-registry.mdx
+++ b/docs/content/docs/api/environment-registry.mdx
@@ -61,12 +61,9 @@ import gymnasium as gym
 import so101_nexus.mujoco
 from so101_nexus import PickConfig, CubeObject
 
-config = PickConfig(
-    objects=[CubeObject(color="blue")],
-    max_episode_steps=512,
-)
+config = PickConfig(objects=[CubeObject(color="blue")])
 
-env = gym.make("MuJoCoPickLift-v1", config=config)
+env = gym.make("MuJoCoPickLift-v1", config=config, max_episode_steps=512)
 ```
 
 See [Configuration Classes](/docs/api/configs) for all available options.

--- a/docs/content/docs/concepts/observations-and-camera-modes.mdx
+++ b/docs/content/docs/concepts/observations-and-camera-modes.mdx
@@ -33,6 +33,8 @@ Camera components add image tensors to a dict-style observation space. They have
 
 Camera components accept `width` and `height` parameters (default 640x480). `WristCamera` also supports domain randomization parameters for FOV and pitch.
 
+Camera observations are rendered by the MuJoCo backend only. The Warp backend is state-only: a `Warp*-v1` env raises `NotImplementedError` if its config includes a camera component, so use a `MuJoCo*-v1` env for visual or camera-based training. See [Backend Support](/docs/concepts/backend-support).
+
 ```python
 from so101_nexus import WristCamera, OverheadCamera
 

--- a/docs/content/docs/guides/customizing-environments.mdx
+++ b/docs/content/docs/guides/customizing-environments.mdx
@@ -7,15 +7,21 @@ Every SO101-Nexus environment accepts a typed config object that controls its be
 
 ## Change Episode Length
 
-Shorter episodes speed up training on simple tasks. Longer episodes give the agent more time for multi-step tasks.
+Shorter episodes speed up training on simple tasks. Longer episodes give the agent more time for multi-step tasks. Episode length is `max_episode_steps`, passed at make time (not on the config), the same way for every env on both backends.
 
 ```python
 import gymnasium as gym
 import so101_nexus.mujoco
+import so101_nexus.warp
 from so101_nexus import TouchConfig
 
-config = TouchConfig(max_episode_steps=256)
-env = gym.make("MuJoCoTouch-v1", config=config)
+config = TouchConfig()
+
+# MuJoCo (single env): applied via the TimeLimit wrapper
+env = gym.make("MuJoCoTouch-v1", config=config, max_episode_steps=256)
+
+# Warp (batched): forwarded to the vector env, which truncates internally
+envs = gym.make_vec("WarpTouch-v1", num_envs=4, device="cuda", config=config, max_episode_steps=256)
 ```
 
 ## Add Camera Observations

--- a/src/so101_nexus/mujoco/base_env.py
+++ b/src/so101_nexus/mujoco/base_env.py
@@ -217,13 +217,13 @@ class SO101NexusMuJoCoBaseEnv(gymnasium.Env):
         )
         if not has_any_camera:
             return spaces.Box(
-                low=-np.inf, high=np.inf, shape=(self._state_obs_size(),), dtype=np.float64
+                low=-np.inf, high=np.inf, shape=(self._state_obs_size(),), dtype=np.float32
             )
         state_size = (
             len(SO101_JOINT_NAMES) if self.config.obs_mode == "visual" else self._state_obs_size()
         )
         obs_dict: dict[str, spaces.Space] = {
-            "state": spaces.Box(low=-np.inf, high=np.inf, shape=(state_size,), dtype=np.float64),
+            "state": spaces.Box(low=-np.inf, high=np.inf, shape=(state_size,), dtype=np.float32),
         }
         if self._wrist_cam_component is not None:
             wc = self._wrist_cam_component
@@ -443,7 +443,7 @@ class SO101NexusMuJoCoBaseEnv(gymnasium.Env):
                 continue  # camera images handled separately in _get_obs
             else:
                 raise ValueError(f"Unsupported observation component: {comp!r}")
-        return np.concatenate(parts)
+        return np.concatenate(parts).astype(np.float32, copy=False)
 
     def _get_component_data(self, component: object) -> np.ndarray:
         """Return data for a task-specific observation component.
@@ -641,7 +641,7 @@ class SO101NexusMuJoCoBaseEnv(gymnasium.Env):
         obs: dict[str, np.ndarray] = {}
         if self.config.obs_mode == "visual":
             self._privileged_state = state
-            obs["state"] = self._get_current_qpos()
+            obs["state"] = self._get_current_qpos().astype(np.float32)
         else:
             obs["state"] = state
 

--- a/src/so101_nexus/warp/base_env.py
+++ b/src/so101_nexus/warp/base_env.py
@@ -42,6 +42,13 @@ from so101_nexus.observations import (
 # _DELTA_ACTION_SCALE: +/-0.05 for the five arm joints, +/-0.2 for the gripper.
 _DELTA_ACTION_SCALE = (0.05, 0.05, 0.05, 0.05, 0.05, 0.2)
 
+# Camera rendering is unsupported on the Warp backend (mujoco_warp has no batched
+# renderer). Point users at MuJoCo, which does render camera observations.
+_NO_CAMERA_MSG = (
+    "Warp backend does not support camera observations; use a MuJoCo env "
+    "(e.g. MuJoCoPickLift-v1) for visual or camera-based training."
+)
+
 
 def _mat_to_quat(mat: torch.Tensor) -> torch.Tensor:
     """Batched rotation matrix ``(..., 3, 3)`` -> ``wxyz`` quaternion ``(..., 4)``.
@@ -342,7 +349,7 @@ class SO101NexusWarpVectorEnv(VectorEnv):
         }
         for comp in observations:
             if isinstance(comp, CameraObservation):
-                raise NotImplementedError("Warp backend does not support camera observations")
+                raise NotImplementedError(_NO_CAMERA_MSG)
             if not isinstance(comp, tuple(supported)):
                 raise NotImplementedError(
                     f"{type(self).__name__} does not support observation "
@@ -372,7 +379,7 @@ class SO101NexusWarpVectorEnv(VectorEnv):
             elif isinstance(comp, GraspState):
                 parts.append(self._is_grasping().unsqueeze(1))
             elif isinstance(comp, CameraObservation):
-                raise NotImplementedError("Warp backend does not support camera observations")
+                raise NotImplementedError(_NO_CAMERA_MSG)
             else:
                 parts.append(self._get_component_data(comp))
         return torch.cat(parts, dim=1).to(torch.float32)

--- a/tests/mujoco/test_envs.py
+++ b/tests/mujoco/test_envs.py
@@ -878,6 +878,51 @@ def test_no_camera_flat_obs(env_id, config_cls):
 
 
 @pytest.mark.parametrize("env_id,config_cls", _CAMERA_ENVS)
+def test_state_obs_is_float32(env_id, config_cls):
+    """State observations are float32, matching the Warp backend and torch models."""
+    cfg = config_cls(observations=[JointPositions()])
+    env = gym.make(env_id, config=cfg)
+    try:
+        assert env.observation_space.dtype == np.float32
+        obs, _ = env.reset()
+        assert obs.dtype == np.float32
+        obs2, _, _, _, _ = env.step(env.action_space.sample())
+        assert obs2.dtype == np.float32
+    finally:
+        env.close()
+
+
+@pytest.mark.parametrize("env_id,config_cls", _CAMERA_ENVS)
+def test_visual_state_and_privileged_state_are_float32(env_id, config_cls):
+    """Visual-mode flat 'state' key and the privileged_state info are float32."""
+    cfg = config_cls(
+        obs_mode="visual",
+        observations=[JointPositions(), OverheadCamera(width=64, height=48)],
+    )
+    env = gym.make(env_id, config=cfg)
+    try:
+        obs, info = env.reset()
+        assert obs["state"].dtype == np.float32
+        assert info["privileged_state"].dtype == np.float32
+    finally:
+        env.close()
+
+
+@pytest.mark.parametrize("env_id", ENV_IDS)
+def test_max_episode_steps_override_truncates(env_id):
+    """gym.make max_episode_steps overrides the registered horizon for every env."""
+    n = 3
+    env = gym.make(env_id, max_episode_steps=n)
+    try:
+        env.reset(seed=0)
+        action = np.zeros(env.action_space.shape, dtype=np.float32)
+        truncations = [bool(env.step(action)[3]) for _ in range(n)]
+        assert truncations == [False, False, True]
+    finally:
+        env.close()
+
+
+@pytest.mark.parametrize("env_id,config_cls", _CAMERA_ENVS)
 def test_visual_obs_mode(env_id, config_cls):
     cfg = config_cls(
         obs_mode="visual",

--- a/tests/test_docs_consistency.py
+++ b/tests/test_docs_consistency.py
@@ -74,3 +74,18 @@ def test_examples_readme_references_existing_example_scripts() -> None:
     referenced = re.findall(r"python (examples/[\w./-]+\.py)", text)
     missing = [path for path in referenced if not (ROOT / path).exists()]
     assert missing == [], f"examples/README.md references missing scripts: {missing}"
+
+
+def test_max_episode_steps_documented_as_make_kwarg_not_config_field() -> None:
+    """Episode length is a gym.make/make_vec keyword, never a config field or table row."""
+    offenders = []
+    for path in TEXT_DOCS:
+        for lineno, line in enumerate(_read(path).splitlines(), start=1):
+            if "max_episode_steps=" in line and "gym.make" not in line:
+                offenders.append((str(path.relative_to(ROOT)), lineno, line.strip()))
+            if re.match(r"\|\s*`?max_episode_steps", line):
+                offenders.append((str(path.relative_to(ROOT)), lineno, line.strip()))
+    assert offenders == [], (
+        "max_episode_steps must be documented as a gym.make/make_vec keyword, "
+        f"never as a config field: {offenders}"
+    )

--- a/tests/warp/test_warp_make_vec.py
+++ b/tests/warp/test_warp_make_vec.py
@@ -22,3 +22,32 @@ def test_make_vec_constructs_native_batched_env():
     assert isinstance(obs, torch.Tensor)
     assert obs.shape == (4, 9)
     envs.close()
+
+
+def test_make_vec_forwards_max_episode_steps():
+    import gymnasium as gym
+    import torch
+
+    import so101_nexus.warp  # noqa: F401
+    from so101_nexus.config import TouchConfig
+
+    default = gym.make_vec("WarpTouch-v1", num_envs=2, device="cpu")
+    assert default.unwrapped.max_episode_steps == 512
+    default.close()
+
+    envs = gym.make_vec(
+        "WarpTouch-v1",
+        num_envs=2,
+        config=TouchConfig(),
+        device="cpu",
+        max_episode_steps=2,
+    )
+    try:
+        assert envs.unwrapped.max_episode_steps == 2
+        envs.reset(seed=0)
+        _, _, _, t1, _ = envs.step(torch.zeros((2, 6)))
+        _, _, _, t2, _ = envs.step(torch.zeros((2, 6)))
+        assert not bool(t1.any())
+        assert bool(t2.all())
+    finally:
+        envs.close()

--- a/tests/warp/test_warp_touch.py
+++ b/tests/warp/test_warp_touch.py
@@ -60,7 +60,7 @@ def test_camera_observation_rejected():
     from so101_nexus.warp.touch_env import WarpTouchVectorEnv
 
     config = TouchConfig(observations=[JointPositions(), WristCamera()])
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError, match="MuJoCo"):
         WarpTouchVectorEnv(num_envs=2, config=config, device="cpu")
 
 


### PR DESCRIPTION
MuJoCo state observations now return float32, matching the Warp backend and torch model conventions (previously float64, which forced .float() casts and broke raw forward passes). Internal physics math stays float64.

Docs: max_episode_steps is owned by the gym registration, not the config. Corrected configs/registry/customizing guides to pass it through gym.make / gym.make_vec, shown uniformly for both backends, with a guard test against future drift and cross-backend override regression tests.

Warp: clarified the unsupported-camera NotImplementedError to point users at the MuJoCo backend and added a docs note.