### PR TITLE
docs: align docs with codebase and add consistency regression tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ for the public-API and deprecation policy.
 ### Fixed
 
 - Pick-and-place reward no longer collapses when the grasp is released to complete the task. Placement progress is now credited while grasped or once the object is set on the goal disc (both backends), so finishing the task is no longer scored below hovering the grasped object above the disc.
+- Documentation consistency sweep (docs vs code): corrected `examples/README.md` PPO entropy defaults and PickLift results to match `ppo_warp.py` and `training/ppo`; removed two non-existent symbols (`SO_ARM100_DIR`, `get_so100_simulation_dir`) from the API overview; fixed the five `configs.mdx` default-observation lists (added `JointPositions()`, corrected dimensions); dropped a dead `agent.robot.get_qpos()` reference and documented the `observation.environment_state`, `success`, and `done` dataset fields plus the `Max Steps` and `Success Hold` teleop controls; documented `RobotCameraPreset` (in `configs.mdx`) and the reward/observation helper functions (in the API overview).
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,8 +69,9 @@ meaningful step. Use standard git commits; never commit via credential tokens.
 - Update tests and documentation alongside code.
 - Add a `## [Unreleased]` entry to [CHANGELOG.md](CHANGELOG.md) for any user-facing
   change.
-- Continuous integration runs lint, tests (Python 3.12 and 3.13, Linux and macOS),
-  the Warp backend tests, and the documentation build. All must pass.
+- Continuous integration runs lint, tests (Python 3.12 and 3.13 on Linux;
+  Python 3.12 MuJoCo backend and docs-consistency smoke tests on macOS), the
+  Warp backend tests, and the documentation build. All must pass.
 
 ## Release process
 

--- a/docs/content/docs/api/configs.mdx
+++ b/docs/content/docs/api/configs.mdx
@@ -94,18 +94,38 @@ robot = RobotConfig(rest_qpos_deg=(0.0, -90.0, 90.0, 37.82, 0.0, -63.03))
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `rest_qpos_deg` | `tuple[float, ...]` | `(0.0, -90.0, 90.0, 37.82, 0.0, -63.03)` | Rest joint positions in degrees, one per joint |
+| `rest_qpos_deg` | `tuple[float, ...]` | `(0.0, -90.0, 90.0, 37.8152144786, 0.0, -63.0253574644)` | Rest joint positions in degrees, one per joint |
 | `init_pose` | `str \| Pose \| None` | `None` | Initial pose for resets. String looks up from `POSES`, `Pose` instance used directly, `None` uses legacy rest + noise. |
 | `grasp_force_threshold` | `float` | `0.5` | Minimum contact force to count as a grasp |
 | `static_vel_threshold` | `float` | `0.2` | Maximum velocity to consider the arm stationary |
 
-### Properties
+### Properties and methods
 
 | Property | Type | Description |
 |----------|------|-------------|
 | `rest_qpos_rad` | `tuple[float, ...]` | `rest_qpos_deg` converted to radians |
 | `rest_qpos` | `tuple[float, ...]` | Alias for `rest_qpos_rad` |
 | `resolve_pose()` | `Pose \| None` | Returns the resolved `Pose` object, or `None` |
+
+---
+## RobotCameraPreset
+
+Robot-specific camera and mounting parameters for SO-100 and SO-101. All fields
+are required (no defaults); `wrist_cam_euler_center_rad` and `wrist_cam_euler_noise_rad`
+expose the Euler angles in radians.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `base_quat` | `tuple[float, float, float, float]` | Base orientation quaternion (w, x, y, z) |
+| `sensor_cam_eye_pos` | `tuple[float, float, float]` | Sensor camera eye position |
+| `sensor_cam_target_pos` | `tuple[float, float, float]` | Sensor camera target position |
+| `human_cam_eye_pos` | `tuple[float, float, float]` | Human camera eye position |
+| `human_cam_target_pos` | `tuple[float, float, float]` | Human camera target position |
+| `wrist_camera_mount_link` | `str` | Link name for wrist camera mounting |
+| `wrist_cam_pos_center` | `tuple[float, float, float]` | Center position for the wrist camera |
+| `wrist_cam_pos_noise` | `tuple[float, float, float]` | Position noise applied to the wrist camera |
+| `wrist_cam_euler_center_deg` | `tuple[float, float, float]` | Center wrist camera Euler angles in degrees |
+| `wrist_cam_euler_noise_deg` | `tuple[float, float, float]` | Euler angle noise applied to the wrist camera |
 
 ---
 
