### PR TITLE
feat(lerobot-adapter): add dataset row to sim qpos decode helpers

### DIFF
--- a/docs/content/docs/concepts/lerobot-compatibility.mdx
+++ b/docs/content/docs/concepts/lerobot-compatibility.mdx
@@ -86,6 +86,39 @@ is follower readback rather than the leader command echo. It creates a
 simulator-only calibration file automatically at
 `$HF_LEROBOT_CALIBRATION/robots/sim_so_follower/teleop_sim.json` when missing.
 
+## Decoding a recorded dataset back to simulator radians
+
+The recorded six-vectors mix units, and `meta/info.json` does not signal the
+split: body joints `shoulder_pan` through `wrist_roll` are LeRobot degrees, but
+`gripper.pos` is `RANGE_0_100` (percent of jaw travel, not degrees). Decoding the
+whole vector with `np.deg2rad` runs cleanly yet silently corrupts only the
+gripper. At a typical grasp value `gripper.pos = 15` the correct angle is `0.113`
+rad, while `deg2rad(15)` gives `0.262` rad (about 8.5 degrees too open), which can
+teach a grip that never closes on the object.
+
+Use the public helpers to convert between a normalized dataset row and simulator
+joint radians without needing a calibration file:
+
+```python
+import numpy as np
+from so101_nexus.lerobot_adapter import (
+    dataset_row_to_sim_qpos,
+    read_gripper_limits_rad,
+    sim_qpos_to_dataset_row,
+)
+
+# row: a six-element action / observation.state vector from the dataset
+qpos_rad = dataset_row_to_sim_qpos(np.asarray(row))  # body deg2rad, gripper 0-100 -> [low, high]
+row_again = sim_qpos_to_dataset_row(qpos_rad)         # inverse, for replay
+```
+
+Both helpers accept NumPy arrays, torch tensors, or sequences of shape `(..., 6)`
+and return the same type, so batched dataset or policy tensors decode directly.
+The gripper limits default to the SO101 jaw travel; pass
+`gripper_limits_rad=read_gripper_limits_rad(env)` for the exact bounds of a
+specific environment. The helpers assume the recording convention used by this
+library (synthetic calibration with `drive_mode=0`).
+
 ## Using LeRobot processors with SO101-Nexus envs
 
 `LeRobotEnvWrapper` requires a `Dict` observation space. Configure the env with at least one camera component (or pick another component beyond the default state-only set) before wrapping it.

