### PR TITLE
feat(readme): add Discord badge and fix Colab stale-wheel install

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
     <a href="https://github.com/johnsutor/so101-nexus/actions"><img alt="Tests" src="https://img.shields.io/github/actions/workflow/status/johnsutor/so101-nexus/ci.yml?label=tests"></a>
     <a href="https://github.com/johnsutor/so101-nexus/releases"><img alt="GitHub release" src="https://img.shields.io/github/release/johnsutor/so101-nexus.svg"></a>
     <a href="https://colab.research.google.com/github/johnsutor/so101-nexus/blob/main/examples/bc_ppo_warp_colab.ipynb"><img alt="Open In Colab" src="https://colab.research.google.com/assets/colab-badge.svg"></a>
+    <a href="https://discord.gg/37kKRXDh8"><img alt="Discord" src="https://img.shields.io/badge/Discord-Join_Us-5865F2?style=flat&logo=discord&logoColor=white"></a>
 </p>
 
 > **Beta**: APIs may change between releases. Feedback and bug reports are welcome.

--- a/docs/app/docs/layout.tsx
+++ b/docs/app/docs/layout.tsx
@@ -1,6 +1,13 @@
 import { source } from "@/lib/source";
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import type { ReactNode } from "react";
+function DiscordIcon() {
+  return (
+    <svg viewBox="0 0 24 24" width="1em" height="1em" fill="currentColor" aria-hidden="true">
+      <path d="M20.317 4.369a19.79 19.79 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.249a18.27 18.27 0 0 0-5.487 0 12.6 12.6 0 0 0-.617-1.25.077.077 0 0 0-.079-.036A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.1 13.1 0 0 1-1.872-.892.077.077 0 0 1-.008-.128c.126-.094.252-.192.372-.291a.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.009c.12.099.246.198.373.292a.077.077 0 0 1-.006.127 12.3 12.3 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.84 19.84 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.028zM8.02 15.331c-1.183 0-2.157-1.086-2.157-2.419 0-1.333.955-2.42 2.157-2.42 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.419-2.157 2.419zm7.975 0c-1.183 0-2.157-1.086-2.157-2.419 0-1.333.955-2.42 2.157-2.42 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.419-2.157 2.419z" />
+    </svg>
+  );
+}
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
@@ -8,6 +15,16 @@ export default function Layout({ children }: { children: ReactNode }) {
       tree={source.pageTree}
       nav={{ title: "SO101-Nexus" }}
       githubUrl="https://github.com/johnsutor/so101-nexus"
+      links={[
+        {
+          type: "icon",
+          label: "Join our Discord",
+          icon: <DiscordIcon />,
+          text: "Discord",
+          url: "https://discord.gg/37kKRXDh8",
+          secondary: true,
+        },
+      ]}
     >
       {children}
     </DocsLayout>

--- a/examples/bc_ppo_warp_colab.ipynb
+++ b/examples/bc_ppo_warp_colab.ipynb
@@ -33,7 +33,9 @@
    "source": [
     "## 2. Install\n",
     "\n",
-    "The example scripts live in `examples/`, not the wheel, so clone the repo and install the `warp` + `train` extras."
+    "The example scripts live in `examples/`, not the wheel, so clone the repo and install the `warp` + `train` extras.\n",
+    "\n",
+    "If you hit `ModuleNotFoundError: No module named 'so101_nexus._reproducibility'` (or any `so101_nexus` submodule), the `so101_nexus` package is resolving to a stale copy that predates that file (e.g. a previously installed `so101-nexus` wheel). This install cell now force-removes any existing `so101-nexus` before the editable install so the cloned copy wins; if you still see it, re-run this cell. The leading underscore on the module is not the cause: the file ships in the wheel and is on `main`."
    ]
   },
   {
@@ -44,6 +46,7 @@
    "source": [
     "!git clone --depth 1 https://github.com/johnsutor/so101-nexus.git\n",
     "%cd so101-nexus\n",
+    "!pip uninstall -y so101-nexus 2>/dev/null || true\n",
     "!pip install -q -e \".[warp,train]\" \"imageio[ffmpeg]\""
    ]
   },

--- a/examples/ppo_warp_colab.ipynb
+++ b/examples/ppo_warp_colab.ipynb
@@ -46,6 +46,7 @@
    "source": [
     "!git clone --depth 1 https://github.com/johnsutor/so101-nexus.git\n",
     "%cd so101-nexus\n",
+    "!pip uninstall -y so101-nexus 2>/dev/null || true\n",
     "!pip install -q -e \".[warp,train]\" \"imageio[ffmpeg]\""
    ]
   },


### PR DESCRIPTION
- Add a Join Us Discord badge (https://discord.gg/37kKRXDh8) to the README header, matching the existing shields.io style.

- Force-remove any preinstalled so101-nexus wheel in the Colab notebooks before the editable install so the cloned copy wins and so101_nexus._reproducibility resolves.