@@ -304,7 +324,7 @@ These are in addition to all `EnvironmentConfig` parameters.
 
 ### Default Observations
 
-When `observations` is not specified: `[EndEffectorPose(), GraspState(), ObjectPose(), ObjectOffset()]` (18 dimensions).
+When `observations` is not specified: `[JointPositions(), EndEffectorPose(), GraspState(), ObjectPose(), ObjectOffset()]` (24 dimensions).
 
 ---
 
@@ -341,7 +361,7 @@ These are in addition to all `EnvironmentConfig` parameters.
 
 ### Default Observations
 
-When `observations` is not specified: `[EndEffectorPose(), GraspState(), TargetPosition(), ObjectPose(), ObjectOffset(), TargetOffset()]` (24 dimensions).
+When `observations` is not specified: `[JointPositions(), EndEffectorPose(), GraspState(), TargetPosition(), ObjectPose(), ObjectOffset(), TargetOffset()]` (30 dimensions).
 
 ---
 
@@ -365,7 +385,7 @@ This is in addition to all `PickConfig` object-pool parameters (`objects`, `n_di
 
 ### Default Observations
 
-When `observations` is not specified: `[EndEffectorPose(), GraspState(), ObjectPose(), ObjectOffset()]` (18 dimensions).
+When `observations` is not specified: `[JointPositions(), EndEffectorPose(), GraspState(), ObjectPose(), ObjectOffset()]` (24 dimensions).
 
 ---
 
@@ -393,7 +413,7 @@ The `MuJoCoLookAt-v1` and `WarpLookAt-v1` registrations default `max_episode_ste
 
 ### Default Observations
 
-When `observations` is not specified: `[JointPositions()]` (6 dimensions).
+When `observations` is not specified: `[JointPositions(), EndEffectorPose(), GazeDirection()]` (16 dimensions).
 
 ---
 
@@ -419,4 +439,4 @@ The `MuJoCoMove-v1` and `WarpMove-v1` registrations default `max_episode_steps` 
 
 ### Default Observations
 
-When `observations` is not specified: `[JointPositions()]` (6 dimensions).
+When `observations` is not specified: `[JointPositions(), EndEffectorPose(), TargetOffset()]` (16 dimensions).

--- a/docs/content/docs/api/core-overview.mdx
+++ b/docs/content/docs/api/core-overview.mdx
@@ -34,7 +34,6 @@ import so101_nexus
 | `YCB_OBJECTS` | `dict[str, str]` | Maps YCB model IDs to human-readable names |
 | `ROBOT_CAMERA_PRESETS` | `dict[str, RobotCameraPreset]` | Named camera mounting presets for SO-100 and SO-101 |
 | `ASSETS_DIR` | `Path` | Root directory for bundled assets |
-| `SO_ARM100_DIR` | `Path` | Asset directory for the SO-100 arm |
 | `SO101_DIR` | `Path` | Asset directory for the SO-101 arm (URDF/XML retained for teleop calibration; the MuJoCo backend loads the menagerie MJCF) |
 
 ### Configuration Classes
@@ -71,6 +70,7 @@ See [Observations](/docs/concepts/observations-and-camera-modes) for conceptual 
 | `TargetPosition` | State (3-dim) | Absolute goal position |
 | `WristCamera` | Camera | RGB image from wrist-mounted camera |
 | `OverheadCamera` | Camera | RGB image from stationary overhead camera |
+| `CameraObservation` | Camera (abstract) | Base class for camera observation components (`WristCamera`, `OverheadCamera`) |
 
 ### Scene Objects
 
@@ -91,6 +91,15 @@ See [Scene Objects](/docs/api/objects) for full reference.
 |----------|-----------|-------------|
 | `sample_color` | `(colors: ColorConfig, rng: Generator \| None = None) -> list[float]` | Resolve a ColorConfig to an RGBA list, sampling uniformly if given a list of colors |
 
+#### Reward and observation helpers
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `privileged_state_feature_names` | `(observations: Sequence[Observation] | None) -> list[str]` | Per-dimension names for the non-camera state observation vector |
+| `reach_progress` | `(distance, *, scale) -> float \| ndarray \| tensor` | Tanh-shaped progress in [0, 1]: 1 at distance 0, decaying toward 0 |
+| `orientation_progress` | `(cos_similarity) -> float \| ndarray \| tensor` | Maps cosine similarity in [-1, 1] to a reward in [0, 1] |
+| `lift_progress` | `(height, *, scale, grasped) -> float \| ndarray \| tensor` | Tanh-shaped lift progress in [0, 1], zero unless grasped |
+| `simple_reward` | `(*, progress, completion_bonus, success) -> float \| ndarray \| tensor` | Single-objective task reward; shaping fills [0, 1 - completion_bonus] via `progress` |
 #### Asset Paths
 
 | Function | Returns | Description |
@@ -98,7 +107,6 @@ See [Scene Objects](/docs/api/objects) for full reference.
 | `get_so101_simulation_dir()` | `Path` | Path to SO-101 `SO101/` assets (URDF/XML, retained for teleop calibration) |
 | `get_so101_mujoco_model_dir()` | `Path` | Directory of the vendored menagerie MJCF (loaded by the MuJoCo backend) |
 | `get_so101_mujoco_model_path()` | `Path` | Path to the menagerie `so101.xml` (loaded by the MuJoCo backend) |
-| `get_so100_simulation_dir()` | `Path` | Path to SO-100 simulation assets |
 
 #### YCB Asset Management
 

--- a/docs/content/docs/environments/index.mdx
+++ b/docs/content/docs/environments/index.mdx
@@ -30,7 +30,7 @@ env = gym.make("MuJoCoPickLift-v1")
 
 ## Train a policy in Colab
 
-Every task has a GPU-parallel Warp counterpart (`Warp*-v1`) you can train with PPO end to end in the browser, no local setup:
+Every task has a GPU-parallel Warp counterpart (`Warp*-v1`); PickLift, Touch, LookAt, and Move have solved PPO baselines you can reproduce in Colab (PickAndPlace's Warp baseline is pending a task fix, see [Training with PPO](/docs/training/ppo)).
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/johnsutor/so101-nexus/blob/main/examples/ppo_warp_colab.ipynb)
 

--- a/docs/content/docs/environments/mujoco-move.mdx
+++ b/docs/content/docs/environments/mujoco-move.mdx
@@ -23,7 +23,7 @@ Move the robot's end-effector in a cardinal direction by a fixed distance.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `direction` | `Literal["up", "down", "left", "right", "forward", "backward"]` | -- | Direction of movement |
+| `direction` | `Literal["up", "down", "left", "right", "forward", "backward"]` | "up" | Direction of movement |
 | `target_distance` | `float` | 0.10 | Distance to move in meters |
 | `success_threshold` | `float` | 0.01 | Shortfall tolerance (m) on the directional displacement. |
 

--- a/docs/content/docs/environments/mujoco-pick-and-place.mdx
+++ b/docs/content/docs/environments/mujoco-pick-and-place.mdx
@@ -15,7 +15,7 @@ Pick up a colored cube and place it on a target disc.
 | Backend | MuJoCo |
 | Max episode steps | 1024 |
 | Config class | `PickAndPlaceConfig` |
-| Task description | "Pick up the small \{cube_color\} cube and place it on the \{target_color\} circle." |
+| Task description | "Pick up the \{cube_color\} cube and place it on the \{target_color\} circle." |
 
 ## Demo Rollout
 

--- a/docs/content/docs/teleoperation/overview.mdx
+++ b/docs/content/docs/teleoperation/overview.mdx
@@ -99,12 +99,15 @@ fields are persisted:
 - `action` always saved (disabled checkbox)
 - `task` always saved by LeRobot v3 metadata
 - `reward` always saved from the same environment step as the frame's action
+- `success` always saved (episode success flag)
+- `done` always saved (episode termination flag)
+- `observation.environment_state` optional, on by default (privileged low-dim state: TCP/object pose, grasp, and offsets)
 - `observation.images.wrist` optional, on by default
 - `observation.images.overhead` optional, on by default
 
 Deselecting an optional field removes it from both the declared dataset
-feature schema and every recorded frame. `observation.state`, `action`, `reward`, and
-`task` stay forced on because LeRobot datasets require them for policy
+feature schema and every recorded frame. `observation.state`, `action`, `reward`,
+`success`, `done`, and `task` stay forced on because LeRobot datasets require them for policy
 training and task indexing.
 
 ### Camera resolution
@@ -135,6 +138,8 @@ The **Advanced Settings** section exposes common options:
   teleop observation and recorded frame. The default is 5.
 - `Pick-and-Place Cube Colors` and `Pick-and-Place Target Colors`:
   sampled cube/target colors for pick-and-place tasks
+- `Max Steps`: overrides the episode's step cap (default 1024)
+- `Success Hold (s)`: seconds to keep recording after the env reports success before auto-stopping (default 0.5 s, 0 = stop immediately)
 
 Options that do not apply to the selected environment are ignored after
 customization is enabled. For example, pick-object settings apply to
@@ -247,15 +252,16 @@ uv run so101-nexus teleop \
 ```
 
 Custom environments should accept SO-100/SO-101 six-joint actions in the
-standard joint order, expose current qpos through `_get_current_qpos()` or
-`agent.robot.get_qpos()`, and return camera observations compatible with the
-selected recording fields. If the unwrapped environment exposes
-`task_description`, teleop records it as the required LeRobot `task` field.
+standard joint order, expose current qpos through `_get_current_qpos()`, and
+return camera observations compatible with the selected recording fields.
+If the unwrapped environment exposes `task_description`, teleop records it
+as the required LeRobot `task` field.
 
 ## Session flow
 
 1. **Configure.** Pick the env, robot type, episode count, FPS, camera
-   resolutions, action space, countdown, and dataset fields. A leader-port
+   resolutions, action space, countdown, dataset fields, Max Steps, and
+   Success Hold. A leader-port
    status banner reports up front whether the configured serial port is
    reachable, with a `Recheck Port` button to refresh after fixing it.
 2. **Initialize.** The app connects to the leader arm and creates the
@@ -278,8 +284,11 @@ frames include:
 - `observation.state`: follower readback (6D), always present
 - `action`: commanded absolute joint positions (6D) by default, always present
 - `reward`: scalar transition reward from the same environment step as `action`, always present
+- `success`: episode success flag, always present
+- `done`: episode termination flag, always present
 - `observation.images.wrist`: wrist camera frames, optional
 - `observation.images.overhead`: overhead camera frames, optional
+- `observation.environment_state`: privileged low-dim state (TCP/object pose, grasp, and offsets), optional
 - `task`: language description, always present
 
 Body joints are stored in LeRobot degree units and the gripper is stored in

--- a/examples/README.md
+++ b/examples/README.md
@@ -109,8 +109,8 @@ Common settings for the solved Warp baselines:
 | `--num-minibatches` | `32` |
 | `--update-epochs` | `10` |
 | `--clip-coef` | `0.2` |
-| `--ent-coef` | `0.005` |
-| `--ent-coef-final` | `0.0` |
+| `--ent-coef` | `0.03` |
+| `--ent-coef-final` | `0.005` |
 | `--vf-coef` | `0.5` |
 | `--max-grad-norm` | `0.5` |
 | `--target-kl` | `None` |
@@ -147,8 +147,8 @@ uv run --extra warp --extra train python examples/ppo_warp.py \
   --total-timesteps 30000000 \
   --num-minibatches 32 \
   --update-epochs 10 \
-  --ent-coef 0.005 \
-  --ent-coef-final 0.0 \
+  --ent-coef 0.03 \
+  --ent-coef-final 0.005 \
   --max-grad-norm 0.5 \
   --target-kl None
 ```
@@ -157,14 +157,13 @@ uv run --extra warp --extra train python examples/ppo_warp.py \
 
 Success rate is the recent completed-episode success rate reported by the Warp
 training rollout at the listed step budget. PickLift reports seed-validated results
-from seeds 1, 2, and 3.
-
+from seeds 1, 2, 3, 4, and 5 (4 of 5 solved).
 | env_id | steps | success rate | wall-clock |
 |---|---:|---:|---:|
 | `WarpTouch-v1` | 5.0M | 1.000 | 88 s |
 | `WarpLookAt-v1` | 5.0M | 1.000 | 62 s |
 | `WarpMove-v1` | 5.0M | 1.000 | 60 s |
-| `WarpPickLift-v1` | 30.0M | 0.905 min, 0.952 mean, 0.993 max final | 24.5 min/run |
+| `WarpPickLift-v1` | 30.0M | 0.965 min, 0.973 mean, 0.985 max final | 24.5 min/run |
 | `WarpPickAndPlace-v1` | pending | pending | pending |
 
 `WarpPickAndPlace-v1` is intentionally excluded for now; the environment needs task

--- a/tests/test_docs_consistency.py
+++ b/tests/test_docs_consistency.py
@@ -89,3 +89,121 @@ def test_max_episode_steps_documented_as_make_kwarg_not_config_field() -> None:
         "max_episode_steps must be documented as a gym.make/make_vec keyword, "
         f"never as a config field: {offenders}"
     )