--- a/docs/content/docs/concepts/lerobot-compatibility.mdx
+++ b/docs/content/docs/concepts/lerobot-compatibility.mdx
@@ -101,9 +101,8 @@ joint radians without needing a calibration file:
 
 ```python
 import numpy as np
-from so101_nexus.lerobot_adapter import (
+from so101_nexus import (
     dataset_row_to_sim_qpos,
-    read_gripper_limits_rad,
     sim_qpos_to_dataset_row,
 )
 
@@ -114,10 +113,11 @@ row_again = sim_qpos_to_dataset_row(qpos_rad)         # inverse, for replay
 
 Both helpers accept NumPy arrays, torch tensors, or sequences of shape `(..., 6)`
 and return the same type, so batched dataset or policy tensors decode directly.
-The gripper limits default to the SO101 jaw travel; pass
-`gripper_limits_rad=read_gripper_limits_rad(env)` for the exact bounds of a
-specific environment. The helpers assume the recording convention used by this
-library (synthetic calibration with `drive_mode=0`).
+They import without the `teleop` extra (no LeRobot dependency), so a training
+repo can use them directly. The gripper limits default to the SO101 jaw travel;
+pass `gripper_limits_rad=(float(env.action_space.low[-1]), float(env.action_space.high[-1]))`
+for the exact bounds of a specific environment. The helpers assume the recording
+convention used by this library (synthetic calibration with `drive_mode=0`).
 
 ## Using LeRobot processors with SO101-Nexus envs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "so101-nexus"
-version = "0.4.4"
+version = "0.4.5"
 description = "End-to-end simulation and training stack for the SO-101 arm: record demonstrations, clone behavior, and reinforce with GPU-parallel MuJoCo / MuJoCo Warp environments, built on LeRobot"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/so101_nexus/__init__.py
+++ b/src/so101_nexus/__init__.py
@@ -35,6 +35,11 @@ from so101_nexus.constants import (
     ColorName,
     sample_color,
 )
+from so101_nexus.lerobot_dataset import (
+    SO101_GRIPPER_LIMITS_RAD,
+    dataset_row_to_sim_qpos,
+    sim_qpos_to_dataset_row,
+)
 from so101_nexus.objects import (
     CubeObject,
     MeshObject,
@@ -103,6 +108,7 @@ __all__ = [
     "REST_POSE",
     "ROBOT_CAMERA_PRESETS",
     "SO101_DIR",
+    "SO101_GRIPPER_LIMITS_RAD",
     "SO101_JOINT_NAMES",
     "YCB_OBJECTS",
     "CameraObservation",
@@ -138,6 +144,7 @@ __all__ = [
     "WristCamera",
     "YCBObject",
     "YcbModelId",
+    "dataset_row_to_sim_qpos",
     "describe_pick_target",
     "ensure_ycb_assets",
     "get_mujoco_ycb_rest_pose",
@@ -152,5 +159,6 @@ __all__ = [
     "orientation_progress",
     "reach_progress",
     "sample_color",
+    "sim_qpos_to_dataset_row",
     "simple_reward",
 ]

--- a/src/so101_nexus/lerobot_adapter/__init__.py
+++ b/src/so101_nexus/lerobot_adapter/__init__.py
@@ -7,9 +7,24 @@ runs LeRobot ChoiceRegistry decorators so ``--robot.type=sim_so_follower`` and
 
 from __future__ import annotations
 
+from so101_nexus.lerobot_adapter.normalization import (
+    SO101_GRIPPER_LIMITS_RAD,
+    dataset_row_to_sim_qpos,
+    read_gripper_limits_rad,
+    sim_qpos_to_dataset_row,
+)
 from so101_nexus.lerobot_adapter.sim_camera import SimCamera
 from so101_nexus.lerobot_adapter.sim_camera_config import SimCameraConfig
 from so101_nexus.lerobot_adapter.sim_follower import SimSOFollower
 from so101_nexus.lerobot_adapter.sim_follower_config import SimSOFollowerConfig
 
-__all__ = ["SimCamera", "SimCameraConfig", "SimSOFollower", "SimSOFollowerConfig"]
+__all__ = [
+    "SO101_GRIPPER_LIMITS_RAD",
+    "SimCamera",
+    "SimCameraConfig",
+    "SimSOFollower",
+    "SimSOFollowerConfig",
+    "dataset_row_to_sim_qpos",
+    "read_gripper_limits_rad",
+    "sim_qpos_to_dataset_row",
+]

--- a/src/so101_nexus/lerobot_adapter/__init__.py
+++ b/src/so101_nexus/lerobot_adapter/__init__.py
@@ -7,16 +7,16 @@ runs LeRobot ChoiceRegistry decorators so ``--robot.type=sim_so_follower`` and
 
 from __future__ import annotations
 
-from so101_nexus.lerobot_adapter.normalization import (
-    SO101_GRIPPER_LIMITS_RAD,
-    dataset_row_to_sim_qpos,
-    read_gripper_limits_rad,
-    sim_qpos_to_dataset_row,
-)
+from so101_nexus.lerobot_adapter.normalization import read_gripper_limits_rad
 from so101_nexus.lerobot_adapter.sim_camera import SimCamera
 from so101_nexus.lerobot_adapter.sim_camera_config import SimCameraConfig
 from so101_nexus.lerobot_adapter.sim_follower import SimSOFollower
 from so101_nexus.lerobot_adapter.sim_follower_config import SimSOFollowerConfig
+from so101_nexus.lerobot_dataset import (
+    SO101_GRIPPER_LIMITS_RAD,
+    dataset_row_to_sim_qpos,
+    sim_qpos_to_dataset_row,
+)
 
 __all__ = [
     "SO101_GRIPPER_LIMITS_RAD",

--- a/src/so101_nexus/lerobot_adapter/normalization.py
+++ b/src/so101_nexus/lerobot_adapter/normalization.py
@@ -21,6 +21,16 @@ MOTOR_MODEL = "sts3215"
 MOTOR_RESOLUTION = 4096
 TICKS_PER_RADIAN = (MOTOR_RESOLUTION - 1) / (2 * math.pi)
 GripperLimitsRad = tuple[float, float]
+_DEG2RAD = math.pi / 180.0
+_RAD2DEG = 180.0 / math.pi
+_GRIPPER_INDEX = MOTOR_NAMES.index(GRIPPER_NAME)
+SO101_GRIPPER_LIMITS_RAD: GripperLimitsRad = (math.radians(-10.0), math.radians(100.0))
+"""Default SO101 gripper jaw travel in radians (-10 deg .. +100 deg).
+
+Matches the gripper actuator control range across the vendored SO101 MuJoCo
+models. Pass ``read_gripper_limits_rad(env)`` for the exact runtime bounds of a
+specific environment.
+"""
 
 
 def build_so101_motors(*, use_degrees: bool) -> dict[str, Motor]:
@@ -161,6 +171,84 @@ def leader_action_to_sim_qpos(
         calibration=calibration,
         gripper_limits_rad=gripper_limits_rad,
     )
+
+
+def dataset_row_to_sim_qpos(
+    row,
+    *,
+    gripper_limits_rad: GripperLimitsRad = SO101_GRIPPER_LIMITS_RAD,
+):
+    """Decode a normalized LeRobot dataset row into simulator joint radians.
+
+    Recorded ``action`` and ``observation.state`` six-vectors mix units: body
+    joints ``shoulder_pan..wrist_roll`` use ``MotorNormMode.DEGREES`` while the
+    gripper uses ``MotorNormMode.RANGE_0_100`` (percent of jaw travel, not
+    degrees). This inverts that per-motor map, avoiding the silent corruption of
+    decoding the whole vector with ``np.deg2rad``.
+
+    Parameters
+    ----------
+    row:
+        NumPy array, torch tensor, or sequence of shape ``(..., 6)`` of recorded
+        values in SO101 joint order.
+    gripper_limits_rad:
+        Simulator gripper ``(low, high)`` control range in radians. Defaults to
+        the SO101 gripper travel; pass ``read_gripper_limits_rad(env)`` for the
+        exact bounds of a specific environment.
+
+    Returns
+    -------
+    Same array type as ``row`` with body joints converted via ``deg2rad`` and the
+    gripper mapped linearly from ``[0, 100]`` onto ``[low, high]``.
+
+    Notes
+    -----
+    Assumes the library recording convention (synthetic calibration,
+    ``drive_mode=0``). Datasets recorded against a physical follower calibration
+    with inverted body drive modes need :func:`leader_action_to_sim_qpos`. This
+    is a pure unit transform; clamping to the actuator range stays the caller's
+    job via :func:`action_for_env`.
+    """
+    values = row if hasattr(row, "shape") else np.asarray(row, dtype=np.float64)
+    if values.shape[-1] != len(MOTOR_NAMES):
+        raise ValueError(f"dataset row last dim {values.shape[-1]} != expected {len(MOTOR_NAMES)}")
+    lower, upper = _validate_gripper_limits(gripper_limits_rad)
+    qpos = values * _DEG2RAD
+    qpos[..., _GRIPPER_INDEX] = lower + values[..., _GRIPPER_INDEX] / 100.0 * (upper - lower)
+    return qpos
+
+
+def sim_qpos_to_dataset_row(
+    qpos,
+    *,
+    gripper_limits_rad: GripperLimitsRad = SO101_GRIPPER_LIMITS_RAD,
+):
+    """Encode simulator joint radians into a normalized LeRobot dataset row.
+
+    Inverse of :func:`dataset_row_to_sim_qpos`: body joints become degrees and
+    the gripper its ``RANGE_0_100`` percent. Useful for replaying a simulator
+    trajectory or policy output as LeRobot dataset rows.
+
+    Parameters
+    ----------
+    qpos:
+        NumPy array, torch tensor, or sequence of shape ``(..., 6)`` of simulator
+        joint radians in SO101 joint order.
+    gripper_limits_rad:
+        Simulator gripper ``(low, high)`` control range in radians.
+
+    Returns
+    -------
+    Same array type as ``qpos`` with body joints in degrees and the gripper as a
+    ``[0, 100]`` percent of ``[low, high]``.
+    """
+    values = qpos if hasattr(qpos, "shape") else np.asarray(qpos, dtype=np.float64)
+    if values.shape[-1] != len(MOTOR_NAMES):
+        raise ValueError(f"sim qpos last dim {values.shape[-1]} != expected {len(MOTOR_NAMES)}")
+    lower, upper = _validate_gripper_limits(gripper_limits_rad)
+    row = values * _RAD2DEG
+    row[..., _GRIPPER_INDEX] = (values[..., _GRIPPER_INDEX] - lower) / (upper - lower) * 100.0
+    return row
 
 
 def _unwrap_env(env: object) -> object:

--- a/src/so101_nexus/lerobot_adapter/normalization.py
+++ b/src/so101_nexus/lerobot_adapter/normalization.py
@@ -10,6 +10,7 @@ from lerobot.motors import Motor, MotorCalibration, MotorNormMode
 from lerobot.motors.feetech import FeetechMotorsBus
 
 from so101_nexus.config import SO101_JOINT_NAMES
+from so101_nexus.lerobot_dataset import GripperLimitsRad, _validate_gripper_limits
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -20,17 +21,6 @@ GRIPPER_NAME = "gripper"
 MOTOR_MODEL = "sts3215"
 MOTOR_RESOLUTION = 4096
 TICKS_PER_RADIAN = (MOTOR_RESOLUTION - 1) / (2 * math.pi)
-GripperLimitsRad = tuple[float, float]
-_DEG2RAD = math.pi / 180.0
-_RAD2DEG = 180.0 / math.pi
-_GRIPPER_INDEX = MOTOR_NAMES.index(GRIPPER_NAME)
-SO101_GRIPPER_LIMITS_RAD: GripperLimitsRad = (math.radians(-10.0), math.radians(100.0))
-"""Default SO101 gripper jaw travel in radians (-10 deg .. +100 deg).
-
-Matches the gripper actuator control range across the vendored SO101 MuJoCo
-models. Pass ``read_gripper_limits_rad(env)`` for the exact runtime bounds of a
-specific environment.
-"""
 
 
 def build_so101_motors(*, use_degrees: bool) -> dict[str, Motor]:
@@ -78,13 +68,6 @@ def unnormalize_values(
     id_values = {motors[name].id: float(value) for name, value in values.items()}
     unnormalized = bus._unnormalize(id_values)
     return {name: int(unnormalized[motors[name].id]) for name in values}
-
-
-def _validate_gripper_limits(gripper_limits_rad: GripperLimitsRad) -> GripperLimitsRad:
-    lower, upper = (float(gripper_limits_rad[0]), float(gripper_limits_rad[1]))
-    if upper == lower:
-        raise ValueError("gripper_limits_rad lower and upper bounds must differ")
-    return lower, upper
 
 
 def _validate_calibration_range(name: str, calibration: MotorCalibration) -> None:
@@ -171,84 +154,6 @@ def leader_action_to_sim_qpos(
         calibration=calibration,
         gripper_limits_rad=gripper_limits_rad,
     )
-
-
-def dataset_row_to_sim_qpos(
-    row,
-    *,
-    gripper_limits_rad: GripperLimitsRad = SO101_GRIPPER_LIMITS_RAD,
-):
-    """Decode a normalized LeRobot dataset row into simulator joint radians.
-
-    Recorded ``action`` and ``observation.state`` six-vectors mix units: body
-    joints ``shoulder_pan..wrist_roll`` use ``MotorNormMode.DEGREES`` while the
-    gripper uses ``MotorNormMode.RANGE_0_100`` (percent of jaw travel, not
-    degrees). This inverts that per-motor map, avoiding the silent corruption of
-    decoding the whole vector with ``np.deg2rad``.
-
-    Parameters
-    ----------
-    row:
-        NumPy array, torch tensor, or sequence of shape ``(..., 6)`` of recorded
-        values in SO101 joint order.
-    gripper_limits_rad:
-        Simulator gripper ``(low, high)`` control range in radians. Defaults to
-        the SO101 gripper travel; pass ``read_gripper_limits_rad(env)`` for the
-        exact bounds of a specific environment.
-
-    Returns
-    -------
-    Same array type as ``row`` with body joints converted via ``deg2rad`` and the
-    gripper mapped linearly from ``[0, 100]`` onto ``[low, high]``.
-
-    Notes
-    -----
-    Assumes the library recording convention (synthetic calibration,
-    ``drive_mode=0``). Datasets recorded against a physical follower calibration
-    with inverted body drive modes need :func:`leader_action_to_sim_qpos`. This
-    is a pure unit transform; clamping to the actuator range stays the caller's
-    job via :func:`action_for_env`.
-    """
-    values = row if hasattr(row, "shape") else np.asarray(row, dtype=np.float64)
-    if values.shape[-1] != len(MOTOR_NAMES):
-        raise ValueError(f"dataset row last dim {values.shape[-1]} != expected {len(MOTOR_NAMES)}")
-    lower, upper = _validate_gripper_limits(gripper_limits_rad)
-    qpos = values * _DEG2RAD
-    qpos[..., _GRIPPER_INDEX] = lower + values[..., _GRIPPER_INDEX] / 100.0 * (upper - lower)
-    return qpos
-
-
-def sim_qpos_to_dataset_row(
-    qpos,
-    *,
-    gripper_limits_rad: GripperLimitsRad = SO101_GRIPPER_LIMITS_RAD,
-):
-    """Encode simulator joint radians into a normalized LeRobot dataset row.
-
-    Inverse of :func:`dataset_row_to_sim_qpos`: body joints become degrees and
-    the gripper its ``RANGE_0_100`` percent. Useful for replaying a simulator
-    trajectory or policy output as LeRobot dataset rows.
-
-    Parameters
-    ----------
-    qpos:
-        NumPy array, torch tensor, or sequence of shape ``(..., 6)`` of simulator
-        joint radians in SO101 joint order.
-    gripper_limits_rad:
-        Simulator gripper ``(low, high)`` control range in radians.
-
-    Returns
-    -------
-    Same array type as ``qpos`` with body joints in degrees and the gripper as a
-    ``[0, 100]`` percent of ``[low, high]``.
-    """
-    values = qpos if hasattr(qpos, "shape") else np.asarray(qpos, dtype=np.float64)
-    if values.shape[-1] != len(MOTOR_NAMES):
-        raise ValueError(f"sim qpos last dim {values.shape[-1]} != expected {len(MOTOR_NAMES)}")
-    lower, upper = _validate_gripper_limits(gripper_limits_rad)
-    row = values * _RAD2DEG
-    row[..., _GRIPPER_INDEX] = (values[..., _GRIPPER_INDEX] - lower) / (upper - lower) * 100.0
-    return row
 
 
 def _unwrap_env(env: object) -> object:

--- a/src/so101_nexus/lerobot_dataset.py
+++ b/src/so101_nexus/lerobot_dataset.py
@@ -1,0 +1,117 @@
+"""Pure unit conversions between LeRobot dataset rows and simulator radians.
+
+These helpers turn recorded ``action`` / ``observation.state`` six-vectors into
+simulator joint radians (and back) without a calibration file. They depend only
+on NumPy and the joint-name config, so they import cleanly without the
+``teleop`` extra (LeRobot is not required). Like the reward functions, they
+accept Python floats, NumPy arrays, and torch tensors by duck typing; ``torch``
+is never imported here and tensor support relies on operator overloading, so the
+same call decodes a single row or a batched ``(..., 6)`` policy tensor.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from so101_nexus.config import SO101_JOINT_NAMES
+
+GripperLimitsRad = tuple[float, float]
+_DEG2RAD = math.pi / 180.0
+_RAD2DEG = 180.0 / math.pi
+_GRIPPER_INDEX = len(SO101_JOINT_NAMES) - 1
+SO101_GRIPPER_LIMITS_RAD: GripperLimitsRad = (math.radians(-10.0), math.radians(100.0))
+"""Default SO101 gripper jaw travel in radians (-10 deg .. +100 deg).
+
+Matches the gripper actuator control range across the vendored SO101 MuJoCo
+models. Pass the env gripper control bounds (``env.action_space`` low/high at the
+gripper index, or ``read_gripper_limits_rad(env)`` from the adapter) for the
+exact runtime limits of a specific environment.
+"""
+
+
+def _validate_gripper_limits(gripper_limits_rad: GripperLimitsRad) -> GripperLimitsRad:
+    lower, upper = (float(gripper_limits_rad[0]), float(gripper_limits_rad[1]))
+    if upper == lower:
+        raise ValueError("gripper_limits_rad lower and upper bounds must differ")
+    return lower, upper
+
+
+def dataset_row_to_sim_qpos(
+    row,
+    *,
+    gripper_limits_rad: GripperLimitsRad = SO101_GRIPPER_LIMITS_RAD,
+):
+    """Decode a normalized LeRobot dataset row into simulator joint radians.
+
+    Recorded ``action`` and ``observation.state`` six-vectors mix units: body
+    joints ``shoulder_pan..wrist_roll`` use ``MotorNormMode.DEGREES`` while the
+    gripper uses ``MotorNormMode.RANGE_0_100`` (percent of jaw travel, not
+    degrees). This inverts that per-motor map, avoiding the silent corruption of
+    decoding the whole vector with ``np.deg2rad``.
+
+    Parameters
+    ----------
+    row:
+        NumPy array, torch tensor, or sequence of shape ``(..., 6)`` of recorded
+        values in SO101 joint order.
+    gripper_limits_rad:
+        Simulator gripper ``(low, high)`` control range in radians. Defaults to
+        the SO101 gripper travel; pass the env gripper bounds for exactness.
+
+    Returns
+    -------
+    Same array type as ``row`` with body joints converted via ``deg2rad`` and the
+    gripper mapped linearly from ``[0, 100]`` onto ``[low, high]``.
+
+    Notes
+    -----
+    Assumes the library recording convention (synthetic calibration,
+    ``drive_mode=0``). This is a pure unit transform; clamping to the actuator
+    range stays the caller's job.
+    """
+    values = row if hasattr(row, "shape") else np.asarray(row, dtype=np.float64)
+    if values.shape[-1] != len(SO101_JOINT_NAMES):
+        raise ValueError(
+            f"dataset row last dim {values.shape[-1]} != expected {len(SO101_JOINT_NAMES)}"
+        )
+    lower, upper = _validate_gripper_limits(gripper_limits_rad)
+    qpos = values * _DEG2RAD
+    qpos[..., _GRIPPER_INDEX] = lower + values[..., _GRIPPER_INDEX] / 100.0 * (upper - lower)
+    return qpos
+
+
+def sim_qpos_to_dataset_row(
+    qpos,
+    *,
+    gripper_limits_rad: GripperLimitsRad = SO101_GRIPPER_LIMITS_RAD,
+):
+    """Encode simulator joint radians into a normalized LeRobot dataset row.
+
+    Inverse of :func:`dataset_row_to_sim_qpos`: body joints become degrees and
+    the gripper its ``RANGE_0_100`` percent. Useful for replaying a simulator
+    trajectory or policy output as LeRobot dataset rows.
+
+    Parameters
+    ----------
+    qpos:
+        NumPy array, torch tensor, or sequence of shape ``(..., 6)`` of simulator
+        joint radians in SO101 joint order.
+    gripper_limits_rad:
+        Simulator gripper ``(low, high)`` control range in radians.
+
+    Returns
+    -------
+    Same array type as ``qpos`` with body joints in degrees and the gripper as a
+    ``[0, 100]`` percent of ``[low, high]``.
+    """
+    values = qpos if hasattr(qpos, "shape") else np.asarray(qpos, dtype=np.float64)
+    if values.shape[-1] != len(SO101_JOINT_NAMES):
+        raise ValueError(
+            f"sim qpos last dim {values.shape[-1]} != expected {len(SO101_JOINT_NAMES)}"
+        )
+    lower, upper = _validate_gripper_limits(gripper_limits_rad)
+    row = values * _RAD2DEG
+    row[..., _GRIPPER_INDEX] = (values[..., _GRIPPER_INDEX] - lower) / (upper - lower) * 100.0
+    return row

--- a/tests/core/test_lerobot_adapter_mujoco.py
+++ b/tests/core/test_lerobot_adapter_mujoco.py
@@ -94,3 +94,21 @@ def test_mujoco_env_clipping_is_reflected_in_returned_action(tmp_path: Path) -> 
     finally:
         if robot.is_connected:
             robot.disconnect()
+
+
+def test_default_gripper_limits_match_env() -> None:
+    import gymnasium as gym
+
+    from so101_nexus.lerobot_adapter.normalization import (
+        SO101_GRIPPER_LIMITS_RAD,
+        read_gripper_limits_rad,
+    )
+
+    env = gym.make("MuJoCoPickLift-v1")
+    try:
+        low, high = read_gripper_limits_rad(env)
+    finally:
+        env.close()
+
+    assert low == pytest.approx(SO101_GRIPPER_LIMITS_RAD[0], abs=1e-3)
+    assert high == pytest.approx(SO101_GRIPPER_LIMITS_RAD[1], abs=1e-3)

--- a/tests/core/test_lerobot_adapter_mujoco.py
+++ b/tests/core/test_lerobot_adapter_mujoco.py
@@ -99,10 +99,8 @@ def test_mujoco_env_clipping_is_reflected_in_returned_action(tmp_path: Path) -> 
 def test_default_gripper_limits_match_env() -> None:
     import gymnasium as gym
 
-    from so101_nexus.lerobot_adapter.normalization import (
-        SO101_GRIPPER_LIMITS_RAD,
-        read_gripper_limits_rad,
-    )
+    from so101_nexus import SO101_GRIPPER_LIMITS_RAD
+    from so101_nexus.lerobot_adapter.normalization import read_gripper_limits_rad
 
     env = gym.make("MuJoCoPickLift-v1")
     try:

--- a/tests/core/test_lerobot_adapter_normalization.py
+++ b/tests/core/test_lerobot_adapter_normalization.py
@@ -238,3 +238,81 @@ def test_read_sim_qpos_supports_tensor_shape() -> None:
             return torch.tensor([[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]])
 
     np.testing.assert_array_equal(read_sim_qpos(_Env()), np.arange(6, dtype=np.float32))
+
+
+def test_dataset_row_to_sim_qpos_inverts_recorder_pipeline() -> None:
+    from so101_nexus.lerobot_adapter.normalization import (
+        MOTOR_NAMES,
+        SO101_GRIPPER_LIMITS_RAD,
+        build_so101_motors,
+        dataset_row_to_sim_qpos,
+        normalize_ticks,
+        sim_rad_to_motor_ticks,
+    )
+    from so101_nexus.lerobot_adapter.synthetic_calibration import (
+        build_synthetic_calibration,
+    )
+
+    calibration = build_synthetic_calibration()
+    motors = build_so101_motors(use_degrees=True)
+    qpos = np.array([0.3, -0.4, 0.5, -0.2, 0.1, 0.113], dtype=np.float64)
+
+    ticks = sim_rad_to_motor_ticks(
+        qpos, calibration=calibration, gripper_limits_rad=SO101_GRIPPER_LIMITS_RAD
+    )
+    values = normalize_ticks(ticks, motors=motors, calibration=calibration)
+    row = np.array([values[name] for name in MOTOR_NAMES])
+
+    decoded = dataset_row_to_sim_qpos(row)
+    np.testing.assert_allclose(decoded, qpos, atol=2e-3)
+
+
+def test_dataset_row_gripper_decodes_as_range_0_100_not_degrees() -> None:
+    from so101_nexus.lerobot_adapter.normalization import (
+        SO101_GRIPPER_LIMITS_RAD,
+        dataset_row_to_sim_qpos,
+    )
+
+    low, high = SO101_GRIPPER_LIMITS_RAD
+    row = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 15.0])
+    decoded = dataset_row_to_sim_qpos(row)
+
+    assert decoded[5] == pytest.approx(low + (15.0 / 100.0) * (high - low))
+    # The naive deg2rad-the-whole-vector decode is the bug; it is far off here.
+    assert abs(decoded[5] - math.radians(15.0)) > 0.1
+
+
+def test_sim_qpos_to_dataset_row_round_trips_batched() -> None:
+    from so101_nexus.lerobot_adapter.normalization import (
+        SO101_GRIPPER_LIMITS_RAD,
+        dataset_row_to_sim_qpos,
+        sim_qpos_to_dataset_row,
+    )
+
+    rng = np.random.default_rng(0)
+    qpos = rng.uniform(-0.5, 0.5, size=(4, 6))
+    low, high = SO101_GRIPPER_LIMITS_RAD
+    qpos[:, 5] = rng.uniform(low, high, size=4)
+
+    row = sim_qpos_to_dataset_row(qpos)
+    np.testing.assert_allclose(dataset_row_to_sim_qpos(row), qpos, atol=1e-12)
+    np.testing.assert_allclose(row[:, :5], np.rad2deg(qpos[:, :5]), atol=1e-12)
+    assert np.all((row[:, 5] >= 0.0) & (row[:, 5] <= 100.0))
+
+
+def test_dataset_row_to_sim_qpos_supports_torch_tensor() -> None:
+    torch = pytest.importorskip("torch")
+    from so101_nexus.lerobot_adapter.normalization import dataset_row_to_sim_qpos
+
+    row_np = np.array([[10.0, -20.0, 30.0, -5.0, 1.0, 15.0], [0.0, 0.0, 0.0, 0.0, 0.0, 100.0]])
+    decoded_t = dataset_row_to_sim_qpos(torch.tensor(row_np))
+
+    assert isinstance(decoded_t, torch.Tensor)
+    np.testing.assert_allclose(decoded_t.numpy(), dataset_row_to_sim_qpos(row_np), atol=1e-12)
+
+
+def test_dataset_row_to_sim_qpos_rejects_wrong_width() -> None:
+    from so101_nexus.lerobot_adapter.normalization import dataset_row_to_sim_qpos
+
+    with pytest.raises(ValueError, match="6"):
+        dataset_row_to_sim_qpos(np.zeros(5))

--- a/tests/core/test_lerobot_adapter_normalization.py
+++ b/tests/core/test_lerobot_adapter_normalization.py
@@ -241,11 +241,10 @@ def test_read_sim_qpos_supports_tensor_shape() -> None:
 
 
 def test_dataset_row_to_sim_qpos_inverts_recorder_pipeline() -> None:
+    from so101_nexus import SO101_GRIPPER_LIMITS_RAD, dataset_row_to_sim_qpos
     from so101_nexus.lerobot_adapter.normalization import (
         MOTOR_NAMES,
-        SO101_GRIPPER_LIMITS_RAD,
         build_so101_motors,
-        dataset_row_to_sim_qpos,
         normalize_ticks,
         sim_rad_to_motor_ticks,
     )
@@ -265,54 +264,3 @@ def test_dataset_row_to_sim_qpos_inverts_recorder_pipeline() -> None:
 
     decoded = dataset_row_to_sim_qpos(row)
     np.testing.assert_allclose(decoded, qpos, atol=2e-3)
-
-
-def test_dataset_row_gripper_decodes_as_range_0_100_not_degrees() -> None:
-    from so101_nexus.lerobot_adapter.normalization import (
-        SO101_GRIPPER_LIMITS_RAD,
-        dataset_row_to_sim_qpos,
-    )
-
-    low, high = SO101_GRIPPER_LIMITS_RAD
-    row = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 15.0])
-    decoded = dataset_row_to_sim_qpos(row)
-
-    assert decoded[5] == pytest.approx(low + (15.0 / 100.0) * (high - low))
-    # The naive deg2rad-the-whole-vector decode is the bug; it is far off here.
-    assert abs(decoded[5] - math.radians(15.0)) > 0.1
-
-
-def test_sim_qpos_to_dataset_row_round_trips_batched() -> None:
-    from so101_nexus.lerobot_adapter.normalization import (
-        SO101_GRIPPER_LIMITS_RAD,
-        dataset_row_to_sim_qpos,
-        sim_qpos_to_dataset_row,
-    )
-
-    rng = np.random.default_rng(0)
-    qpos = rng.uniform(-0.5, 0.5, size=(4, 6))
-    low, high = SO101_GRIPPER_LIMITS_RAD
-    qpos[:, 5] = rng.uniform(low, high, size=4)
-
-    row = sim_qpos_to_dataset_row(qpos)
-    np.testing.assert_allclose(dataset_row_to_sim_qpos(row), qpos, atol=1e-12)
-    np.testing.assert_allclose(row[:, :5], np.rad2deg(qpos[:, :5]), atol=1e-12)
-    assert np.all((row[:, 5] >= 0.0) & (row[:, 5] <= 100.0))
-
-
-def test_dataset_row_to_sim_qpos_supports_torch_tensor() -> None:
-    torch = pytest.importorskip("torch")
-    from so101_nexus.lerobot_adapter.normalization import dataset_row_to_sim_qpos
-
-    row_np = np.array([[10.0, -20.0, 30.0, -5.0, 1.0, 15.0], [0.0, 0.0, 0.0, 0.0, 0.0, 100.0]])
-    decoded_t = dataset_row_to_sim_qpos(torch.tensor(row_np))
-
-    assert isinstance(decoded_t, torch.Tensor)
-    np.testing.assert_allclose(decoded_t.numpy(), dataset_row_to_sim_qpos(row_np), atol=1e-12)
-
-
-def test_dataset_row_to_sim_qpos_rejects_wrong_width() -> None:
-    from so101_nexus.lerobot_adapter.normalization import dataset_row_to_sim_qpos
-
-    with pytest.raises(ValueError, match="6"):
-        dataset_row_to_sim_qpos(np.zeros(5))

--- a/tests/core/test_lerobot_dataset.py
+++ b/tests/core/test_lerobot_dataset.py
@@ -1,0 +1,77 @@
+"""Tests for the lerobot-free dataset row to sim qpos conversions."""
+
+from __future__ import annotations
+
+import math
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+
+from so101_nexus import (
+    SO101_GRIPPER_LIMITS_RAD,
+    dataset_row_to_sim_qpos,
+    sim_qpos_to_dataset_row,
+)
+
+
+def test_dataset_row_gripper_decodes_as_range_0_100_not_degrees() -> None:
+    low, high = SO101_GRIPPER_LIMITS_RAD
+    row = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 15.0])
+    decoded = dataset_row_to_sim_qpos(row)
+
+    assert decoded[5] == pytest.approx(low + (15.0 / 100.0) * (high - low))
+    # The naive deg2rad-the-whole-vector decode is the bug; it is far off here.
+    assert abs(decoded[5] - math.radians(15.0)) > 0.1
+
+
+def test_sim_qpos_to_dataset_row_round_trips_batched() -> None:
+    rng = np.random.default_rng(0)
+    qpos = rng.uniform(-0.5, 0.5, size=(4, 6))
+    low, high = SO101_GRIPPER_LIMITS_RAD
+    qpos[:, 5] = rng.uniform(low, high, size=4)
+
+    row = sim_qpos_to_dataset_row(qpos)
+    np.testing.assert_allclose(dataset_row_to_sim_qpos(row), qpos, atol=1e-12)
+    np.testing.assert_allclose(row[:, :5], np.rad2deg(qpos[:, :5]), atol=1e-12)
+    assert np.all((row[:, 5] >= 0.0) & (row[:, 5] <= 100.0))
+
+
+def test_dataset_row_to_sim_qpos_respects_custom_gripper_limits() -> None:
+    row = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 50.0])
+    decoded = dataset_row_to_sim_qpos(row, gripper_limits_rad=(0.0, 2.0))
+    assert decoded[5] == pytest.approx(1.0)
+
+
+def test_dataset_row_to_sim_qpos_supports_torch_tensor() -> None:
+    torch = pytest.importorskip("torch")
+
+    row_np = np.array([[10.0, -20.0, 30.0, -5.0, 1.0, 15.0], [0.0, 0.0, 0.0, 0.0, 0.0, 100.0]])
+    decoded_t = dataset_row_to_sim_qpos(torch.tensor(row_np))
+
+    assert isinstance(decoded_t, torch.Tensor)
+    np.testing.assert_allclose(decoded_t.numpy(), dataset_row_to_sim_qpos(row_np), atol=1e-12)
+
+
+def test_dataset_row_to_sim_qpos_rejects_wrong_width() -> None:
+    with pytest.raises(ValueError, match="6"):
+        dataset_row_to_sim_qpos(np.zeros(5))
+
+
+def test_decode_helpers_import_without_lerobot() -> None:
+    """The decode path must work without the teleop extra (LeRobot)."""
+    code = (
+        "import sys; sys.modules['lerobot'] = None;"  # make `import lerobot` raise
+        "import numpy as np;"
+        "from so101_nexus import dataset_row_to_sim_qpos, SO101_GRIPPER_LIMITS_RAD;"
+        "low, high = SO101_GRIPPER_LIMITS_RAD;"
+        "row = np.zeros(6); row[5] = 50.0;"
+        "q = dataset_row_to_sim_qpos(row);"
+        "assert q.shape == (6,);"
+        "assert abs(q[5] - (low + 0.5 * (high - low))) < 1e-9;"
+        "print('ok')"
+    )
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=False)
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip().endswith("ok")

--- a/uv.lock
+++ b/uv.lock
@@ -3405,7 +3405,7 @@ wheels = [
 
 [[package]]
 name = "so101-nexus"
-version = "0.4.4"
+version = "0.4.5"
 source = { editable = "." }
 dependencies = [
     { name = "gymnasium" },


### PR DESCRIPTION
Add public dataset_row_to_sim_qpos and sim_qpos_to_dataset_row helpers plus SO101_GRIPPER_LIMITS_RAD to convert normalized LeRobot dataset rows (body joints in degrees, gripper in RANGE_0_100) back to simulator radians without needing a calibration file. This avoids the silent gripper corruption from applying np.deg2rad to the whole six-vector. Also export read_gripper_limits_rad for the documented per-env override.

Verified against johnsutor/MuJoCoPickLift: decoded qpos land inside the actuator ctrl ranges and round-trip to tick precision.

Bump version to 0.4.5.