### PR TITLE
fix(render): remove doubled shadow and ground aliasing in cameras

### DIFF
--- a/src/so101_nexus/mujoco/look_at_env.py
+++ b/src/so101_nexus/mujoco/look_at_env.py
@@ -14,7 +14,7 @@ from so101_nexus.config import ControlMode, LookAtConfig
 from so101_nexus.constants import COLOR_MAP, sample_color
 from so101_nexus.mujoco.base_env import SO101NexusMuJoCoBaseEnv
 from so101_nexus.rewards import orientation_progress, simple_reward
-from so101_nexus.scene import MUJOCO_SCENE_OPTION_XML
+from so101_nexus.scene import MUJOCO_SCENE_OPTION_XML, SCENE_LIGHTS_XML, SCENE_VISUAL_XML
 
 if TYPE_CHECKING:
     from so101_nexus.objects import CubeObject
@@ -45,13 +45,10 @@ def _build_look_at_scene_xml(obj: CubeObject, ground_rgba: list[float]) -> str:
   <include file="{robot_path}"/>
   {MUJOCO_SCENE_OPTION_XML}
 
-  <visual>
-    <headlight diffuse="0.0 0.0 0.0" ambient="0.3 0.3 0.3" specular="0 0 0"/>
-  </visual>
+{SCENE_VISUAL_XML}
 
   <worldbody>
-    <light pos="1 1 3.5" dir="-0.27 -0.27 -0.92" directional="true" diffuse="0.5 0.5 0.5"/>
-    <light pos="0 0 3.5" dir="0 0 -1" directional="true" diffuse="0.5 0.5 0.5"/>
+{SCENE_LIGHTS_XML}
     <geom name="floor" type="plane" size="0 0 0.01" rgba="{gr} {gg} {gb} {ga}"
           pos="0 0 0" contype="1" conaffinity="1"/>
     <body name="look_target" pos="0.15 0 {hs}" mocap="true">

--- a/src/so101_nexus/mujoco/move_env.py
+++ b/src/so101_nexus/mujoco/move_env.py
@@ -13,7 +13,7 @@ from so101_nexus.config import DIRECTION_VECTORS, ControlMode, MoveConfig
 from so101_nexus.constants import sample_color
 from so101_nexus.mujoco.base_env import SO101NexusMuJoCoBaseEnv
 from so101_nexus.rewards import simple_reward
-from so101_nexus.scene import MUJOCO_SCENE_OPTION_XML
+from so101_nexus.scene import MUJOCO_SCENE_OPTION_XML, SCENE_LIGHTS_XML, SCENE_VISUAL_XML
 
 _SO101_DIR = get_so101_mujoco_model_dir()
 _SO101_XML = get_so101_mujoco_model_path()
@@ -30,13 +30,10 @@ def _build_move_scene_xml(ground_rgba: list[float]) -> str:
   <include file="{robot_path}"/>
   {MUJOCO_SCENE_OPTION_XML}
 
-  <visual>
-    <headlight diffuse="0.0 0.0 0.0" ambient="0.3 0.3 0.3" specular="0 0 0"/>
-  </visual>
+{SCENE_VISUAL_XML}
 
   <worldbody>
-    <light pos="1 1 3.5" dir="-0.27 -0.27 -0.92" directional="true" diffuse="0.5 0.5 0.5"/>
-    <light pos="0 0 3.5" dir="0 0 -1" directional="true" diffuse="0.5 0.5 0.5"/>
+{SCENE_LIGHTS_XML}
     <geom name="floor" type="plane" size="0 0 0.01" rgba="{gr} {gg} {gb} {ga}"
           pos="0 0 0" contype="1" conaffinity="1"/>
     <site name="move_target" type="sphere" size="0.015" rgba="0 0.8 0.2 0.7"

--- a/src/so101_nexus/object_slots.py
+++ b/src/so101_nexus/object_slots.py
@@ -23,6 +23,7 @@ import numpy as np
 
 from so101_nexus.constants import COLOR_MAP
 from so101_nexus.objects import CubeObject, MeshObject, SceneObject, YCBObject
