### PR TITLE
feat(teleop): one-indexed episode counter and dataset name warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ for the public-API and deprecation policy.
 
 ## [Unreleased]
 
+### Changed
+
+- Teleop recorder UI: the episode progress counter is now one-indexed ("Episode 1 / 5" at the start of the first episode, matching the already-one-indexed "Recording episode 1/5..." status text) instead of showing "Episode 0 / 5" before any episode was recorded.
+- Teleop recorder UI: the dataset Repo ID warning now also flags a repo ID that already has a dataset on local disk (`HF_LEROBOT_HOME/<repo_id>`), flags (on blur) a repo ID that already exists as a dataset on the HuggingFace Hub, and warns when no `username/` namespace is given that the recording will be local-only and cannot be pushed to the Hub.
+
 ## [0.4.8] - 2026-07-12
 
 ### Added

--- a/src/so101_nexus/teleop/app.py
+++ b/src/so101_nexus/teleop/app.py
@@ -92,8 +92,9 @@ class CustomizationUIState:
 
 
 def _progress_text(completed: int, total: int) -> str:
-    """Format a progress string for the episode counter."""
-    return f"**Episode {completed} / {total}**"
+    """Format a progress string for the episode counter, one-indexed like the recording status."""
+    current = min(completed + 1, total)
+    return f"**Episode {current} / {total}**"
 
 
 def _format_hub_links(repo_id: str) -> str:
@@ -673,26 +674,59 @@ def _cb_update_customization_for_env(env_id: str):
     )
 
 
-def _cb_validate_repo_id(repo_id: str):
-    """Return a warning update for the repo ID input."""
-    import gradio as gr
-
-    from so101_nexus.teleop.session import RepoIdStatus, validate_hub_repo_id
+def _repo_id_warning_messages(repo_id: str, *, check_remote: bool) -> list[str]:
+    """Return warning strings for *repo_id*: format, no-username, and existence conflicts."""
+    from so101_nexus.teleop.session import (
+        RepoIdStatus,
+        local_dataset_exists,
+        local_dataset_path,
+        remote_dataset_exists,
+        validate_hub_repo_id,
+    )
 
     status = validate_hub_repo_id(repo_id)
-    if status in (RepoIdStatus.OK, RepoIdStatus.LOCAL_ONLY):
-        return gr.update(visible=False, value="")
+    if status is RepoIdStatus.INVALID_CHARS:
+        return [
+            "Invalid repo ID: must be alphanumeric plus `-`, `_`, or `.`, "
+            "with no spaces and a maximum length of 96 characters."
+        ]
+
+    messages: list[str] = []
     if status is RepoIdStatus.MISSING_NAMESPACE:
