### PR TITLE
fix(render): use spotlight key light to remove floor shadow-map acne

### DIFF
--- a/src/so101_nexus/scene.py
+++ b/src/so101_nexus/scene.py
@@ -22,25 +22,30 @@ WARP_SCENE_OPTION_XML = (
     'integrator="implicit" impratio="10" iterations="10" ls_iterations="20"/>'
 )
 
-# Shared ``<visual>`` block for every backend scene. ``shadowsize`` and
-# ``offsamples`` raise the shadow-map resolution and offscreen multisample count
-# above the MuJoCo defaults (4096 / 4), and ``shadowclip`` tightens the
-# directional-light shadow frustum (default 1.0) to concentrate shadow texels on
-# the workspace. Together they remove the blocky shadow-edge and silhouette
-# aliasing seen in rendered camera observations (overhead corners, distant floor
-# in the wrist view). Values match the vendored menagerie ``scene.xml``.
+# Shared ``<visual>`` block for every backend scene. ``offsamples`` raises the
+# offscreen multisample count above the MuJoCo default (4) to anti-alias geometry
+# edges. ``shadowsize`` raises the shadow-map resolution. The shadow caster is a
+# spotlight (see ``SCENE_LIGHTS_XML``), so no ``shadowclip`` is needed: a spotlight
+# already has a bounded, perspective shadow frustum focused on its cone.
 SCENE_VISUAL_XML = """\
   <visual>
     <headlight diffuse="0.0 0.0 0.0" ambient="0.3 0.3 0.3" specular="0 0 0"/>
     <quality shadowsize="8192" offsamples="8"/>
-    <map shadowclip="0.5"/>
   </visual>"""
 
-# Two directional lights: an angled key light that casts the scene's single
-# shadow plus an overhead fill light with ``castshadow="false"``. Both lights
-# casting shadows previously produced a doubled robot shadow.
+# Key + fill lighting. The key is a SPOTLIGHT (not a directional light) aimed at
+# the workspace: a directional light must shadow-map the entire infinite floor, so
+# its far, grazing texels fail the depth test and dither into a speckle moire on
+# the ground in wrist-camera views ("weird textures in the ground"). A spotlight's
+# frustum is bounded to its cone, concentrating shadow-map texels on the workspace
+# and leaving the far floor unshadowed (and clean). The cutoff (~25 deg from 3.5 m
+# up) covers the whole workspace with margin; its falloff ring sits out of frame.
+# Position and aim reproduce the previous directional key's light direction, so
+# shading is unchanged. The overhead fill is directional with ``castshadow="false"``
+# (a single caster avoids a doubled robot shadow).
 SCENE_LIGHTS_XML = """\
-    <light pos="1 1 3.5" dir="-0.27 -0.27 -0.92" directional="true" diffuse="0.5 0.5 0.5"/>
+    <light pos="1 1 3.5" dir="-0.227 -0.268 -0.936" directional="false"
+           cutoff="25" exponent="1" diffuse="0.5 0.5 0.5"/>
     <light pos="0 0 3.5" dir="0 0 -1" directional="true" diffuse="0.5 0.5 0.5"
            castshadow="false"/>"""
 

--- a/tests/core/test_scene.py
+++ b/tests/core/test_scene.py
@@ -3,6 +3,9 @@
 import tempfile
 
 import mujoco