+from so101_nexus.scene import SCENE_LIGHTS_XML, SCENE_VISUAL_XML
 from so101_nexus.ycb_assets import (
     get_ycb_collision_mesh,
     get_ycb_texture_file,
@@ -176,13 +177,10 @@ def build_object_scene_xml(
   <include file="{robot_xml_path}"/>
   {option_xml}
 
-{asset_section}  <visual>
-    <headlight diffuse="0.0 0.0 0.0" ambient="0.3 0.3 0.3" specular="0 0 0"/>
-  </visual>
+{asset_section}{SCENE_VISUAL_XML}
 
   <worldbody>
-    <light pos="1 1 3.5" dir="-0.27 -0.27 -0.92" directional="true" diffuse="0.5 0.5 0.5"/>
-    <light pos="0 0 3.5" dir="0 0 -1" directional="true" diffuse="0.5 0.5 0.5"/>
+{SCENE_LIGHTS_XML}
     <geom name="floor" type="plane" size="0 0 0.01" rgba="{gr} {gg} {gb} {ga}"
           pos="0 0 0" contype="1" conaffinity="1"/>
 

--- a/src/so101_nexus/scene.py
+++ b/src/so101_nexus/scene.py
@@ -22,6 +22,28 @@ WARP_SCENE_OPTION_XML = (
     'integrator="implicit" impratio="10" iterations="10" ls_iterations="20"/>'
 )
 
+# Shared ``<visual>`` block for every backend scene. ``shadowsize`` and
+# ``offsamples`` raise the shadow-map resolution and offscreen multisample count
+# above the MuJoCo defaults (4096 / 4), and ``shadowclip`` tightens the
+# directional-light shadow frustum (default 1.0) to concentrate shadow texels on
+# the workspace. Together they remove the blocky shadow-edge and silhouette
+# aliasing seen in rendered camera observations (overhead corners, distant floor
+# in the wrist view). Values match the vendored menagerie ``scene.xml``.
+SCENE_VISUAL_XML = """\
+  <visual>
+    <headlight diffuse="0.0 0.0 0.0" ambient="0.3 0.3 0.3" specular="0 0 0"/>
+    <quality shadowsize="8192" offsamples="8"/>
+    <map shadowclip="0.5"/>
+  </visual>"""
+
+# Two directional lights: an angled key light that casts the scene's single
+# shadow plus an overhead fill light with ``castshadow="false"``. Both lights
+# casting shadows previously produced a doubled robot shadow.
+SCENE_LIGHTS_XML = """\
+    <light pos="1 1 3.5" dir="-0.27 -0.27 -0.92" directional="true" diffuse="0.5 0.5 0.5"/>
+    <light pos="0 0 3.5" dir="0 0 -1" directional="true" diffuse="0.5 0.5 0.5"
+           castshadow="false"/>"""
+
 
 def build_robot_floor_scene_xml(
     ground_rgba: list[float],
@@ -61,13 +83,10 @@ def build_robot_floor_scene_xml(
   <include file="{robot_xml_path}"/>
   {option_xml}
 
-  <visual>
-    <headlight diffuse="0.0 0.0 0.0" ambient="0.3 0.3 0.3" specular="0 0 0"/>
-  </visual>
+{SCENE_VISUAL_XML}
 
   <worldbody>
-    <light pos="1 1 3.5" dir="-0.27 -0.27 -0.92" directional="true" diffuse="0.5 0.5 0.5"/>
-    <light pos="0 0 3.5" dir="0 0 -1" directional="true" diffuse="0.5 0.5 0.5"/>
+{SCENE_LIGHTS_XML}
     <geom name="floor" type="plane" size="0 0 0.01" rgba="{gr} {gg} {gb} {ga}"
           pos="0 0 0" contype="1" conaffinity="1"/>
 {extra_bodies}{overhead_camera_xml}  </worldbody>

--- a/tests/core/test_scene.py
+++ b/tests/core/test_scene.py
@@ -48,3 +48,48 @@ def test_robot_floor_builder_compiles_with_both_options():
         assert model.nq > 0
         # No target site/body: robot + floor only.
         assert mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SITE, "reach_target") == -1
+
+
+def _compile_scene(xml: str) -> mujoco.MjModel:
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".xml", dir=get_so101_mujoco_model_dir(), delete=True
+    ) as f:
+        f.write(xml)
+        f.flush()
+        return mujoco.MjModel.from_xml_path(f.name)
+
+
+def test_scenes_have_single_shadow_caster_and_antialiasing():
+    """Built scenes cast exactly one shadow and apply high-quality AA settings.
+
+    Guards the rendering fixes: two shadow-casting lights produced a doubled
+    robot shadow, and the MuJoCo default offscreen quality (offsamples=4,
+    shadowsize=4096, shadowclip=1.0) left blocky shadow and silhouette aliasing
+    in camera observations.
+    """
+    from so101_nexus.object_slots import build_object_scene_xml
+    from so101_nexus.objects import CubeObject
+    from so101_nexus.scene import build_robot_floor_scene_xml
+
+    robot_path = str(get_so101_mujoco_model_path())
+    scenes = [
+        build_robot_floor_scene_xml(
+            [0.5, 0.5, 0.5, 1.0],
+            option_xml=MUJOCO_SCENE_OPTION_XML,
+            robot_xml_path=robot_path,
+        ),
+        build_object_scene_xml(
+            [CubeObject()],
+            ["pick_slot_0"],
+            [0.5, 0.5, 0.5, 1.0],
+            option_xml=MUJOCO_SCENE_OPTION_XML,
+            robot_xml_path=robot_path,
+        ),
+    ]
+    for xml in scenes:
+        model = _compile_scene(xml)
+        assert model.nlight == 2
+        assert int(model.light_castshadow.sum()) == 1
+        assert model.vis.quality.offsamples >= 8
+        assert model.vis.quality.shadowsize >= 8192
+        assert model.vis.map.shadowclip <= 0.5


### PR DESCRIPTION
Built MuJoCo/Warp scenes declared two shadow-casting directional lights (producing a doubled robot shadow) and carried no <quality>/<map>, so offscreen camera renders fell back to MuJoCo defaults (offsamples=4, shadowsize=4096, shadowclip=1.0), leaving blocky shadow-edge and silhouette aliasing on the ground.

Extract the duplicated <visual> + lights block into shared SCENE_VISUAL_XML / SCENE_LIGHTS_XML constants in scene.py: set castshadow=false on the overhead fill light (single shadow) and add quality shadowsize=8192 offsamples=8 plus map shadowclip=0.5, matching the vendored menagerie scene.xml. Reuse across all four scene builders (scene.py, object_slots.py, mujoco/move_env.py, mujoco/look_at_env.py).

Add a regression test asserting exactly one shadow caster and the AA quality settings on both public scene builders.