### PR TITLE
chore: prepare 0.4.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ for the public-API and deprecation policy.
 
 ## [Unreleased]
 
+## [0.4.9] - 2026-07-16
+
 ### Changed
 
 - Teleop recorder UI: the episode progress counter is now one-indexed ("Episode 1 / 5" at the start of the first episode, matching the already-one-indexed "Recording episode 1/5..." status text) instead of showing "Episode 0 / 5" before any episode was recorded.
@@ -280,7 +282,8 @@ for the public-API and deprecation policy.
 
 - Initial release: SO-101 MuJoCo simulation with cameras, GitHub Actions CI, and the core project structure.
 
-[Unreleased]: https://github.com/johnsutor/so101-nexus/compare/0.4.8...HEAD
+[Unreleased]: https://github.com/johnsutor/so101-nexus/compare/0.4.9...HEAD
+[0.4.9]: https://github.com/johnsutor/so101-nexus/compare/0.4.8...0.4.9
 [0.4.8]: https://github.com/johnsutor/so101-nexus/compare/0.4.7...0.4.8
 [0.4.7]: https://github.com/johnsutor/so101-nexus/compare/0.4.5...0.4.7
 [0.4.5]: https://github.com/johnsutor/so101-nexus/compare/0.4.4...0.4.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "so101-nexus"
-version = "0.4.8"
+version = "0.4.9"
 description = "End-to-end simulation and training stack for the SO-101 arm: record demonstrations, clone behavior, and reinforce with GPU-parallel MuJoCo / MuJoCo Warp environments, built on LeRobot"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -3405,7 +3405,7 @@ wheels = [
 
 [[package]]
 name = "so101-nexus"
-version = "0.4.8"
+version = "0.4.9"
 source = { editable = "." }
 dependencies = [
     { name = "gymnasium" },


### PR DESCRIPTION
Bump version to 0.4.9 in pyproject.toml/uv.lock and fold the Unreleased changelog entries (episode counter, dataset name warnings, reaching/grasping potential-based shaping, Warp NaN/Inf sanitization) into the 0.4.9 section, reopening an empty Unreleased.


