### PR TITLE
fix(examples): fix Colab ModuleNotFoundError for in-kernel so101_nexu…

### DIFF
--- a/examples/bc_ppo_warp_colab.ipynb
+++ b/examples/bc_ppo_warp_colab.ipynb
@@ -35,7 +35,8 @@
     "\n",
     "The example scripts live in `examples/`, not the wheel, so clone the repo and install the `warp` + `train` extras.\n",
     "\n",
-    "If you hit `ModuleNotFoundError: No module named 'so101_nexus._reproducibility'` (or any `so101_nexus` submodule), the `so101_nexus` package is resolving to a stale copy that predates that file (e.g. a previously installed `so101-nexus` wheel). This install cell now force-removes any existing `so101-nexus` before the editable install so the cloned copy wins; if you still see it, re-run this cell. The leading underscore on the module is not the cause: the file ships in the wheel and is on `main`."
+    "\n",
+    "If you hit `ModuleNotFoundError: No module named 'so101_nexus._reproducibility'` (or any `so101_nexus` submodule) in a later cell, it is not a stale wheel: `pip install -e` adds the package to `sys.path` via a `.pth` file that Python only reads at interpreter startup. This kernel was already running before the install cell executed, so `!python ...` cells (fresh subprocesses) pick up the new install but in-kernel `import so101_nexus...` cells do not. The install cell below also inserts `src/` onto `sys.path` directly so both paths work without a runtime restart."
    ]
   },
   {
@@ -47,7 +48,17 @@
     "!git clone --depth 1 https://github.com/johnsutor/so101-nexus.git\n",
     "%cd so101-nexus\n",
     "!pip uninstall -y so101-nexus 2>/dev/null || true\n",
-    "!pip install -q -e \".[warp,train]\" \"imageio[ffmpeg]\""
+    "!pip install -q -e \".[warp,train]\" \"imageio[ffmpeg]\"",
+    "\n",
+    "# `pip install -e` registers the package via a .pth file that Python only\n",
+    "# reads when an interpreter starts. This kernel was already running before\n",
+    "# the install above, so `!python ...` cells (fresh subprocesses) see the\n",
+    "# package but in-kernel `import so101_nexus...` cells below will not unless\n",
+    "# `src/` is also put on sys.path explicitly, here.\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "sys.path.insert(0, str(Path.cwd() / \"src\"))"
    ]
   },
   {

--- a/examples/ppo_warp_colab.ipynb
+++ b/examples/ppo_warp_colab.ipynb
@@ -35,7 +35,10 @@
    "source": [
     "## 2. Install\n",
     "\n",
-    "The example scripts live in `examples/`, not the wheel, so clone the repo and install the `warp` + `train` extras."
+    "The example scripts live in `examples/`, not the wheel, so clone the repo and install the `warp` + `train` extras.",
+    "\n",
+    "\n",
+    "If you hit `ModuleNotFoundError: No module named 'so101_nexus._reproducibility'` (or any `so101_nexus` submodule) in a later cell, it is not a stale wheel: `pip install -e` adds the package to `sys.path` via a `.pth` file that Python only reads at interpreter startup. This kernel was already running before the install cell executed, so `!python ...` cells (fresh subprocesses) pick up the new install but in-kernel `import so101_nexus...` cells do not. The install cell below also inserts `src/` onto `sys.path` directly so both paths work without a runtime restart."
    ]
   },
   {
@@ -47,7 +50,17 @@
     "!git clone --depth 1 https://github.com/johnsutor/so101-nexus.git\n",
     "%cd so101-nexus\n",
     "!pip uninstall -y so101-nexus 2>/dev/null || true\n",
-    "!pip install -q -e \".[warp,train]\" \"imageio[ffmpeg]\""
+    "!pip install -q -e \".[warp,train]\" \"imageio[ffmpeg]\"",
+    "\n",
+    "# `pip install -e` registers the package via a .pth file that Python only\n",
+    "# reads when an interpreter starts. This kernel was already running before\n",
+    "# the install above, so `!python ...` cells (fresh subprocesses) see the\n",
+    "# package but in-kernel `import so101_nexus...` cells below will not unless\n",
+    "# `src/` is also put on sys.path explicitly, here.\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "sys.path.insert(0, str(Path.cwd() / \"src\"))"
    ]
   },
   {


### PR DESCRIPTION
…s imports

pip install -e registers the package via a .pth file that Python only reads at interpreter startup. The Colab kernel is already running when the install cell executes, so !python subprocess cells (fresh interpreters) pick up the editable install but in-kernel 'from examples.bc_ppo_warp import ...' cells do not, raising ModuleNotFoundError: No module named 'so101_nexus._reproducibility'.

The previous mitigation (pip uninstall + reinstall) blamed a stale wheel and did not address this. Insert src/ onto sys.path explicitly right after the install so in-kernel imports work without a runtime restart, and correct the markdown note explaining the failure.


