### PR TITLE
feat(teleop): surface leader port status on Configure step

### DIFF
--- a/docs/content/docs/teleoperation/overview.mdx
+++ b/docs/content/docs/teleoperation/overview.mdx
@@ -49,9 +49,15 @@ sudo chmod 666 /dev/ttyACM0
 lerobot-find-port
 ```
 
-If the recorder starts before the port is writable, the Initialize step now
-stays open and shows exact recovery commands. Fix the port in another
-terminal, then click `Retry Initialization` in the same browser session.
+The Configure step shows a leader-port status banner up front: it reports
+whether the device exists and is readable and writable before you fill in
+the rest of the form. Click `Recheck Port` after fixing permissions to
+refresh it, and `Initialize Session` is blocked with the same guidance while
+the port is not ready. If the recorder still cannot open the arm at connect
+time, the Initialize step stays open and shows the connection error, with
+exact recovery commands when the port is missing or blocked by permissions.
+Fix the port in another terminal, then click `Retry Initialization` in the
+same browser session.
 
 ## Launching the recorder
 
@@ -249,7 +255,9 @@ selected recording fields. If the unwrapped environment exposes
 ## Session flow
 
 1. **Configure.** Pick the env, robot type, episode count, FPS, camera
-   resolutions, action space, countdown, and dataset fields.
+   resolutions, action space, countdown, and dataset fields. A leader-port
+   status banner reports up front whether the configured serial port is
+   reachable, with a `Recheck Port` button to refresh after fixing it.
 2. **Initialize.** The app connects to the leader arm and creates the
    dataset. If the port is unavailable or blocked by permissions, fix it
    and retry from the same page.

--- a/src/so101_nexus/teleop/app.py
+++ b/src/so101_nexus/teleop/app.py
@@ -38,6 +38,7 @@ from so101_nexus.teleop.dataset import (
 from so101_nexus.teleop.leader import (
     ROBOT_JOINT_NAMES,
     check_robot_env_mismatch,
+    diagnose_leader_port,
     format_leader_connection_error,
     get_leader,
     import_backend_for_env_id,
@@ -261,6 +262,46 @@ def _append_init_log(init_state: dict, message: str) -> None:
 def _current_init_log(init_state: dict) -> str:
     """Return the accumulated init log text."""
     return init_state.get("log_text", "")
+
+
+def _format_port_status(leader_port: str) -> str:
+    """Return Markdown describing whether *leader_port* looks ready to connect.
+
+    The check is best-effort: it confirms the serial device exists and is
+    readable/writable, but the arm is only truly verified when the session is
+    initialized. Surfacing it on the Configure step lets a user fix the port
+    before filling in the rest of the form.
+    """
+    diag = diagnose_leader_port(leader_port)
+    if diag.kind == "ok":
+        return (
+            f"**Leader port `{leader_port}` looks accessible.** "
+            "The arm connection is verified when you initialize the session."
+        )
+    text = f"**Leader port `{leader_port}` is not ready.** {diag.message}"
+    if diag.recovery_hint:
+        text += f"\n\n```\n{diag.recovery_hint}\n```"
+    return text
+
+
+def _cb_recheck_port(leader_port: str):
+    """Re-run the proactive leader-port check and refresh the status banner."""
+    import gradio as gr
+
+    return gr.update(value=_format_port_status(leader_port))
+
+
+def _require_port_ready(leader_port: str) -> None:
+    """Raise ``gr.Error`` if *leader_port* fails the proactive accessibility check."""
+    import gradio as gr
+
+    diag = diagnose_leader_port(leader_port)
+    if diag.kind == "ok":
+        return
+    message = diag.message
+    if diag.recovery_hint:
+        message += f"\n{diag.recovery_hint}"
+    raise gr.Error(message)
 
 
 def _connect_leader(robot_type: str, leader_port: str, leader_id: str):
@@ -518,6 +559,8 @@ def _cb_start_init(
 ):
     """Validate inputs and launch the init worker thread."""
     import gradio as gr
+
+    _require_port_ready(leader_port)
 
     config = _normalized_init_config(
         leader_id_default,
@@ -1024,8 +1067,12 @@ def _build_setup_screen(
     all_env_ids: list[str],
     default_leader_id: str,
     wrist_roll_offset: float,
+    leader_port: str,
 ):
     """Build the Configure step contents and return all input components."""
+    gr.Markdown("### Leader Arm")
+    port_status = gr.Markdown(_format_port_status(leader_port))
+    recheck_port_btn = gr.Button("Recheck Port", variant="secondary")
     gr.Markdown("### Environment & Robot")
     default_robot_type = "so101"
     default_env = _default_env_id(all_env_ids, default_robot_type)
@@ -1215,6 +1262,8 @@ def _build_setup_screen(
         common_customization_group,
         pick_customization_group,
         pick_and_place_customization_group,
+        port_status,
+        recheck_port_btn,
     )
 
 
@@ -1281,6 +1330,8 @@ def _wire_events(
     env_id_input,
     repo_id_input,
     repo_id_warning,
+    port_status,
+    recheck_port_btn,
     customization_outputs,
     init_log,
     retry_btn,
@@ -1327,6 +1378,7 @@ def _wire_events(
         session["state"].should_stop = True
 
     retry_init = functools.partial(_cb_retry_init_with_session, session, init_state, leader_port)
+    recheck_port = functools.partial(_cb_recheck_port, leader_port)
 
     env_id_input.change(
         fn=_cb_update_customization_for_env,
@@ -1338,6 +1390,7 @@ def _wire_events(
         inputs=[repo_id_input],
         outputs=[repo_id_warning],
     )
+    recheck_port_btn.click(fn=recheck_port, outputs=[port_status])
     init_btn.click(fn=start_init, inputs=init_inputs, outputs=[walkthrough, init_log, retry_btn])
     init_timer.tick(
         fn=poll_init,
@@ -1514,7 +1567,11 @@ def main(
                     common_customization_group,
                     pick_customization_group,
                     pick_and_place_customization_group,
-                ) = _build_setup_screen(gr, all_env_ids, leader_id_default, wrist_roll_offset)
+                    port_status,
+                    recheck_port_btn,
+                ) = _build_setup_screen(
+                    gr, all_env_ids, leader_id_default, wrist_roll_offset, leader_port
+                )
 
             with gr.Step("Initialize", id=1):
                 init_log, retry_btn, init_timer = _build_init_step(gr)
@@ -1586,6 +1643,8 @@ def main(
             env_id_input=env_id_input,
             repo_id_input=repo_id_input,
             repo_id_warning=repo_id_warning,
+            port_status=port_status,
+            recheck_port_btn=recheck_port_btn,
             customization_outputs=[
                 customize_env_input,
                 object_pool_input,

--- a/tests/core/test_teleop_app_helpers.py
+++ b/tests/core/test_teleop_app_helpers.py
@@ -114,6 +114,61 @@ def test_cb_validate_repo_id_status_branches(fake_gradio) -> None:
     assert "alphanumeric" in invalid["value"]
 
 
+def test_format_port_status_ok_when_accessible(monkeypatch) -> None:
+    from so101_nexus.teleop.app import _format_port_status
+
+    monkeypatch.setattr("so101_nexus.teleop.leader.os.path.exists", lambda _p: True)
+    monkeypatch.setattr("so101_nexus.teleop.leader.os.access", lambda _p, _m: True)
+
+    text = _format_port_status("/dev/ttyACM0")
+
+    assert "/dev/ttyACM0" in text
+    assert "looks accessible" in text
+
+
+def test_format_port_status_not_ready_includes_recovery_hint(monkeypatch) -> None:
+    from so101_nexus.teleop.app import _format_port_status
+
+    monkeypatch.setattr("so101_nexus.teleop.leader.os.path.exists", lambda _p: False)
+
+    text = _format_port_status("/dev/ttyACM9")
+
+    assert "/dev/ttyACM9" in text
+    assert "not ready" in text
+    assert "lerobot-find-port" in text
+
+
+def test_cb_recheck_port_refreshes_status(monkeypatch, fake_gradio) -> None:
+    from so101_nexus.teleop.app import _cb_recheck_port
+
+    monkeypatch.setattr("so101_nexus.teleop.leader.os.path.exists", lambda _p: True)
+    monkeypatch.setattr("so101_nexus.teleop.leader.os.access", lambda _p, _m: False)
+
+    update = _cb_recheck_port("/dev/ttyACM0")
+
+    assert "not ready" in update["value"]
+    assert "chmod" in update["value"]
+
+
+def test_require_port_ready_blocks_when_not_accessible(monkeypatch, fake_gradio) -> None:
+    from so101_nexus.teleop.app import _require_port_ready
+
+    monkeypatch.setattr("so101_nexus.teleop.leader.os.path.exists", lambda _p: True)
+    monkeypatch.setattr("so101_nexus.teleop.leader.os.access", lambda _p, _m: False)
+
+    with pytest.raises(fake_gradio.Error, match="chmod"):
+        _require_port_ready("/dev/ttyACM0")
+
+
+def test_require_port_ready_allows_accessible_port(monkeypatch, fake_gradio) -> None:
+    from so101_nexus.teleop.app import _require_port_ready
+
+    monkeypatch.setattr("so101_nexus.teleop.leader.os.path.exists", lambda _p: True)
+    monkeypatch.setattr("so101_nexus.teleop.leader.os.access", lambda _p, _m: True)
+
+    assert _require_port_ready("/dev/ttyACM0") is None
+
+
 def test_build_field_selection_all_keys() -> None:
     selection = _build_field_selection([WRIST_KEY, OVERHEAD_KEY, "task"])
 
@@ -297,7 +352,7 @@ def test_setup_screen_defaults_to_absolute_joint_position(monkeypatch) -> None:
         lambda _env_id: teleop_app.CustomizationUIState(),
     )
 
-    _build_setup_screen(fake_gr, ["MuJoCoTouch-v1"], "leader", -90.0)
+    _build_setup_screen(fake_gr, ["MuJoCoTouch-v1"], "leader", -90.0, "/dev/null")
 
     action_space_radio = next(radio for radio in radios if radio.label == "Action Space")
     assert action_space_radio.value == "joint_pos"

--- a/tests/core/test_teleop_ui.py
+++ b/tests/core/test_teleop_ui.py
@@ -36,7 +36,7 @@ def test_app_builds_with_walkthrough() -> None:
 
     with gr.Blocks(), gr.Walkthrough(selected=0) as wt:
         with gr.Step("Configure", id=0):
-            _build_setup_screen(gr, all_env_ids, "test_leader", -90.0)
+            _build_setup_screen(gr, all_env_ids, "test_leader", -90.0, "/dev/null")
         with gr.Step("Initialize", id=1):
             _build_init_step(gr)
         with gr.Step("Record", id=2):


### PR DESCRIPTION
Proactively check leader-arm serial port availability before the user fills in the Configure form, instead of failing in the Initialize worker thread. The Configure step now shows a port status banner (from the existing diagnose_leader_port check) with a Recheck Port button, and Initialize Session is blocked with recovery guidance while the port is not ready.

Adds _format_port_status, _cb_recheck_port, and _require_port_ready to the teleop app, plus tests for the formatter, recheck callback, and guard. Updates the teleoperation docs.