+
+
+def test_core_overview_lists_only_real_public_symbols() -> None:
+    """Every symbol in core-overview.mdx tables must be a real package export.
+
+    Guards against dead references (e.g. a symbol copied from a sibling
+    project) by checking each documented table's first-column identifier
+    against the package ``__all__``. Submodule-only functions (the Environment
+    Registry section) are excluded on purpose.
+    """
+    init_src = _read(ROOT / "src" / "so101_nexus" / "__init__.py")
+    match = re.search(r"__all__\s*=\s*\[(.*?)\]", init_src, re.DOTALL)
+    assert match, "could not locate __all__ in so101_nexus/__init__.py"
+    public = set(re.findall(r'"([A-Za-z_][A-Za-z0-9_]*)"', match.group(1)))
+    assert public, "parsed empty __all__"
+
+    allowed_sections = {
+        "Constants",
+        "Asset Paths",
+        "Color",
+        "YCB Asset Management",
+        "Reward and observation helpers",
+        "Observation Components",
+        "Scene Objects",
+        "Configuration Classes",
+        "Type Aliases",
+    }
+    text = _read(DOCS / "api" / "core-overview.mdx")
+    missing: list[str] = []
+    section: str | None = None
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("### "):
+            section = stripped[4:].strip()
+            continue
+        if stripped.startswith("#### "):
+            section = stripped[5:].strip()
+            continue
+        if section not in allowed_sections or not stripped.startswith("|"):
+            continue
+        if set(stripped) <= {"|", "-", ":", " "}:
+            continue
+        cells = [c.strip() for c in stripped.strip("|").split("|")]
+        if not cells:
+            continue
+        name = cells[0].strip("`")
+        name = re.sub(r"\(.*\)$", "", name)
+        if name.lower() in {
+            "name",
+            "class",
+            "type",
+            "definition",
+            "function",
+            "property",
+            "method",
+            "argument",
+            "parameter",
+            "env_id",
+            "returns",
+            "signature",
+            "description",
+        }:
+            continue
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
+            continue
+        if name not in public:
+            missing.append(name)
+    assert missing == [], f"core-overview.mdx references non-exported symbols: {missing}"
+
+
+def test_docs_reference_only_registered_env_ids() -> None:
+    """Every ``MuJoCo*``/``Warp*`` env id in docs must be a registered id."""
+    registered: set[str] = set()
+    for backend in ("mujoco", "warp"):
+        src = _read(ROOT / "src" / "so101_nexus" / backend / "__init__.py")
+        registered.update(re.findall(r'id="([^"]+)"', src))
+    assert registered, "could not parse any registered env ids from backend modules"
+
+    offenders: list[tuple[str, str]] = []
+    docs = set(DOCS.rglob("*.mdx")) | {ROOT / "README.md", ROOT / "examples" / "README.md"}
+    pattern = re.compile(r"\b(?:MuJoCo|Warp)[A-Za-z]*-v\d+\b")
+    for path in docs:
+        for found in pattern.finditer(_read(path)):
+            if found.group(0) not in registered:
+                offenders.append((str(path.relative_to(ROOT)), found.group(0)))
+    assert offenders == [], f"docs reference unregistered env ids: {offenders}"
+
+
+def test_examples_readme_entropy_matches_ppo_warp_defaults() -> None:
+    """examples/README.md entropy flags must match ``ppo_warp.py`` Args defaults."""
+    ppo = _read(ROOT / "examples" / "ppo_warp.py")
+    ent_coef = re.search(r"ent_coef:\s*float\s*=\s*([\d.]+)", ppo)
+    ent_coef_final = re.search(r"ent_coef_final:\s*float\s*=\s*([\d.]+)", ppo)
+    assert ent_coef, "could not parse ppo_warp.py entropy default ent_coef"
+    assert ent_coef_final, "could not parse ppo_warp.py entropy default ent_coef_final"
+
+    readme = _read(ROOT / "examples" / "README.md")
+    table_ent = re.search(r"`--ent-coef`\s*\|\s*`([\d.]+)`", readme)
+    table_final = re.search(r"`--ent-coef-final`\s*\|\s*`([\d.]+)`", readme)
+    assert table_ent, "could not parse examples/README.md --ent-coef table row"
+    assert table_final, "could not parse examples/README.md --ent-coef-final table row"
+    assert table_ent.group(1) == ent_coef.group(1), (
+        f"--ent-coef {table_ent.group(1)} != ppo_warp.py default {ent_coef.group(1)}"
+    )
+    assert table_final.group(1) == ent_coef_final.group(1), (
+        f"--ent-coef-final {table_final.group(1)} != ppo_warp.py default {ent_coef_final.group(1)}"
+    )
+    # The "Starting commands" bash block repeats the same flags; guard it too.
+    bash_ent = re.findall(r"--ent-coef ([\d.]+)", readme)
+    bash_final = re.findall(r"--ent-coef-final ([\d.]+)", readme)
+    assert bash_ent, "could not parse examples/README.md --ent-coef command flag"
+    assert bash_final, "could not parse examples/README.md --ent-coef-final command flag"
+    assert all(b == ent_coef.group(1) for b in bash_ent), (
+        f"--ent-coef command {bash_ent} != ppo_warp.py default {ent_coef.group(1)}"
+    )
+    assert all(b == ent_coef_final.group(1) for b in bash_final), (
+        f"--ent-coef-final command {bash_final} != ppo_warp.py default {ent_coef_final.group(1)}"
+    )