-        msg = (
+        messages.append(
             "Use `username/dataset` format if you plan to push to the Hub. "
             "Leave blank for local-only recording."
         )
-    else:
-        msg = (
-            "Invalid repo ID: must be alphanumeric plus `-`, `_`, or `.`, "
-            "with no spaces and a maximum length of 96 characters."
+    elif status is RepoIdStatus.LOCAL_ONLY:
+        messages.append(
+            "No username given: recording will be local-only. Use `username/dataset` "
+            "if you want to be able to push this dataset to the Hub."
         )
-    return gr.update(visible=True, value=f"_{msg}_")
+
+    if status is not RepoIdStatus.LOCAL_ONLY and local_dataset_exists(repo_id):
+        messages.append(f"A dataset already exists on disk at `{local_dataset_path(repo_id)}`.")
+
+    if check_remote and status is RepoIdStatus.OK and remote_dataset_exists(repo_id):
+        messages.append(
+            f"A dataset named `{repo_id.strip()}` already exists on the HuggingFace Hub."
+        )
+
+    return messages
+
+
+def _cb_validate_repo_id(repo_id: str, *, check_remote: bool = False):
+    """Return a warning update for the repo ID input.
+
+    *check_remote* additionally queries the HuggingFace Hub for a name
+    collision; callers should reserve that for infrequent triggers (e.g. on
+    blur) since it is a network call.
+    """
+    import gradio as gr
+
+    messages = _repo_id_warning_messages(repo_id, check_remote=check_remote)
+    if not messages:
+        return gr.update(visible=False, value="")
+    return gr.update(visible=True, value="\n\n".join(f"_{msg}_" for msg in messages))
 
 
 def _cb_poll_init(session: dict, init_state: dict):
@@ -1446,6 +1480,11 @@ def _wire_events(
     )
     repo_id_input.change(
         fn=_cb_validate_repo_id,
+        inputs=[repo_id_input],
+        outputs=[repo_id_warning],
+    )
+    repo_id_input.blur(
+        fn=functools.partial(_cb_validate_repo_id, check_remote=True),
         inputs=[repo_id_input],
         outputs=[repo_id_warning],
     )

--- a/src/so101_nexus/teleop/session.py
+++ b/src/so101_nexus/teleop/session.py
@@ -13,9 +13,12 @@ import datetime
 import importlib
 import tempfile
 from enum import Enum
+from typing import TYPE_CHECKING
 
 import numpy as np
 
+if TYPE_CHECKING:
+    from pathlib import Path
 from so101_nexus.observations import OverheadCamera, WristCamera
 from so101_nexus.teleop.config_customization import (
     ConfigFactory,
@@ -65,6 +68,38 @@ def _default_repo_id(env_id: str) -> str:
     ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     safe = env_id.replace("/", "-").replace(" ", "_")
     return f"local/teleop-{safe}-{ts}"
+
+
+def local_dataset_path(repo_id: str) -> Path:
+    """Return the on-disk LeRobot dataset directory for *repo_id*."""
+    from lerobot.utils.constants import HF_LEROBOT_HOME
+
+    return HF_LEROBOT_HOME / repo_id.strip()
+
+
+def local_dataset_exists(repo_id: str) -> bool:
+    """Return whether a LeRobot dataset directory already exists for *repo_id*."""
+    stripped = repo_id.strip()
+    return bool(stripped) and local_dataset_path(stripped).exists()
+
+
+def remote_dataset_exists(repo_id: str) -> bool | None:
+    """Return whether *repo_id* already exists as a dataset on the HuggingFace Hub.
+
+    Returns ``None`` when existence cannot be determined -- a malformed or
+    local-only repo ID, or an unreachable Hub -- rather than raising, since
+    this backs a best-effort UI warning and must never block recording.
+    """
+    stripped = repo_id.strip()
+    if validate_hub_repo_id(stripped) is not RepoIdStatus.OK:
+        return None
+
+    from huggingface_hub import repo_exists
+
+    try:
+        return repo_exists(stripped, repo_type="dataset")
+    except Exception:
+        return None
 
 
 def _resolve_env_config(env_ctor: type) -> object | None:

--- a/tests/core/test_teleop_app_helpers.py
+++ b/tests/core/test_teleop_app_helpers.py
@@ -60,11 +60,16 @@ def fake_gradio(monkeypatch):
 
 
 def test_progress_text_formats_episode_count() -> None:
-    assert _progress_text(2, 5) == "**Episode 2 / 5**"
+    assert _progress_text(2, 5) == "**Episode 3 / 5**"
 
 
 def test_progress_text_formats_zero_completed() -> None:
-    assert _progress_text(0, 10) == "**Episode 0 / 10**"
+    assert _progress_text(0, 10) == "**Episode 1 / 10**"
+
+
+def test_progress_text_caps_at_total_once_all_episodes_completed() -> None:
+    """Once every episode is saved, the counter reads N/N, not N+1/N."""
+    assert _progress_text(5, 5) == "**Episode 5 / 5**"
 
 
 def test_format_hub_links_basic() -> None:
@@ -96,11 +101,14 @@ def test_format_hub_links_url_encodes_dataset_page_path() -> None:
     assert "https://huggingface.co/datasets/alice/data%20set" in text
 
 
-def test_cb_validate_repo_id_status_branches(fake_gradio) -> None:
+def test_cb_validate_repo_id_status_branches(fake_gradio, monkeypatch, tmp_path) -> None:
     from so101_nexus.teleop.app import _cb_validate_repo_id
 
+    monkeypatch.setattr("lerobot.utils.constants.HF_LEROBOT_HOME", tmp_path)
+
     blank = _cb_validate_repo_id("")
-    assert blank["visible"] is False
+    assert blank["visible"] is True
+    assert "local-only" in blank["value"]
 
     ok = _cb_validate_repo_id("alice/dataset")
     assert ok["visible"] is False
@@ -112,6 +120,51 @@ def test_cb_validate_repo_id_status_branches(fake_gradio) -> None:
     invalid = _cb_validate_repo_id("alice/has space")
     assert invalid["visible"] is True
     assert "alphanumeric" in invalid["value"]
+
+
+def test_cb_validate_repo_id_warns_when_local_dataset_exists(
+    fake_gradio, monkeypatch, tmp_path
+) -> None:
+    from so101_nexus.teleop.app import _cb_validate_repo_id
+
+    monkeypatch.setattr("lerobot.utils.constants.HF_LEROBOT_HOME", tmp_path)
+    (tmp_path / "alice" / "dataset").mkdir(parents=True)
+
+    result = _cb_validate_repo_id("alice/dataset")
+
+    assert result["visible"] is True
+    assert "already exists on disk" in result["value"]
+
+
+def test_cb_validate_repo_id_skips_remote_check_by_default(
+    fake_gradio, monkeypatch, tmp_path
+) -> None:
+    from so101_nexus.teleop.app import _cb_validate_repo_id
+
+    monkeypatch.setattr("lerobot.utils.constants.HF_LEROBOT_HOME", tmp_path)
+
+    def _boom(repo_id, repo_type):
+        raise AssertionError("remote check should not run without check_remote=True")
+
+    monkeypatch.setattr("huggingface_hub.repo_exists", _boom)
+
+    result = _cb_validate_repo_id("alice/dataset")
+
+    assert result["visible"] is False
+
+
+def test_cb_validate_repo_id_warns_when_remote_dataset_exists(
+    fake_gradio, monkeypatch, tmp_path
+) -> None:
+    from so101_nexus.teleop.app import _cb_validate_repo_id
+
+    monkeypatch.setattr("lerobot.utils.constants.HF_LEROBOT_HOME", tmp_path)
+    monkeypatch.setattr("huggingface_hub.repo_exists", lambda repo_id, repo_type: True)
+
+    result = _cb_validate_repo_id("alice/dataset", check_remote=True)
+
+    assert result["visible"] is True
+    assert "already exists on the HuggingFace Hub" in result["value"]
 
 
 def test_format_port_status_ok_when_accessible(monkeypatch) -> None:

--- a/tests/core/test_teleop_session.py
+++ b/tests/core/test_teleop_session.py
@@ -26,6 +26,9 @@ from so101_nexus.teleop.session import (
     _replace_wrist_camera,
     _resolve_env_config,
     _wire_camera_observations,
+    local_dataset_exists,
+    local_dataset_path,
+    remote_dataset_exists,
     validate_hub_repo_id,
 )
 
@@ -85,6 +88,49 @@ def test_validate_hub_repo_id_invalid_chars() -> None:
 
 def test_validate_hub_repo_id_local_default_passes() -> None:
     assert validate_hub_repo_id("local/teleop-Reach-v0-20260518_120000") is RepoIdStatus.OK
+
+
+def test_local_dataset_path_joins_hf_lerobot_home(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("lerobot.utils.constants.HF_LEROBOT_HOME", tmp_path)
+
+    assert local_dataset_path("alice/my-dataset") == tmp_path / "alice/my-dataset"
+
+
+def test_local_dataset_exists_true_when_directory_present(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("lerobot.utils.constants.HF_LEROBOT_HOME", tmp_path)
+    (tmp_path / "alice" / "my-dataset").mkdir(parents=True)
+
+    assert local_dataset_exists("alice/my-dataset") is True
+    assert local_dataset_exists("alice/other-dataset") is False
+
+
+def test_local_dataset_exists_false_for_blank_repo_id(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("lerobot.utils.constants.HF_LEROBOT_HOME", tmp_path)
+
+    assert local_dataset_exists("") is False
+    assert local_dataset_exists("   ") is False
+
+
+def test_remote_dataset_exists_skips_network_for_non_ok_status() -> None:
+    """Malformed or local-only repo IDs never reach the Hub, so no request is made."""
+    assert remote_dataset_exists("") is None
+    assert remote_dataset_exists("just-a-name") is None
+    assert remote_dataset_exists("alice/has space") is None
+
+
+def test_remote_dataset_exists_returns_hub_result(monkeypatch) -> None:
+    monkeypatch.setattr("huggingface_hub.repo_exists", lambda repo_id, repo_type: True)
+
+    assert remote_dataset_exists("alice/my-dataset") is True
+
+
+def test_remote_dataset_exists_returns_none_on_hub_error(monkeypatch) -> None:
+    def _raise(repo_id, repo_type):
+        raise ConnectionError("offline")
+
+    monkeypatch.setattr("huggingface_hub.repo_exists", _raise)
+
+    assert remote_dataset_exists("alice/my-dataset") is None
 
 
 class _ExplicitConfigEnv:


### PR DESCRIPTION
- Progress counter ("Episode X / Y") is now one-indexed at the start of recording, matching the existing "Recording episode X/Y" status text; previously showed "Episode 0 / 5" before any episode was saved.
- Repo ID warning now also flags a dataset that already exists on local disk (HF_LEROBOT_HOME/<repo_id>), flags on blur when it already exists on the HuggingFace Hub, and warns when no username namespace is given that recording will be local-only.