### PR TITLE
feat(teleop): record privileged state and success/done by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "so101-nexus"
-version = "0.4.5"
+version = "0.4.6"
 description = "End-to-end simulation and training stack for the SO-101 arm: record demonstrations, clone behavior, and reinforce with GPU-parallel MuJoCo / MuJoCo Warp environments, built on LeRobot"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/so101_nexus/__init__.py
+++ b/src/so101_nexus/__init__.py
@@ -59,6 +59,7 @@ from so101_nexus.observations import (
     TargetOffset,
     TargetPosition,
     WristCamera,
+    privileged_state_feature_names,
 )
 from so101_nexus.rewards import (
     lift_progress,
@@ -157,6 +158,7 @@ __all__ = [
     "get_ycb_visual_mesh",
     "lift_progress",
     "orientation_progress",
+    "privileged_state_feature_names",
     "reach_progress",
     "sample_color",
     "sim_qpos_to_dataset_row",

--- a/src/so101_nexus/lerobot_adapter/normalization.py
+++ b/src/so101_nexus/lerobot_adapter/normalization.py
@@ -181,6 +181,26 @@ def read_sim_qpos(env: object) -> np.ndarray:
     raise TypeError("Simulator env must expose _get_current_qpos().")
 
 
+def read_privileged_state(env: object) -> np.ndarray | None:
+    """Return the env's non-camera state observation vector, or ``None``.
+
+    Reads the flat privileged state the env would emit in ``obs_mode="state"``
+    (and carries as ``info["privileged_state"]`` in visual mode): the
+    concatenation of every non-camera observation component
+    (TCP pose, grasp, object pose, offsets, ...). Returns ``None`` when the env
+    exposes no component-based state (no ``_compute_obs_components`` method or an
+    empty/absent ``config.observations``), so callers can skip the channel.
+    """
+    unwrapped = _unwrap_env(env)
+    compute = getattr(unwrapped, "_compute_obs_components", None)
+    if not callable(compute):
+        return None
+    observations = getattr(getattr(unwrapped, "config", None), "observations", None)
+    if not observations or all(getattr(c, "size", 0) == 0 for c in observations):
+        return None
+    return np.asarray(compute(), dtype=np.float32)
+
+
 def _control_bounds(env: object) -> tuple[np.ndarray, np.ndarray] | None:
     unwrapped = _unwrap_env(env)
     if hasattr(unwrapped, "_ctrl_low") and hasattr(unwrapped, "_ctrl_high"):

--- a/src/so101_nexus/lerobot_adapter/sim_follower.py
+++ b/src/so101_nexus/lerobot_adapter/sim_follower.py
@@ -22,6 +22,7 @@ from so101_nexus.lerobot_adapter.normalization import (
     motor_ticks_to_sim_rad,
     normalize_ticks,
     read_gripper_limits_rad,
+    read_privileged_state,
     read_sim_qpos,
     sim_rad_to_motor_ticks,
     unnormalize_values,
@@ -195,6 +196,10 @@ class SimSOFollower(Robot):
             f"{motor}.pos": value for motor, value in motor_values.items()
         }
         logger.debug("%s read sim state: %.1fms", self, (time.perf_counter() - start) * 1e3)
+
+        privileged_state = read_privileged_state(self._env)
+        if privileged_state is not None:
+            obs_dict["environment_state"] = privileged_state
 
         for camera_name, camera in self.cameras.items():
             start = time.perf_counter()

--- a/src/so101_nexus/observations.py
+++ b/src/so101_nexus/observations.py
@@ -19,8 +19,12 @@ Typical usage::
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class Observation(ABC):
@@ -264,3 +268,35 @@ class OverheadCamera(CameraObservation):
     ) -> None:
         super().__init__(width=width, height=height)
         self.fov_deg = fov_deg
+
+
+def privileged_state_feature_names(
+    observations: Sequence[Observation] | None,
+) -> list[str]:
+    """Return per-dimension names for the non-camera state observation vector.
+
+    The names match the concatenation order of the flat state vector built from
+    ``observations`` (camera components, whose ``size`` is 0, are skipped). Each
+    scalar dimension is named ``<component name>_<i>`` (e.g. ``object_pose_0``),
+    giving a stable, self-describing schema for the recorded
+    ``observation.environment_state`` channel.
+
+    Parameters
+    ----------
+    observations
+        Observation components (as on ``EnvironmentConfig.observations``), or
+        ``None``.
+
+    Returns
+    -------
+    list[str]
+        One name per scalar dimension, in component order. Empty when
+        ``observations`` is ``None`` or has no non-camera components.
+    """
+    if observations is None:
+        return []
+    names: list[str] = []
+    for comp in observations:
+        for i in range(comp.size):
+            names.append(f"{comp.name}_{i}")
+    return names

--- a/src/so101_nexus/policy_adapters/recorder.py
+++ b/src/so101_nexus/policy_adapters/recorder.py
@@ -133,7 +133,14 @@ class RolloutRecorder:
             next_obs, reward, terminated, truncated, info = self.env.step(action_rad)
 
             if self.dataset is not None:
-                self._add_frame(obs, action_deg, task, float(reward))
+                self._add_frame(
+                    obs,
+                    action_deg,
+                    task,
+                    float(reward),
+                    success=float(bool(info.get("success", False))),
+                    done=float(terminated or truncated),
+                )
 
             obs = next_obs
             if terminated or truncated:
@@ -177,6 +184,9 @@ class RolloutRecorder:
         action_deg: np.ndarray,
         task: str,
         reward: float,
+        *,
+        success: float = 0.0,
+        done: float = 0.0,
     ) -> None:
         """Append one frame to the configured dataset."""
         from so101_nexus.teleop.dataset import FieldSelection, build_frame
@@ -184,9 +194,12 @@ class RolloutRecorder:
         if self.dataset is None:
             raise RuntimeError("RolloutRecorder has no dataset configured.")
 
+        # Rollout obs in visual mode carries only joints, so the privileged
+        # environment_state channel is not recorded here.
         selection = FieldSelection(
             wrist_image="wrist_camera" in self.camera_keys,
             overhead_image="overhead_camera" in self.camera_keys,
+            environment_state=False,
             task=True,
         )
         frame = build_frame(
@@ -195,6 +208,8 @@ class RolloutRecorder:
             action=action_deg.astype(np.float32),
             task=task,
             reward=reward,
+            success=success,
+            done=done,
             wrist_image=obs.get("wrist_camera"),
             overhead_image=obs.get("overhead_camera"),
         )