+import numpy as np
+from hypothesis import given, settings
+from hypothesis import strategies as st
 
 from so101_nexus import get_so101_mujoco_model_dir, get_so101_mujoco_model_path
 from so101_nexus.scene import (
@@ -59,37 +62,58 @@ def _compile_scene(xml: str) -> mujoco.MjModel:
         return mujoco.MjModel.from_xml_path(f.name)
 
 
-def test_scenes_have_single_shadow_caster_and_antialiasing():
-    """Built scenes cast exactly one shadow and apply high-quality AA settings.
+_unit = st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False).map(
+    lambda v: round(v, 4)
+)
+_ground_rgba = st.tuples(
+    _unit,
+    _unit,
+    _unit,
+    st.floats(min_value=0.1, max_value=1.0, allow_nan=False).map(lambda v: round(v, 4)),
+).map(list)
 
-    Guards the rendering fixes: two shadow-casting lights produced a doubled
-    robot shadow, and the MuJoCo default offscreen quality (offsamples=4,
-    shadowsize=4096, shadowclip=1.0) left blocky shadow and silhouette aliasing
-    in camera observations.
+
+@given(
+    rgba=_ground_rgba,
+    with_object=st.booleans(),
+    half_size=st.floats(min_value=0.01, max_value=0.04, allow_nan=False),
+)
+@settings(max_examples=25, deadline=None)
+def test_scenes_use_spotlight_shadow_caster_and_edge_antialiasing(rgba, with_object, half_size):
+    """Every built scene casts exactly one spotlight shadow and keeps edge MSAA.
+
+    Property: regardless of ground colour or scene contents, the AA/shadow contract
+    holds. It guards the rendering fix: a *directional* light must shadow-map the
+    entire infinite floor, so its far grazing texels dither into a speckle moire on
+    the ground in wrist-camera views ("weird textures in the ground"). MSAA cannot
+    remove it (a per-fragment depth-test artifact, not an edge) and raising
+    ``shadowsize`` worsened it. The shadow caster is therefore a spotlight, whose
+    bounded cone frustum concentrates shadow texels on the workspace; the overhead
+    fill stays directional and non-casting (a single caster avoids a doubled
+    shadow). ``offsamples`` stays above the MuJoCo default (4) for edge AA.
     """
     from so101_nexus.object_slots import build_object_scene_xml
     from so101_nexus.objects import CubeObject
     from so101_nexus.scene import build_robot_floor_scene_xml
 
     robot_path = str(get_so101_mujoco_model_path())
-    scenes = [
-        build_robot_floor_scene_xml(
-            [0.5, 0.5, 0.5, 1.0],
-            option_xml=MUJOCO_SCENE_OPTION_XML,
-            robot_xml_path=robot_path,
-        ),
-        build_object_scene_xml(
-            [CubeObject()],
+    if with_object:
+        xml = build_object_scene_xml(
+            [CubeObject(half_size=half_size)],
             ["pick_slot_0"],
-            [0.5, 0.5, 0.5, 1.0],
+            rgba,
             option_xml=MUJOCO_SCENE_OPTION_XML,
             robot_xml_path=robot_path,
-        ),
-    ]
-    for xml in scenes:
-        model = _compile_scene(xml)
-        assert model.nlight == 2
-        assert int(model.light_castshadow.sum()) == 1
-        assert model.vis.quality.offsamples >= 8
-        assert model.vis.quality.shadowsize >= 8192
-        assert model.vis.map.shadowclip <= 0.5
+        )
+    else:
+        xml = build_robot_floor_scene_xml(
+            rgba, option_xml=MUJOCO_SCENE_OPTION_XML, robot_xml_path=robot_path
+        )
+
+    model = _compile_scene(xml)
+    assert model.nlight == 2
+    casters = np.flatnonzero(model.light_castshadow)
+    assert casters.size == 1, "exactly one shadow caster (a second caster doubles the robot shadow)"
+    assert model.light_type[casters[0]] == int(mujoco.mjtLightType.mjLIGHT_SPOT)
+    assert model.vis.quality.offsamples >= 8
+    assert model.vis.quality.shadowsize >= 8192


### PR DESCRIPTION
A directional key light must shadow-map the entire infinite floor, so its far grazing texels fail the depth test and dither into a speckle moire on the ground in wrist-camera views. MSAA (offsamples) cannot fix it (a per-fragment depth-test artifact, not an edge) and raising shadowsize only worsened it. Replace the directional key with a focused spotlight aimed at the workspace (same light direction, bounded cone frustum), keeping the cast shadow while leaving the far floor unshadowed and clean. Drop shadowclip, now unnecessary for a spotlight.

The scene test becomes a hypothesis property test asserting the AA/shadow contract (single spotlight caster, offsamples >= 8, shadowsize >= 8192) holds for arbitrary ground colors and scene contents.