### PR DESCRIPTION
Fix doc-vs-code drift across the user-facing docs and add guardrail tests.

Blocking fixes (would mislead users into broken code):
- examples/README.md: entropy defaults corrected to ppo_warp.py values (0.03/0.005, was 0.005/0.0) and PickLift results aligned to training/ppo
- api/core-overview.mdx: removed non-existent symbols SO_ARM100_DIR and get_so100_simulation_dir (AttributeError on access)
- api/configs.mdx: fixed all five default-observation lists (added JointPositions, corrected dimensions)
- environments/mujoco-pick-and-place.mdx: dropped phantom 'small' in the task-description template
- teleoperation/overview.mdx: removed dead agent.robot.get_qpos() reference (only _get_current_qpos is supported)

Minor fixes:
- mujoco-move.mdx: direction default '--' to 'up'
- environments/index.mdx: overstated Warp-PPO trainability for PickAndPlace
- CONTRIBUTING.md: CI matrix wording (macOS runs 3.12 MuJoCo + docs smoke)
- configs.mdx: rest_qpos_deg full precision, resolve_pose under Properties and methods, added RobotCameraPreset section
- core-overview.mdx: added CameraObservation, reward/observation helpers

New regression tests:
- core-overview symbols must be in __all__
- doc env IDs must be registered (parsed from backend source)
- examples/README entropy must match ppo_warp.py defaults (table + bash)