--- a/src/so101_nexus/teleop/app.py
+++ b/src/so101_nexus/teleop/app.py
@@ -12,7 +12,7 @@ import importlib
 import logging
 import os
 import threading
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
@@ -29,6 +29,7 @@ from so101_nexus.teleop.config_customization import (
     overrides_to_mapping,
 )
 from so101_nexus.teleop.dataset import (
+    ENV_STATE_KEY,
     OVERHEAD_KEY,
     WRIST_KEY,
     FieldSelection,
@@ -54,6 +55,7 @@ from so101_nexus.teleop.session import (
     _resolve_env_ctor,
     make_review_video,
     make_state_plot,
+    resolve_recording_observations,
 )
 
 if TYPE_CHECKING:
@@ -61,7 +63,7 @@ if TYPE_CHECKING:
 
     from so101_nexus.teleop.cli import TeleopArgs
 
-_OPTIONAL_FIELD_CHOICES = [WRIST_KEY, OVERHEAD_KEY]
+_OPTIONAL_FIELD_CHOICES = [WRIST_KEY, OVERHEAD_KEY, ENV_STATE_KEY]
 _FOLLOWER_ROBOT_ID = "teleop_sim"
 _TASK_PENDING_TEXT = "### Current task\n\n_Task will appear after reset._"
 logger = logging.getLogger(__name__)
@@ -121,6 +123,7 @@ def _build_field_selection(field_selection_value: list[str]) -> FieldSelection:
     return FieldSelection(
         wrist_image=WRIST_KEY in field_selection_value,
         overhead_image=OVERHEAD_KEY in field_selection_value,
+        environment_state=ENV_STATE_KEY in field_selection_value,
         task="task" in field_selection_value,
     )
 
@@ -331,6 +334,33 @@ def _create_dataset(repo_id: str, fps: int, robot_type: str, features: dict, lea
         raise RuntimeError(f"Failed to create dataset: {exc}") from exc
 
 
+def _resolve_env_state_names(
+    env_id: str,
+    wrist_wh: tuple[int, int],
+    overhead_wh: tuple[int, int],
+    *,
+    overrides: TeleopConfigOverrides | None,
+    profile_path: str | None,
+    factory,
+) -> list[str]:
+    """Return per-dim names for the env's privileged state, or ``[]`` if none.
+
+    Resolves the same recording config the follower will run so the declared
+    ``observation.environment_state`` schema matches the runtime vector.
+    """
+    from so101_nexus.observations import privileged_state_feature_names
+
+    observations = resolve_recording_observations(
+        env_id,
+        wrist_wh,
+        overhead_wh,
+        overrides=overrides,
+        profile_path=profile_path,
+        factory=factory,
+    )
+    return privileged_state_feature_names(observations)
+
+
 def _run_init_worker(
     session: dict,
     init_state: dict,
@@ -362,7 +392,24 @@ def _run_init_worker(
         follower_features = dict(action_features)
         follower_features["wrist"] = (wrist_wh[1], wrist_wh[0], 3)
         follower_features["overhead"] = (overhead_wh[1], overhead_wh[0], 3)
-        features = build_features(field_selection, follower_features, action_features)
+        env_state_names = _resolve_env_state_names(
+            env_id,
+            wrist_wh,
+            overhead_wh,
+            overrides=env_overrides,
+            profile_path=session.get("env_config_profile"),
+            factory=session.get("env_config_factory"),
+        )
+        if field_selection.environment_state and not env_state_names:
+            # Env exposes no privileged (non-camera) state; keep schema and
+            # frames 1:1 by dropping the channel instead of declaring an empty one.
+            field_selection = replace(field_selection, environment_state=False)
+        features = build_features(
+            field_selection,
+            follower_features,
+            action_features,
+            env_state_names=env_state_names,
+        )
         dataset = _create_dataset(repo_id, fps, robot_type, features, leader)
         session.update(
             leader=leader,
@@ -867,18 +914,27 @@ def _cb_approve_episode(session: dict):
 
         sel = session["field_selection"]
         rewards = list(s.episode_rewards)
+        successes = list(s.episode_successes)
+        dones = list(s.episode_dones)
+        env_states = list(s.episode_env_states)
         for i in range(len(actions)):
             wrist_img = s.episode_wrist_images[i] if i < len(s.episode_wrist_images) else None
             overhead_img = (
                 s.episode_overhead_images[i] if i < len(s.episode_overhead_images) else None
             )
             reward = rewards[i] if i < len(rewards) else 0.0
+            success = successes[i] if i < len(successes) else 0.0
+            done = dones[i] if i < len(dones) else 0.0
+            env_state = env_states[i] if i < len(env_states) else None
             frame = build_frame(
                 sel,
                 state=s.episode_states[i],
                 action=actions[i],
                 task=s.task_description,
                 reward=reward,
+                success=success,
+                done=done,
+                env_state=env_state,
                 wrist_image=wrist_img,
                 overhead_image=overhead_img,
             )
@@ -1109,7 +1165,7 @@ def _build_setup_screen(
         choices=_OPTIONAL_FIELD_CHOICES,
         value=list(_OPTIONAL_FIELD_CHOICES),
         label="Dataset fields",
-        info="observation.state, action, and task are always saved",
+        info="observation.state, action, task, reward, success, and done are always saved",
     )
 
     with gr.Accordion("Advanced Settings", open=False):

--- a/src/so101_nexus/teleop/dataset.py
+++ b/src/so101_nexus/teleop/dataset.py
@@ -16,10 +16,17 @@ import numpy as np
 
 WRIST_KEY = "observation.images.wrist"
 OVERHEAD_KEY = "observation.images.overhead"
+ENV_STATE_KEY = "observation.environment_state"
 REWARD_KEY = "reward"
-# Canonical LeRobot reward feature (matches the `modify_features` docstring
-# example in lerobot.datasets.dataset_tools): a scalar float32 per frame.
-REWARD_FEATURE: dict[str, Any] = {"dtype": "float32", "shape": (1,), "names": None}
+SUCCESS_KEY = "success"
+DONE_KEY = "done"
+# Canonical LeRobot scalar feature (matches the `modify_features` docstring
+# example in lerobot.datasets.dataset_tools): a scalar float32 per frame. Reused
+# for reward, success, and done, which are all always-recorded env-step scalars.
+SCALAR_FEATURE: dict[str, Any] = {"dtype": "float32", "shape": (1,), "names": None}
+REWARD_FEATURE: dict[str, Any] = SCALAR_FEATURE
+# The always-recorded per-step env scalars, in schema order.
+SCALAR_KEYS: tuple[str, ...] = (REWARD_KEY, SUCCESS_KEY, DONE_KEY)
 
 
 @dataclass(frozen=True)
@@ -28,6 +35,7 @@ class FieldSelection:
 
     wrist_image: bool = True
     overhead_image: bool = True
+    environment_state: bool = True
     task: bool = True
 
     @property
@@ -70,6 +78,8 @@ def build_features(
     selection: FieldSelection,
     follower_features: dict[str, Any],
     action_features: dict[str, Any],
+    *,
+    env_state_names: list[str] | None = None,
 ) -> dict[str, dict[str, Any]]:
     """Return the LeRobot feature dict for the selected fields.
 
@@ -81,6 +91,11 @@ def build_features(
         ``SimSOFollower.observation_features``-shaped dict.
     action_features
         ``SimSOFollower.action_features``-shaped dict.
+    env_state_names
+        Per-dimension names for the privileged ``observation.environment_state``
+        vector (see :func:`so101_nexus.observations.privileged_state_feature_names`).
+        When provided and ``selection.environment_state`` is set, the channel is
+        declared as a ``(len(names),)`` float32 feature; otherwise it is omitted.
     """
     hw_to_dataset_features = _hw_to_dataset_features()
     features: dict[str, dict[str, Any]] = {}
@@ -92,9 +107,19 @@ def build_features(
             use_video=True,
         )
     )
-    # Reward is always available from `env.step` and is always recorded; it is
-    # not a user-toggleable field, so it is declared unconditionally.
-    features[REWARD_KEY] = dict(REWARD_FEATURE)
+    # Privileged low-dim ground-truth state (TCP/object pose, grasp, offsets).
+    # Declared directly because `hw_to_dataset_features` would fold per-dim
+    # floats into `observation.state`; a standalone vector needs its own key.
+    if selection.environment_state and env_state_names:
+        features[ENV_STATE_KEY] = {
+            "dtype": "float32",
+            "shape": (len(env_state_names),),
+            "names": list(env_state_names),
+        }
+    # reward/success/done are always available from `env.step` and are always
+    # recorded; they are not user-toggleable fields, so declared unconditionally.
+    for key in SCALAR_KEYS:
+        features[key] = dict(SCALAR_FEATURE)
     return features
 
 
@@ -105,6 +130,9 @@ def build_frame(
     action: np.ndarray,
     task: str,
     reward: float = 0.0,
+    success: float = 0.0,
+    done: float = 0.0,
+    env_state: np.ndarray | None = None,
     wrist_image: np.ndarray | None,
     overhead_image: np.ndarray | None,
 ) -> dict[str, Any]:
@@ -112,9 +140,11 @@ def build_frame(
     frame: dict[str, Any] = {
         "observation.state": state.astype(np.float32),
         "action": action.astype(np.float32),
-        # Per-step transition reward, aligned with `action` on this frame
+        # Per-step env-step scalars, aligned with `action` on this frame
         # (LeRobot `Transition` carries reward with (observation, action)).
         REWARD_KEY: np.array([reward], dtype=np.float32),
+        SUCCESS_KEY: np.array([success], dtype=np.float32),
+        DONE_KEY: np.array([done], dtype=np.float32),
     }
     # LeRobot v3 stores task text outside the regular feature schema, but
     # `LeRobotDataset.add_frame` requires it on every frame.
@@ -133,6 +163,13 @@ def build_frame(
                 "check that the env exposes an overhead camera."
             )
         frame[OVERHEAD_KEY] = overhead_image
+    if selection.environment_state:
+        if env_state is None:
+            raise ValueError(
+                "environment_state selected but no privileged state was recorded; "
+                "check that the env exposes non-camera observation components."
+            )
+        frame[ENV_STATE_KEY] = np.asarray(env_state, dtype=np.float32)
     return frame
 
 
@@ -144,9 +181,10 @@ def _make_reward_scalar_dataset_cls():
     ``Value("float32")`` in ``get_hf_features_from_features``. The buffer of
     (1,) arrays that ``add_frame`` accumulates triggers a NumPy deprecation
     warning when ``datasets`` coerces each element to ``float`` during
-    ``save_episode``. This subclass squeezes the reward buffer to Python
-    scalars before the ``np.stack`` that backs ``save_episode``, matching how
-    LeRobot handles its own ``DEFAULT_FEATURES`` (timestamp, frame_index, etc.).
+    ``save_episode``. This subclass squeezes each scalar buffer (reward,
+    success, done) to Python scalars before the ``np.stack`` that backs
+    ``save_episode``, matching how LeRobot handles its own ``DEFAULT_FEATURES``
+    (timestamp, frame_index, etc.).
 
     The in-progress buffer moved between supported 0.5.x layouts: 0.5.0 keeps
     it on the dataset (``self.episode_buffer``), while 0.5.1 routes recording
@@ -158,7 +196,7 @@ def _make_reward_scalar_dataset_cls():
     from lerobot.datasets.lerobot_dataset import LeRobotDataset
 
     class RewardRecordingDataset(LeRobotDataset):
-        """LeRobotDataset that records the reward feature without scalar coercion warnings."""
+        """LeRobotDataset that records scalar features without coercion warnings."""
 
         def _active_episode_buffer(self) -> dict | None:
             """Return the in-progress episode buffer across LeRobot 0.5.x layouts."""
@@ -174,8 +212,10 @@ def _make_reward_scalar_dataset_cls():
         ) -> None:
             if episode_data is None:
                 buf = self._active_episode_buffer()
-                if buf is not None and isinstance(buf.get("reward"), list):
-                    buf["reward"] = [float(np.asarray(v).reshape(-1)[0]) for v in buf["reward"]]
+                if buf is not None:
+                    for key in SCALAR_KEYS:
+                        if isinstance(buf.get(key), list):
+                            buf[key] = [float(np.asarray(v).reshape(-1)[0]) for v in buf[key]]
             super().save_episode(episode_data, parallel_encoding)
 
     return RewardRecordingDataset

--- a/src/so101_nexus/teleop/recorder.py
+++ b/src/so101_nexus/teleop/recorder.py
@@ -66,7 +66,9 @@ class _InitialLeaderFollower(Protocol):
 
 class _StepInfoLike(Protocol):
     terminated: bool
+    truncated: bool
     reward: float
+    info: dict[str, Any]
 
 
 @dataclass
@@ -82,6 +84,9 @@ class RecordingState:
     episode_actions: list[np.ndarray] = field(default_factory=list)
     episode_states: list[np.ndarray] = field(default_factory=list)
     episode_rewards: list[float] = field(default_factory=list)
+    episode_env_states: list[np.ndarray] = field(default_factory=list)
+    episode_successes: list[float] = field(default_factory=list)
+    episode_dones: list[float] = field(default_factory=list)
     episode_wrist_images: list[np.ndarray] = field(default_factory=list)
     episode_overhead_images: list[np.ndarray] = field(default_factory=list)
     task_description: str = ""
@@ -99,6 +104,9 @@ class RecordingState:
         self.episode_actions.clear()
         self.episode_states.clear()
         self.episode_rewards.clear()
+        self.episode_env_states.clear()
+        self.episode_successes.clear()
+        self.episode_dones.clear()
         self.episode_wrist_images.clear()
         self.episode_overhead_images.clear()
         self.task_description = ""
@@ -339,10 +347,23 @@ def _append_step_buffers(
     step_info: _StepInfoLike | None,
     joint_names: tuple[str, ...],
 ) -> None:
-    """Append one step's actions, states, reward, and camera frames to buffers."""
+    """Append one step's actions, states, reward, success, done, env state, and cameras."""
     state.episode_actions.append(_dict_to_vector(sent_action, joint_names))
     state.episode_states.append(_dict_to_vector(obs, joint_names))
-    # Reward from `env.step(a_t)` (captured by `SimSOFollower.send_action`)
-    # aligns with this frame's action; default to 0.0 before the first step.
+    # Reward/success/done from `env.step(a_t)` (captured by
+    # `SimSOFollower.send_action`) align with this frame's action; default before
+    # the first step. `done` is `terminated or truncated`; `success` is the env's
+    # `info["success"]` (0.0 when the env sets no success key).
     state.episode_rewards.append(step_info.reward if step_info is not None else 0.0)
+    if step_info is None:
+        state.episode_successes.append(0.0)
+        state.episode_dones.append(0.0)
+    else:
+        state.episode_successes.append(float(bool(step_info.info.get("success", False))))
+        state.episode_dones.append(float(step_info.terminated or step_info.truncated))
+    # Privileged state is the pre-step observation (s_t), aligned with
+    # `observation.state`. Absent when the env exposes no non-camera components.
+    env_state = obs.get("environment_state")
+    if env_state is not None:
+        state.episode_env_states.append(np.asarray(env_state, dtype=np.float32))
     _publish_camera_frames(state, obs)

--- a/src/so101_nexus/teleop/session.py
+++ b/src/so101_nexus/teleop/session.py
@@ -165,6 +165,36 @@ def _recording_env_kwargs(
     return kwargs
 
 
+def resolve_recording_observations(
+    env_id: str,
+    wrist_wh: tuple[int, int],
+    overhead_wh: tuple[int, int],
+    *,
+    overrides: TeleopConfigOverrides | None = None,
+    profile_path: str | None = None,
+    factory: ConfigFactory | None = None,
+) -> list | None:
+    """Return the resolved recording config's ``observations`` list, or ``None``.
+
+    Resolves the exact config the recording follower will run
+    (``_recording_env_kwargs`` path), so the privileged-state schema derived from
+    it matches the runtime ``observation.environment_state`` vector. ``None`` when
+    the env exposes no config object (no privileged state to declare).
+    """
+    kwargs = _recording_env_kwargs(
+        env_id,
+        wrist_wh,
+        overhead_wh,
+        overrides=overrides,
+        profile_path=profile_path,
+        factory=factory,
+    )
+    config = kwargs.get("config")
+    if config is None:
+        return None
+    return getattr(config, "observations", None)
+
+
 def prepare_follower_calibration(*, calibration_dir, robot_id: str):
     """Ensure a SimSOFollower-compatible calibration file exists."""
     from pathlib import Path

--- a/tests/core/test_lerobot_adapter_normalization.py
+++ b/tests/core/test_lerobot_adapter_normalization.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+import types
 from typing import Any
 
 import numpy as np
@@ -264,3 +265,54 @@ def test_dataset_row_to_sim_qpos_inverts_recorder_pipeline() -> None:
 
     decoded = dataset_row_to_sim_qpos(row)
     np.testing.assert_allclose(decoded, qpos, atol=2e-3)
+
+
+def test_read_privileged_state_none_without_compute_method() -> None:
+    from so101_nexus.lerobot_adapter.normalization import read_privileged_state
+
+    # No _compute_obs_components: env is not a component-based sim env.
+    env = types.SimpleNamespace(unwrapped=types.SimpleNamespace())
+    assert read_privileged_state(env) is None
+
+
+def test_read_privileged_state_none_when_observations_falsy() -> None:
+    from so101_nexus.lerobot_adapter.normalization import read_privileged_state
+
+    # Callable present but config.observations is empty -> skip the channel.
+    unwrapped = types.SimpleNamespace(
+        _compute_obs_components=lambda: np.zeros(3, dtype=np.float32),
+        config=types.SimpleNamespace(observations=[]),
+    )
+    assert read_privileged_state(types.SimpleNamespace(unwrapped=unwrapped)) is None
+
+
+def test_read_privileged_state_none_for_camera_only_observations() -> None:
+    from so101_nexus.lerobot_adapter.normalization import read_privileged_state
+
+    # All components report size == 0 (cameras): no privileged scalar vector.
+    cameras = [types.SimpleNamespace(size=0), types.SimpleNamespace(size=0)]
+    unwrapped = types.SimpleNamespace(
+        _compute_obs_components=lambda: np.empty(0, dtype=np.float32),
+        config=types.SimpleNamespace(observations=cameras),
+    )
+    assert read_privileged_state(types.SimpleNamespace(unwrapped=unwrapped)) is None
+
+
+def test_read_privileged_state_returns_float32_vector_via_unwrap() -> None:
+    from so101_nexus.lerobot_adapter.normalization import read_privileged_state
+
+    vector = np.arange(4, dtype=np.float64)
+    unwrapped = types.SimpleNamespace(
+        _compute_obs_components=lambda: vector,
+        config=types.SimpleNamespace(observations=[types.SimpleNamespace(size=4)]),
+    )
+    # Outer env only exposes `unwrapped`; the method lives on the inner env,
+    # so a returned vector proves the unwrap path is exercised.
+    wrapped = types.SimpleNamespace(unwrapped=unwrapped)
+
+    result = read_privileged_state(wrapped)
+
+    assert result is not None
+    assert result.dtype == np.float32
+    assert result.shape == (4,)
+    np.testing.assert_array_equal(result, np.arange(4, dtype=np.float32))

--- a/tests/core/test_observations.py
+++ b/tests/core/test_observations.py
@@ -16,6 +16,7 @@ from so101_nexus.observations import (
     TargetOffset,
     TargetPosition,
     WristCamera,
+    privileged_state_feature_names,
 )
 
 
@@ -137,3 +138,46 @@ class TestCameraComponents:
         r2 = repr(cam2)
         assert "800" in r2
         assert "600" in r2
+
+
+class TestPrivilegedStateFeatureNames:
+    def test_none_returns_empty(self):
+        assert privileged_state_feature_names(None) == []
+
+    def test_camera_only_components_contribute_no_names(self):
+        # Camera components report size == 0, so no scalar dims are named.
+        assert privileged_state_feature_names([WristCamera(), OverheadCamera()]) == []
+
+    def test_mixed_components_named_in_order_with_per_dim_suffixes(self):
+        names = privileged_state_feature_names(
+            [EndEffectorPose(), GraspState(), ObjectPose(), ObjectOffset()]
+        )
+        assert names == [
+            "end_effector_pose_0",
+            "end_effector_pose_1",
+            "end_effector_pose_2",
+            "end_effector_pose_3",
+            "end_effector_pose_4",
+            "end_effector_pose_5",
+            "end_effector_pose_6",
+            "grasp_state_0",
+            "object_pose_0",
+            "object_pose_1",
+            "object_pose_2",
+            "object_pose_3",
+            "object_pose_4",
+            "object_pose_5",
+            "object_pose_6",
+            "object_offset_0",
+            "object_offset_1",
+            "object_offset_2",
+        ]
+
+    def test_cameras_interleaved_with_state_are_skipped(self):
+        # A camera between two state components must not shift or add names.
+        assert privileged_state_feature_names([GraspState(), WristCamera(), ObjectOffset()]) == [
+            "grasp_state_0",
+            "object_offset_0",
+            "object_offset_1",
+            "object_offset_2",
+        ]

--- a/tests/core/test_rollout_recorder_dataset.py
+++ b/tests/core/test_rollout_recorder_dataset.py
@@ -85,6 +85,8 @@ def test_record_episode_writes_lerobot_frames_in_degrees() -> None:
         "observation.state",
         "action",
         "reward",
+        "success",
+        "done",
         "task",
         WRIST_KEY,
         OVERHEAD_KEY,

--- a/tests/core/test_teleop_app_helpers.py
+++ b/tests/core/test_teleop_app_helpers.py
@@ -36,7 +36,7 @@ from so101_nexus.teleop.app import (
     _progress_text,
 )
 from so101_nexus.teleop.config_customization import TeleopConfigOverrides
-from so101_nexus.teleop.dataset import OVERHEAD_KEY, WRIST_KEY
+from so101_nexus.teleop.dataset import ENV_STATE_KEY, OVERHEAD_KEY, WRIST_KEY
 from so101_nexus.teleop.recorder import RecordingState
 
 
@@ -170,10 +170,11 @@ def test_require_port_ready_allows_accessible_port(monkeypatch, fake_gradio) -> 
 
 
 def test_build_field_selection_all_keys() -> None:
-    selection = _build_field_selection([WRIST_KEY, OVERHEAD_KEY, "task"])
+    selection = _build_field_selection([WRIST_KEY, OVERHEAD_KEY, ENV_STATE_KEY, "task"])
 
     assert selection.wrist_image is True
     assert selection.overhead_image is True
+    assert selection.environment_state is True
     assert selection.task is True
 
 
@@ -182,6 +183,7 @@ def test_build_field_selection_empty() -> None:
 
     assert selection.wrist_image is False
     assert selection.overhead_image is False
+    assert selection.environment_state is False
     assert selection.task is False
 
 
@@ -190,6 +192,7 @@ def test_build_field_selection_only_wrist() -> None:
 
     assert selection.wrist_image is True
     assert selection.overhead_image is False
+    assert selection.environment_state is False
     assert selection.task is False
 
 
@@ -1099,7 +1102,9 @@ def test_approve_episode_restores_record_controls_for_next_episode(fake_gradio) 
         "state": state,
         "dataset": dataset,
         "action_space": "joint_pos",
-        "field_selection": FieldSelection(wrist_image=False, overhead_image=False, task=False),
+        "field_selection": FieldSelection(
+            wrist_image=False, overhead_image=False, environment_state=False, task=False
+        ),
         "env_id": "CustomLookAtSO101-v1",
         "fps": 30,
     }

--- a/tests/core/test_teleop_dataset.py
+++ b/tests/core/test_teleop_dataset.py
@@ -12,8 +12,12 @@ import pytest
 
 from so101_nexus.config import SO101_JOINT_NAMES
 from so101_nexus.teleop.dataset import (
+    DONE_KEY,
+    ENV_STATE_KEY,
     OVERHEAD_KEY,
     REWARD_KEY,
+    SCALAR_FEATURE,
+    SUCCESS_KEY,
     WRIST_KEY,
     FieldSelection,
     build_features,
@@ -55,6 +59,8 @@ def test_build_features_default_contains_all_keys() -> None:
         "observation.state",
         "action",
         REWARD_KEY,
+        SUCCESS_KEY,
+        DONE_KEY,
         WRIST_KEY,
         OVERHEAD_KEY,
     }
@@ -102,6 +108,7 @@ def test_build_frame_default_includes_all_selected_fields() -> None:
     action = np.ones(6, dtype=np.float32)
     wrist = np.zeros((64, 64, 3), dtype=np.uint8)
     overhead = np.ones((64, 64, 3), dtype=np.uint8) * 255
+    env_state = np.array([1.0, 2.0, 3.0], dtype=np.float32)
 
     frame = build_frame(
         sel,
@@ -111,12 +118,16 @@ def test_build_frame_default_includes_all_selected_fields() -> None:
         reward=0.25,
         wrist_image=wrist,
         overhead_image=overhead,
+        env_state=env_state,
     )
 
     assert set(frame) == {
         "observation.state",
         "action",
         REWARD_KEY,
+        SUCCESS_KEY,
+        DONE_KEY,
+        ENV_STATE_KEY,
         WRIST_KEY,
         OVERHEAD_KEY,
         "task",
@@ -125,10 +136,13 @@ def test_build_frame_default_includes_all_selected_fields() -> None:
     assert frame[REWARD_KEY].dtype == np.float32
     assert frame[REWARD_KEY].shape == (1,)
     np.testing.assert_allclose(frame[REWARD_KEY], [0.25])
+    np.testing.assert_allclose(frame[ENV_STATE_KEY], [1.0, 2.0, 3.0])
 
 
 def test_build_frame_keeps_task_when_task_deselected_for_lerobot_v3() -> None:
-    sel = FieldSelection(wrist_image=False, overhead_image=False, task=False)
+    sel = FieldSelection(
+        wrist_image=False, overhead_image=False, environment_state=False, task=False
+    )
     state = np.zeros(6, dtype=np.float32)
     action = np.zeros(6, dtype=np.float32)
 
@@ -141,7 +155,7 @@ def test_build_frame_keeps_task_when_task_deselected_for_lerobot_v3() -> None:
         overhead_image=None,
     )
 
-    assert set(frame) == {"observation.state", "action", REWARD_KEY, "task"}
+    assert set(frame) == {"observation.state", "action", REWARD_KEY, SUCCESS_KEY, DONE_KEY, "task"}
     assert frame["task"] == "required by LeRobotDataset.add_frame"
     assert frame[REWARD_KEY].shape == (1,)
 
@@ -157,6 +171,144 @@ def test_build_frame_raises_when_selected_image_missing() -> None:
             wrist_image=None,
             overhead_image=None,
         )
+
+
+def test_field_selection_defaults_environment_state_on() -> None:
+    # The privileged channel is recorded by default; flipping this silently
+    # drops observation.environment_state from every dataset.
+    assert FieldSelection().environment_state is True
+
+
+def test_build_features_declares_env_state_when_selected_with_names() -> None:
+    sel = FieldSelection(wrist_image=False, overhead_image=False)
+    names = ["object_pose_0", "object_pose_1", "grasp_state_0"]
+    features = build_features(sel, _follower_features(), _motor_features(), env_state_names=names)
+
+    assert features[ENV_STATE_KEY] == {
+        "dtype": "float32",
+        "shape": (3,),
+        "names": names,
+    }
+    # success and done are always declared as the canonical scalar feature.
+    assert (
+        features[SUCCESS_KEY]
+        == SCALAR_FEATURE
+        == {
+            "dtype": "float32",
+            "shape": (1,),
+            "names": None,
+        }
+    )
+    assert features[DONE_KEY] == SCALAR_FEATURE
+
+
+@pytest.mark.parametrize(
+    "selection, env_state_names",
+    [
+        # selection on but no names -> env_state channel not declarable.
+        (FieldSelection(wrist_image=False, overhead_image=False), []),
+        # names present but selection off -> user opted out.
+        (
+            FieldSelection(wrist_image=False, overhead_image=False, environment_state=False),
+            ["object_pose_0"],
+        ),
+    ],
+)
+def test_build_features_omits_env_state(selection, env_state_names) -> None:
+    features = build_features(
+        selection,
+        _follower_features(),
+        _motor_features(),
+        env_state_names=env_state_names,
+    )
+
+    assert ENV_STATE_KEY not in features
+    # reward/success/done stay regardless of the env_state decision.
+    assert SUCCESS_KEY in features
+    assert DONE_KEY in features
+
+
+def test_build_frame_emits_success_and_done_as_float32_scalars() -> None:
+    sel = FieldSelection(wrist_image=False, overhead_image=False, environment_state=False)
+    frame = build_frame(
+        sel,
+        state=np.zeros(6, dtype=np.float32),
+        action=np.zeros(6, dtype=np.float32),
+        task="t",
+        success=1.0,
+        done=1.0,
+        wrist_image=None,
+        overhead_image=None,
+    )
+
+    for key in (SUCCESS_KEY, DONE_KEY):
+        assert frame[key].dtype == np.float32
+        assert frame[key].shape == (1,)
+    # Values propagate (not hardcoded).
+    np.testing.assert_array_equal(frame[SUCCESS_KEY], [1.0])
+    np.testing.assert_array_equal(frame[DONE_KEY], [1.0])
+
+
+def test_build_frame_success_and_done_default_to_zero() -> None:
+    sel = FieldSelection(wrist_image=False, overhead_image=False, environment_state=False)
+    frame = build_frame(
+        sel,
+        state=np.zeros(6, dtype=np.float32),
+        action=np.zeros(6, dtype=np.float32),
+        task="t",
+        wrist_image=None,
+        overhead_image=None,
+    )
+
+    np.testing.assert_array_equal(frame[SUCCESS_KEY], [0.0])
+    np.testing.assert_array_equal(frame[DONE_KEY], [0.0])
+
+
+def test_build_frame_writes_env_state_when_selected() -> None:
+    sel = FieldSelection(wrist_image=False, overhead_image=False, environment_state=True)
+    env_state = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+    frame = build_frame(
+        sel,
+        state=np.zeros(6, dtype=np.float32),
+        action=np.zeros(6, dtype=np.float32),
+        task="t",
+        env_state=env_state,
+        wrist_image=None,
+        overhead_image=None,
+    )
+
+    assert frame[ENV_STATE_KEY].dtype == np.float32
+    np.testing.assert_array_equal(frame[ENV_STATE_KEY], [1.0, 2.0, 3.0])
+
+
+def test_build_frame_raises_when_env_state_selected_but_missing() -> None:
+    sel = FieldSelection(wrist_image=False, overhead_image=False, environment_state=True)
+    with pytest.raises(ValueError, match="environment_state selected but no privileged state"):
+        build_frame(
+            sel,
+            state=np.zeros(6, dtype=np.float32),
+            action=np.zeros(6, dtype=np.float32),
+            task="t",
+            env_state=None,
+            wrist_image=None,
+            overhead_image=None,
+        )
+
+
+def test_build_frame_omits_env_state_when_deselected() -> None:
+    sel = FieldSelection(wrist_image=False, overhead_image=False, environment_state=False)
+    # env_state supplied but not selected -> key must be absent.
+    frame = build_frame(
+        sel,
+        state=np.zeros(6, dtype=np.float32),
+        action=np.zeros(6, dtype=np.float32),
+        task="t",
+        env_state=np.array([1.0, 2.0], dtype=np.float32),
+        wrist_image=None,
+        overhead_image=None,
+    )
+
+    assert ENV_STATE_KEY not in frame
 
 
 def _reload_dataset_module():

--- a/tests/core/test_teleop_dataset_compat.py
+++ b/tests/core/test_teleop_dataset_compat.py
@@ -29,6 +29,40 @@ class _FakeLeader:
         }
 
 
+def _record_episode(tmp_path, *, env_id: str, max_steps: int, robot_id: str):
+    """Drive the recording thread against *env_id* and return the populated state."""
+    from so101_nexus.config import SO101_JOINT_NAMES
+    from so101_nexus.teleop.recorder import RecordingState, recording_thread
+
+    state = RecordingState(num_episodes=1)
+    leader = _FakeLeader()
+    leader.connect()
+    thread = threading.Thread(
+        target=recording_thread,
+        kwargs={
+            "state": state,
+            "env_id": env_id,
+            "leader": leader,
+            "joint_names": SO101_JOINT_NAMES,
+            "fps": 30,
+            "max_steps": max_steps,
+            "countdown": 0,
+            "wrist_roll_offset_deg": -90.0,
+            "wrist_wh": (160, 120),
+            "overhead_wh": (160, 120),
+            "follower_calibration_dir": tmp_path / "cal",
+            "follower_robot_id": robot_id,
+        },
+        daemon=True,
+    )
+    thread.start()
+    thread.join(timeout=30)
+    assert not thread.is_alive()
+    assert state.error is None, state.error
+    assert len(state.episode_actions) == max_steps
+    return state
+
+
 @pytest.mark.slow
 def test_gradio_recording_reloads_as_lerobot_dataset(tmp_path) -> None:
     pytest.importorskip("mujoco")
@@ -38,6 +72,7 @@ def test_gradio_recording_reloads_as_lerobot_dataset(tmp_path) -> None:
     from lerobot.datasets.lerobot_dataset import LeRobotDataset
 
     from so101_nexus.config import SO101_JOINT_NAMES
+    from so101_nexus.observations import privileged_state_feature_names
     from so101_nexus.teleop.dataset import (
         OVERHEAD_KEY,
         REWARD_KEY,
@@ -47,41 +82,24 @@ def test_gradio_recording_reloads_as_lerobot_dataset(tmp_path) -> None:
         build_features,
         build_frame,
     )
-    from so101_nexus.teleop.recorder import RecordingState, recording_thread
+    from so101_nexus.teleop.session import resolve_recording_observations
 
-    state = RecordingState(num_episodes=1)
-    leader = _FakeLeader()
-    leader.connect()
-
-    thread = threading.Thread(
-        target=recording_thread,
-        kwargs={
-            "state": state,
-            "env_id": "MuJoCoTouch-v1",
-            "leader": leader,
-            "joint_names": SO101_JOINT_NAMES,
-            "fps": 30,
-            "max_steps": 5,
-            "countdown": 0,
-            "wrist_roll_offset_deg": -90.0,
-            "wrist_wh": (160, 120),
-            "overhead_wh": (160, 120),
-            "follower_calibration_dir": tmp_path / "cal",
-            "follower_robot_id": "teleop_sim_smoke",
-        },
-        daemon=True,
+    state = _record_episode(
+        tmp_path, env_id="MuJoCoTouch-v1", max_steps=5, robot_id="teleop_sim_smoke"
     )
-    thread.start()
-    thread.join(timeout=30)
-
-    assert not thread.is_alive()
-    assert state.error is None, state.error
-    assert len(state.episode_actions) == 5
 
     selection = FieldSelection()
     action_features = {f"{name}.pos": float for name in SO101_JOINT_NAMES}
     follower_features = {**action_features, "wrist": (120, 160, 3), "overhead": (120, 160, 3)}
-    features = build_features(selection, follower_features, action_features)
+    # FieldSelection() defaults environment_state=True, so the privileged low-dim
+    # state must be declared (via names resolved from the SAME recording config the
+    # follower ran) and supplied to every frame; otherwise build_frame raises.
+    env_state_names = privileged_state_feature_names(
+        resolve_recording_observations("MuJoCoTouch-v1", (160, 120), (160, 120))
+    )
+    features = build_features(
+        selection, follower_features, action_features, env_state_names=env_state_names
+    )
 
     dataset_root = tmp_path / "dataset"
     dataset = _make_reward_scalar_dataset_cls().create(
@@ -101,6 +119,7 @@ def test_gradio_recording_reloads_as_lerobot_dataset(tmp_path) -> None:
             action=state.episode_actions[i],
             task="reach the target",
             reward=reward,
+            env_state=state.episode_env_states[i],
             wrist_image=state.episode_wrist_images[i],
             overhead_image=state.episode_overhead_images[i],
         )
@@ -144,3 +163,122 @@ def test_gradio_recording_reloads_as_lerobot_dataset(tmp_path) -> None:
     reward_min = float(np.asarray(reward_stats["min"]).reshape(-1)[0])
     reward_max = float(np.asarray(reward_stats["max"]).reshape(-1)[0])
     assert reward_min <= float(sample[REWARD_KEY]) <= reward_max
+
+
+@pytest.mark.slow
+def test_camera_free_recording_reloads_env_state_success_done(tmp_path) -> None:
+    pytest.importorskip("mujoco")
+    pytest.importorskip("so101_nexus.mujoco")
+
+    from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+    from so101_nexus.config import SO101_JOINT_NAMES
+    from so101_nexus.observations import privileged_state_feature_names
+    from so101_nexus.teleop.dataset import (
+        DONE_KEY,
+        ENV_STATE_KEY,
+        SUCCESS_KEY,
+        FieldSelection,
+        _make_reward_scalar_dataset_cls,
+        build_features,
+        build_frame,
+    )
+    from so101_nexus.teleop.session import resolve_recording_observations
+
+    env_id = "MuJoCoPickLift-v1"
+    max_steps = 6
+    state = _record_episode(
+        tmp_path, env_id=env_id, max_steps=max_steps, robot_id="teleop_envstate_smoke"
+    )
+    # The privileged low-dim state, success, and done are recorded once per step,
+    # aligned with the action buffer.
+    assert len(state.episode_env_states) == max_steps
+    assert len(state.episode_successes) == max_steps
+    assert len(state.episode_dones) == max_steps
+
+    # Camera-free selection: no wrist/overhead video, so `finalize` never invokes
+    # ffmpeg. This isolates the env_state/success/done channels from video encoding
+    # (which can hang in some environments), while still exercising the real
+    # LeRobot write + reload path via `_make_reward_scalar_dataset_cls`.
+    selection = FieldSelection(
+        wrist_image=False,
+        overhead_image=False,
+        environment_state=True,
+        task=True,
+    )
+    action_features = {f"{name}.pos": float for name in SO101_JOINT_NAMES}
+    env_state_names = privileged_state_feature_names(
+        resolve_recording_observations(env_id, (160, 120), (160, 120))
+    )
+    assert env_state_names, "PickLift env must expose privileged state names"
+    assert env_state_names[0] == "end_effector_pose_0"
+    n = len(env_state_names)
+
+    # No cameras selected, so the follower features reduce to the joint floats,
+    # yielding observation.state + action + the always-on scalar channels.
+    features = build_features(
+        selection, action_features, action_features, env_state_names=env_state_names
+    )
+
+    dataset_root = tmp_path / "dataset"
+    dataset = _make_reward_scalar_dataset_cls().create(
+        repo_id="local/teleop-envstate",
+        fps=30,
+        features=features,
+        robot_type="sim_so_follower",
+        root=dataset_root,
+        use_videos=False,
+    )
+
+    for i in range(len(state.episode_actions)):
+        reward = state.episode_rewards[i] if i < len(state.episode_rewards) else 0.0
+        frame = build_frame(
+            selection,
+            state=state.episode_states[i],
+            action=state.episode_actions[i],
+            task="pick and lift the object",
+            reward=reward,
+            success=state.episode_successes[i],
+            done=state.episode_dones[i],
+            env_state=state.episode_env_states[i],
+            wrist_image=None,
+            overhead_image=None,
+        )
+        dataset.add_frame(frame)
+    dataset.save_episode()
+    dataset.finalize()
+
+    reloaded = LeRobotDataset("local/teleop-envstate", root=dataset_root)
+
+    # Privileged state reloads as a self-describing (n,) float32 vector, with the
+    # per-dimension names carried through from privileged_state_feature_names.
+    assert reloaded.features[ENV_STATE_KEY]["shape"] == (n,)
+    assert reloaded.features[ENV_STATE_KEY]["dtype"] == "float32"
+    assert reloaded.features[ENV_STATE_KEY]["names"][0] == "end_effector_pose_0"
+    # success/done are always-on scalar env-step channels, declared like reward.
+    for key in (SUCCESS_KEY, DONE_KEY):
+        assert reloaded.features[key]["shape"] == (1,)
+        assert reloaded.features[key]["dtype"] == "float32"
+
+    assert len(reloaded) == max_steps
+
+    sample = reloaded[0]
+    # env_state reloads as an (n,) vector holding the exact recorded frame-0 state.
+    assert sample[ENV_STATE_KEY].shape == (n,)
+    np.testing.assert_allclose(
+        sample[ENV_STATE_KEY].numpy(),
+        state.episode_env_states[0],
+        rtol=1e-5,
+        atol=1e-6,
+    )
+    # Like reward, the (1,) success/done features map to scalar HF Values, so they
+    # read back as 0-d tensors (one per frame), not (1,) vectors.
+    assert sample[SUCCESS_KEY].dim() == 0
+    assert sample[DONE_KEY].dim() == 0
+    assert float(sample[SUCCESS_KEY]) == pytest.approx(state.episode_successes[0])
+    assert float(sample[DONE_KEY]) == pytest.approx(state.episode_dones[0])
+
+    # LeRobot's automatic per-feature stats aggregation covers every recorded
+    # channel, so normalization bounds exist downstream for the new channels too.
+    for key in (ENV_STATE_KEY, SUCCESS_KEY, DONE_KEY):
+        assert key in reloaded.meta.stats

--- a/tests/core/test_teleop_recorder.py
+++ b/tests/core/test_teleop_recorder.py
@@ -15,6 +15,7 @@ from so101_nexus.config import SO101_JOINT_NAMES
 from so101_nexus.teleop.recorder import (
     RecordingState,
     TeeStream,
+    _append_step_buffers,
     _publish_camera_frames,
     compute_delta_actions,
     recording_thread,
@@ -315,3 +316,101 @@ def test_recording_thread_records_error_on_leader_failure(tmp_path) -> None:
     assert state.recording_finished
     assert state.error is not None
     assert "simulated leader read failure" in state.error
+
+
+def _motor_obs(value: float = 0.0) -> dict[str, object]:
+    return {f"{name}.pos": value for name in SO101_JOINT_NAMES}
+
+
+def _step_info(*, terminated=False, truncated=False, info=None, reward=0.0):
+    return types.SimpleNamespace(
+        terminated=terminated,
+        truncated=truncated,
+        info={} if info is None else info,
+        reward=reward,
+    )
+
+
+def test_append_step_buffers_non_terminal_step_records_zero_success_and_done() -> None:
+    state = RecordingState()
+
+    _append_step_buffers(
+        state,
+        _motor_obs(1.0),
+        _motor_obs(2.0),
+        _step_info(terminated=False, truncated=False, info={}, reward=0.5),
+        SO101_JOINT_NAMES,
+    )
+
+    assert state.episode_rewards == [0.5]
+    assert state.episode_successes == [0.0]
+    assert state.episode_dones == [0.0]
+
+
+def test_append_step_buffers_terminal_success_records_success_and_done() -> None:
+    state = RecordingState()
+
+    _append_step_buffers(
+        state,
+        _motor_obs(1.0),
+        _motor_obs(2.0),
+        _step_info(terminated=True, info={"success": True}, reward=1.0),
+        SO101_JOINT_NAMES,
+    )
+
+    assert state.episode_successes == [1.0]
+    assert state.episode_dones == [1.0]
+
+
+def test_append_step_buffers_truncated_step_records_done_without_success() -> None:
+    state = RecordingState()
+
+    _append_step_buffers(
+        state,
+        _motor_obs(1.0),
+        _motor_obs(2.0),
+        _step_info(terminated=False, truncated=True, info={}),
+        SO101_JOINT_NAMES,
+    )
+
+    assert state.episode_successes == [0.0]
+    assert state.episode_dones == [1.0]
+
+
+def test_append_step_buffers_appends_env_state_from_obs() -> None:
+    state = RecordingState()
+    obs = _motor_obs(2.0)
+    obs["environment_state"] = np.arange(18, dtype=np.float64)
+
+    _append_step_buffers(
+        state,
+        _motor_obs(1.0),
+        obs,
+        _step_info(),
+        SO101_JOINT_NAMES,
+    )
+
+    assert len(state.episode_env_states) == 1
+    stored = state.episode_env_states[0]
+    assert stored.dtype == np.float32
+    assert stored.shape == (18,)
+    np.testing.assert_array_equal(stored, np.arange(18, dtype=np.float32))
+
+
+def test_append_step_buffers_pre_first_step_defaults_and_skips_env_state() -> None:
+    state = RecordingState()
+
+    # step_info is None before the first env.step (seed frame); obs has no
+    # environment_state key, so no privileged vector is buffered.
+    _append_step_buffers(
+        state,
+        _motor_obs(1.0),
+        _motor_obs(1.0),
+        None,
+        SO101_JOINT_NAMES,
+    )
+
+    assert state.episode_rewards == [0.0]
+    assert state.episode_successes == [0.0]
+    assert state.episode_dones == [0.0]
+    assert state.episode_env_states == []

--- a/uv.lock
+++ b/uv.lock
@@ -3405,7 +3405,7 @@ wheels = [
 
 [[package]]
 name = "so101-nexus"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "." }
 dependencies = [
     { name = "gymnasium" },


### PR DESCRIPTION
Close three audit gaps in teleop and rollout dataset recording.

Teleop datasets could not contain object pose, TCP pose, grasp state, or TCP->object offset: the follower only surfaced joints and camera frames. The env already computes the full privileged vector, so surface it through the standard observation pipeline and persist it as a self-describing observation.environment_state channel, on by default.

Teleop and rollout recordings also discarded the per-step success boolean and had no done signal. Persist both as first-class scalar float32 channels alongside reward, so learners no longer reverse-engineer a reward bump.

- observations: privileged_state_feature_names for per-dim schema names
- normalization: read_privileged_state reads the env's non-camera state
- sim_follower: get_observation emits environment_state when available
- dataset: FieldSelection.environment_state default on; build_features and build_frame declare/write environment_state, success, done; squeeze all scalar channels on save
- recorder: RecordingState buffers env_state/success/done; success from info["success"], done from terminated or truncated
- session: resolve_recording_observations matches schema to runtime vector
- app: init worker resolves env-state names (drops channel when the task has none), wires the field-selection checkbox and approve path
- policy_adapters: RolloutRecorder writes success/done per frame

Bump version to 0.4.6.