### PR TITLE
fix(rewards): make pick-and-place potential monotone along ideal traj…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ for the public-API and deprecation policy.
 
 ## [Unreleased]
 
+### Added
+
+- `so101_nexus.rewards.place_task_potential`, `place_reach_potential`, `place_grasp_potential`: shared, tensor-agnostic facet potentials for place tasks, now used by both pick-and-place backends instead of per-backend inline formulas.
+
+### Changed
+
+- Pick-and-place facet potentials (both backends) are now monotone non-decreasing along the ideal grasp-lift-carry-lower-release-settle trajectory, so every step of forward progress pays a non-negative shaping delta (previously a perfect demonstration paid -0.09 for the mandatory 5 cm lift, ~1e-7/step for carrying toward the goal, and -0.25 for releasing the object on the goal, with only the terminal bonus showing structure). The task potential (`info["task_potential"]`) is now a staged additive sum -- transport progress measured by Chebyshev distance `max(obj_to_goal_xy, height_gap)` plus an arm-stillness term gated on `is_obj_placed` -- instead of a product of xy-proximity x height-back-near-rest x stillness factors, and the reach/grasp potentials are held up by `is_obj_placed` so releasing on the goal and retreating after delivery pay no negative delta. Dwelling anywhere still pays ~0 (all facets remain potential-based deltas), genuine regressions (dropping the object mid-carry, knocking it off the goal) still pay negative deltas, and per-step bounds are unchanged at `[-0.75, 1.0]`. See `docs/superpowers/plans/2026-07-16-monotone-place-potential.md`.
+
 ## [0.4.9] - 2026-07-16
 
 ### Changed

--- a/docs/superpowers/skills/reward-engineering/SKILL.md
+++ b/docs/superpowers/skills/reward-engineering/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: reward-engineering
+description: Use when designing or reviewing a reward function for a new so101-nexus environment (or auditing an existing one), especially any task with a multi-phase or dwelling-prone completion condition (grasp-then-release, reach-then-hold, multi-object sequencing). Covers dwelling-vs-potential-based shaping, keeping the potential monotone along the ideal trajectory, how to spot a reward-hacking trap before it costs a training run, and the primitives/citations to use.
+---
+
+# Reward engineering for so101-nexus environments
+
+Procedural guide for writing a new task's reward, or auditing an existing one, so
+dense shaping helps training instead of becoming the thing the policy learns to
+game. Grounded in a real, previously-shipped bug: `PickAndPlaceEnv`'s
+`task_progress` term let a policy collect ~90% of the reward budget forever by
+hovering a grasped object above the goal without ever placing it (see
+`docs/superpowers/plans/2026-07-12-potential-based-task-progress-shaping.md` for
+the full writeup and the fix).
+
+## The core failure mode: dwelling rewards
+
+A **dwelling** reward term is a function of the *current state alone*,
+recomputed fresh every step: `r_t = f(s_t)`. If `f` saturates near its maximum
+before the task's actual `success` condition fires, and the episode does not
+terminate until `success`, a policy that reaches a high-`f` state and then does
+*nothing further* collects that near-maximum reward every remaining step of the
+episode -- often far more total return than a policy that pushes on to finish
+and terminate early. This is not a hypothetical: `Amodei, Olah, Steinhardt,
+Christiano, Schulman & Mane, "Concrete Problems in AI Safety," arXiv:1606.06565
+(2016)` name this *reward hacking* as one of five concrete AI-accident problem
+classes, and `Krakovna, Uesato, Mikulik, Rahtz, Everitt, Kumar, Kenton, Leike &
+Legg, "Specification gaming: the flip side of AI ingenuity" (DeepMind, 2020,
+tinyurl.com/specification-gaming)` catalogue ~60 real instances, including a
+Lego-stacking agent (`Popov, Heess, Lillicrap, Hafner, Barth-Maron, Vecerik,
+Lampe, Tassa, Erez & Riedmiller, "Data-efficient Deep RL for Dexterous
+Manipulation," arXiv:1704.03073, 2017`) rewarded for a block's height that
+simply flipped the block instead of stacking it.
+
+**Multi-phase tasks are the highest-risk shape.** A task whose `success`
+requires state B *after* first passing through state A (e.g. grasp-then-lower,
+reach-then-release, pick-then-place) is dangerous whenever the natural,
+easiest-to-explore trajectory reaches a *dwelling-rewarding* state A and stops
+there, because completing the task requires *reversing or complicating* the
+just-learned behaviour (releasing a grasp, lowering back down, decelerating).
+Single-phase tasks (reach a point, look at an object) are comparatively safe:
+crossing the completion threshold is not a reversal of the most-explored
+trajectory, so the same failure mode is far less likely to be where training
+actually gets stuck -- but it is not categorically impossible, so still check.
+
+## Checklist when writing a reward for a new task
+
+1. **Read `so101_nexus/rewards.py` first.** Reuse `reach_progress`,
+   `orientation_progress`, `lift_progress`, `simple_reward`,
+   `potential_shaping`, `place_task_potential`, `place_reach_potential`,
+   `place_grasp_potential` -- never inline a shaping formula. If none of these
+   fit, propose a new one there (never in a backend env class); see
+   `CLAUDE.md`/`AGENTS.md`'s "Reward functions live in `so101_nexus.rewards`" rule.
+2. **Write down `success` first**, as a precise boolean predicate over state.
+   Then ask: is there a *strict subset* of `success`'s conditions that a
+   dwelling reward term would saturate on? If yes, that subset is the exploit
+   surface -- this is exactly what happened when `task_progress` rewarded
+   goal-xy proximity alone while `success` additionally required height and
+   staticness.
+3. **For any term that is part of, or a proxy for, the multi-phase completion
+   surface identified in step 2**: make it a **potential-based delta**, not a
+   raw state value.
+   - Define a potential function `Phi(s)` in `[0, 1]` that is zero until every
+     phase relevant to that term has genuinely started (e.g. gate on "grasped
+     or already placed"). Build it as **boolean phase gates around an
+     additive, staged progress sum** (ManiSkill PickCube's dense-reward shape:
+     `reaching + is_grasped + place*is_grasped + static*is_obj_placed`), NOT
+     as a product of continuous progress factors. Products are how you gate
+     *raw dwelling* terms, where coasting on one maxed factor is the threat; a
+     potential *delta* already pays ~0 for coasting, so the product buys
+     nothing and instead lets any one small factor mute every other factor's
+     gradient -- an arm-stillness factor at realistic carry speed multiplied
+     pick-and-place's entire transport gradient down to ~1e-7/step (see the
+     worked example below).
+   - **Walk `Phi` through the ideal trajectory phase by phase before shipping
+     it** (approach, grasp, lift, carry, lower, release, settle) and check it
+     never decreases: any dip means `potential_shaping` pays *negative* reward
+     for mandatory forward progress. Shaping is policy-invariant for ANY
+     `Phi`, so you are free to pick one that ranks states in the right order
+     -- delta-shaping fixes dwelling, it cannot fix a potential that ranks a
+     later phase below an earlier one. The three traps found in the shipped
+     pick-and-place potential
+     (`docs/superpowers/plans/2026-07-16-monotone-place-potential.md`):
+     1. *Undo-factors*: a height-back-near-rest factor pays negative on the
+        lift the task requires. Measure transport with a distance under which
+        the lift is free, e.g. Chebyshev `max(xy_dist, height_gap)` (a plain
+        3D norm still dips slightly on lift-off).
+     2. *Gradient-muting products*: stillness x transport zeroes the carry
+        gradient at any realistic arm speed. Make stillness additive and gate
+        it on `is_obj_placed` (ManiSkill's `static_reward * is_obj_placed`).
+     3. *Missing successor holds*: a sub-potential a later phase must undo
+        (grasp before release, reach before retreat) pays a negative delta at
+        the finish unless held up by its successor condition: `grasped OR
+        placed` (`rewards.place_grasp_potential`), `max(reach, placed)`
+        (`rewards.place_reach_potential`). Keep the negative delta for
+        genuine regressions -- if dropping the object paid 0 while grasping
+        paid +, a grasp-drop-regrasp cycle would pump unbounded reward;
+        symmetric deltas make every closed loop net exactly 0.
+   - Feed `rewards.potential_shaping(Phi(s'), Phi(s))` as the term's value
+     instead of `Phi(s')` directly. This requires tracking `Phi(s_prev)` as
+     per-episode state on the env (a plain attribute for the scalar MuJoCo
+     backend, a `(num_envs,)` tensor updated by index for the batched Warp
+     backend), seeded post-settle in `_refresh_reset_reference_state` (mirror
+     the existing `_initial_obj_z` baseline pattern) and updated once per real
+     step inside `_compute_reward`/`_compute_reward_terminated` *after* reading
+     the previous value.
+   - This is the `gamma=1` telescoping special case of `Ng, Harada & Russell,
+     "Policy Invariance Under Reward Transformations: Theory and Application to
+     Reward Shaping," ICML 1999` (Theorem 1: `F(s,a,s') = gamma*Phi(s') -
+     Phi(s)` is necessary and sufficient for the shaped MDP's optimal policy to
+     equal the unshaped MDP's). Summed over an episode it telescopes to
+     `Phi(final) - Phi(initial)`, bounded regardless of dwell time, so standing
+     still nets ~0 further reward. Use `gamma=1` rather than a full discount
+     because the env does not know the training algorithm's `gamma`; this is
+     exact at `gamma=1` and a close approximation for `gamma` near 1 (typical
+     PPO/FPO settings, 0.95-0.99). If a term's potential is genuinely
+     phase/time-dependent (not just state-dependent), see `Devlin & Kudenko,
+     "Dynamic Potential-Based Reward Shaping," AAMAS 2012` (Eq. 4), which
+     extends the same guarantee to `Phi(s, t)`.
+   - **Do not soften `success`/`terminated` itself into a continuous proxy to
+     get partial credit.** Get partial credit from the *shaping* potential
+     instead. A soft success proxy that never has to cross the real threshold
+     just relocates the exploit to a new, not-yet-discovered shape (a policy
+     that maximizes the soft proxy without ever really finishing) -- this is
+     the mistake to avoid, not a hypothetical: see the "Concrete changes"
+     section of the design note above for the reasoning trail.
+4. **Terms that are NOT part of the completion surface** (e.g. a generic
+   TCP-to-object reach term while the object is still far away) can stay flat
+   dwelling terms at a modest budget weight; not everything needs potential
+   shaping, only the specific surface a policy could exploit to avoid
+   finishing. Reserve the biggest weight cut for `completion_bonus`, not the
+   dwelling terms, if you are tuning a budget split.
+5. **Verify `terminated == success`** in both backends' `step()` (already the
+   base-class contract) so a real completion always ends the episode -- a
+   potential-based term only closes the *dwelling* exploit; if the episode
+   never ends on success, dwelling on the terminal state itself becomes the new
+   exploit.
+6. **Write the regression test before you trust the fix.** Simulate "hover"
+   (call the reward computation twice with an unchanged potential) and assert
+   the potential-shaped facet of `info["reward_components"]` is ~0 on the
+   second call; then simulate genuine progress (potential increases) and assert
+   real credit is paid. See `test_pick_and_place_hovering_earns_no_dwelling_task_objective_reward`
+   in `tests/mujoco/test_envs.py` for the pattern.
+7. Consider the sparse-reward alternative. `Andrychowicz, Wolski, Ray,
+   Schneider, Fong, Welinder, McGrew, Tobin, Abbeel & Zaremba, "Hindsight
+   Experience Replay," NeurIPS 2017 (arXiv:1707.01495)` is the other major
+   line of attack on this class of problem: train off-policy on a sparse
+   binary success signal and relabel failed trajectories with the goal they
+   *actually* reached, removing the dense-shaping exploit surface entirely by
+   not having one. Not applicable to this repo's on-policy training recipes
+   today (HER needs an off-policy, replay-buffer algorithm and a
+   goal-conditioned value function), but worth naming when proposing a new
+   training recipe, not just a new env.
+
+## Citations (primary sources, read in full before citing further)
+
+- Amodei, Olah, Steinhardt, Christiano, Schulman & Mane, "Concrete Problems in
+  AI Safety," arXiv:1606.06565 (2016). https://arxiv.org/abs/1606.06565
+- Krakovna, Uesato, Mikulik, Rahtz, Everitt, Kumar, Kenton, Leike & Legg,
+  "Specification gaming: the flip side of AI ingenuity," Google DeepMind blog
+  (2020), with the maintained master list at tinyurl.com/specification-gaming.
+  https://deepmind.google/discover/blog/specification-gaming-the-flip-side-of-ai-ingenuity/
+- Ng, Harada & Russell, "Policy Invariance Under Reward Transformations: Theory
+  and Application to Reward Shaping," ICML 1999, pp. 278-287.
+  https://people.eecs.berkeley.edu/~pabbeel/cs287-fa09/readings/NgHaradaRussell-shaping-ICML1999.pdf
+- Devlin & Kudenko, "Dynamic Potential-Based Reward Shaping," AAMAS 2012,
+  pp. 433-440. https://eprints.whiterose.ac.uk/id/eprint/75121/2/p433_devlin.pdf
+- Popov, Heess, Lillicrap, Hafner, Barth-Maron, Vecerik, Lampe, Tassa, Erez &
+  Riedmiller, "Data-efficient Deep Reinforcement Learning for Dexterous
+  Manipulation," arXiv:1704.03073 (2017). https://arxiv.org/abs/1704.03073
+- Andrychowicz, Wolski, Ray, Schneider, Fong, Welinder, McGrew, Tobin, Abbeel &
+  Zaremba, "Hindsight Experience Replay," NeurIPS 2017, arXiv:1707.01495.
+  https://arxiv.org/abs/1707.01495
+
+## Worked example
+
+`docs/superpowers/plans/2026-07-12-potential-based-task-progress-shaping.md` is
+a complete worked application of this checklist to `PickAndPlaceEnv` and
+`PickLiftEnv` (both backends): problem diagnosis, the decision with citations
+mapped to concrete design choices, exact scope, and non-goals (why
+Touch/Move/LookAt were left unchanged). Read it alongside
+`so101_nexus/rewards.py`'s `potential_shaping` and `place_task_potential`
+docstrings for the concrete implementation pattern to copy.
+
+That plan's original "Non-goals" left `reaching`/`grasping` as flat dwelling
+terms, reasoning they carried a smaller combined budget and were not (yet) an
+exploited surface -- explicitly flagged to revisit "if evidence of the same
+failure mode surfaces there." It did:
+`docs/superpowers/plans/2026-07-16-pick-grasp-potential-shaping.md` is the
+follow-up that converts `reaching`/`grasping` to potential-shaped deltas too,
+once fixing `task_objective` alone made their combined flat budget the new
+dominant dwelling ceiling. Read both plans together; the second is a second
+application of this same checklist, not a different pattern.
+
+`docs/superpowers/plans/2026-07-16-monotone-place-potential.md` is the third
+application, and the origin of checklist step 3's monotonicity walk: with
+every facet correctly delta-shaped, a recorded teleop episode's step-reward
+graph exposed that the potential itself was not monotone along the ideal
+trajectory -- the mandatory lift paid -0.09, carrying toward the goal paid
+~1e-7 (stillness-muted product), and releasing on the goal paid -0.25, so a
+perfect demonstration earned nothing but the terminal bonus. The fix swapped
+the product potential for the staged additive `place_task_potential` and
+added the `is_obj_placed` successor holds. Lesson: the 0.4.8/0.4.9 fixes
+chose the right *mechanism* (deltas) around the wrong *potential*; audit both.
+
+## Discovery
+
+The skill source lives in-repo so it is versioned with the project. To make it
+discoverable, copy or symlink this directory into
+`${CODEX_HOME:-$HOME/.codex}/skills/reward-engineering`. Keeping the source
+in-repo keeps it in sync with the codebase.

--- a/skills/reward-engineering/SKILL.md
+++ b/skills/reward-engineering/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: reward-engineering
+description: Use when designing or reviewing a reward function for a new so101-nexus environment (or auditing an existing one), especially any task with a multi-phase or dwelling-prone completion condition (grasp-then-release, reach-then-hold, multi-object sequencing). Covers dwelling-vs-potential-based shaping, keeping the potential monotone along the ideal trajectory, how to spot a reward-hacking trap before it costs a training run, and the primitives/citations to use.
+---
+
+# Reward engineering for so101-nexus environments
+
+Procedural guide for writing a new task's reward, or auditing an existing one, so
+dense shaping helps training instead of becoming the thing the policy learns to
+game. Grounded in a real, previously-shipped bug: `PickAndPlaceEnv`'s
+`task_progress` term let a policy collect ~90% of the reward budget forever by
+hovering a grasped object above the goal without ever placing it (see
+`docs/superpowers/plans/2026-07-12-potential-based-task-progress-shaping.md` for
+the full writeup and the fix).
+
+## The core failure mode: dwelling rewards
+
+A **dwelling** reward term is a function of the *current state alone*,
+recomputed fresh every step: `r_t = f(s_t)`. If `f` saturates near its maximum
+before the task's actual `success` condition fires, and the episode does not
+terminate until `success`, a policy that reaches a high-`f` state and then does
+*nothing further* collects that near-maximum reward every remaining step of the
+episode -- often far more total return than a policy that pushes on to finish
+and terminate early. This is not a hypothetical: `Amodei, Olah, Steinhardt,
+Christiano, Schulman & Mane, "Concrete Problems in AI Safety," arXiv:1606.06565
+(2016)` name this *reward hacking* as one of five concrete AI-accident problem
+classes, and `Krakovna, Uesato, Mikulik, Rahtz, Everitt, Kumar, Kenton, Leike &
+Legg, "Specification gaming: the flip side of AI ingenuity" (DeepMind, 2020,
+tinyurl.com/specification-gaming)` catalogue ~60 real instances, including a
+Lego-stacking agent (`Popov, Heess, Lillicrap, Hafner, Barth-Maron, Vecerik,
+Lampe, Tassa, Erez & Riedmiller, "Data-efficient Deep RL for Dexterous
+Manipulation," arXiv:1704.03073, 2017`) rewarded for a block's height that
+simply flipped the block instead of stacking it.
+
+**Multi-phase tasks are the highest-risk shape.** A task whose `success`
+requires state B *after* first passing through state A (e.g. grasp-then-lower,
+reach-then-release, pick-then-place) is dangerous whenever the natural,
+easiest-to-explore trajectory reaches a *dwelling-rewarding* state A and stops
+there, because completing the task requires *reversing or complicating* the
+just-learned behaviour (releasing a grasp, lowering back down, decelerating).
+Single-phase tasks (reach a point, look at an object) are comparatively safe:
+crossing the completion threshold is not a reversal of the most-explored
+trajectory, so the same failure mode is far less likely to be where training
+actually gets stuck -- but it is not categorically impossible, so still check.
+
+## Checklist when writing a reward for a new task
+
+1. **Read `so101_nexus/rewards.py` first.** Reuse `reach_progress`,
+   `orientation_progress`, `lift_progress`, `simple_reward`,
+   `potential_shaping`, `place_task_potential`, `place_reach_potential`,
+   `place_grasp_potential` -- never inline a shaping formula. If none of these
+   fit, propose a new one there (never in a backend env class); see
+   `CLAUDE.md`/`AGENTS.md`'s "Reward functions live in `so101_nexus.rewards`" rule.
+2. **Write down `success` first**, as a precise boolean predicate over state.
+   Then ask: is there a *strict subset* of `success`'s conditions that a
+   dwelling reward term would saturate on? If yes, that subset is the exploit
+   surface -- this is exactly what happened when `task_progress` rewarded
+   goal-xy proximity alone while `success` additionally required height and
+   staticness.
+3. **For any term that is part of, or a proxy for, the multi-phase completion
+   surface identified in step 2**: make it a **potential-based delta**, not a
+   raw state value.
+   - Define a potential function `Phi(s)` in `[0, 1]` that is zero until every
+     phase relevant to that term has genuinely started (e.g. gate on "grasped
+     or already placed"). Build it as **boolean phase gates around an
+     additive, staged progress sum** (ManiSkill PickCube's dense-reward shape:
+     `reaching + is_grasped + place*is_grasped + static*is_obj_placed`), NOT
+     as a product of continuous progress factors. Products are how you gate
+     *raw dwelling* terms, where coasting on one maxed factor is the threat; a
+     potential *delta* already pays ~0 for coasting, so the product buys
+     nothing and instead lets any one small factor mute every other factor's
+     gradient -- an arm-stillness factor at realistic carry speed multiplied
+     pick-and-place's entire transport gradient down to ~1e-7/step (see the
+     worked example below).
+   - **Walk `Phi` through the ideal trajectory phase by phase before shipping
+     it** (approach, grasp, lift, carry, lower, release, settle) and check it
+     never decreases: any dip means `potential_shaping` pays *negative* reward
+     for mandatory forward progress. Shaping is policy-invariant for ANY
+     `Phi`, so you are free to pick one that ranks states in the right order
+     -- delta-shaping fixes dwelling, it cannot fix a potential that ranks a
+     later phase below an earlier one. The three traps found in the shipped
+     pick-and-place potential
+     (`docs/superpowers/plans/2026-07-16-monotone-place-potential.md`):
+     1. *Undo-factors*: a height-back-near-rest factor pays negative on the
+        lift the task requires. Measure transport with a distance under which
+        the lift is free, e.g. Chebyshev `max(xy_dist, height_gap)` (a plain
+        3D norm still dips slightly on lift-off).
+     2. *Gradient-muting products*: stillness x transport zeroes the carry
+        gradient at any realistic arm speed. Make stillness additive and gate
+        it on `is_obj_placed` (ManiSkill's `static_reward * is_obj_placed`).
+     3. *Missing successor holds*: a sub-potential a later phase must undo
+        (grasp before release, reach before retreat) pays a negative delta at
+        the finish unless held up by its successor condition: `grasped OR
+        placed` (`rewards.place_grasp_potential`), `max(reach, placed)`
+        (`rewards.place_reach_potential`). Keep the negative delta for
+        genuine regressions -- if dropping the object paid 0 while grasping
+        paid +, a grasp-drop-regrasp cycle would pump unbounded reward;
+        symmetric deltas make every closed loop net exactly 0.
+   - Feed `rewards.potential_shaping(Phi(s'), Phi(s))` as the term's value
+     instead of `Phi(s')` directly. This requires tracking `Phi(s_prev)` as
+     per-episode state on the env (a plain attribute for the scalar MuJoCo
+     backend, a `(num_envs,)` tensor updated by index for the batched Warp
+     backend), seeded post-settle in `_refresh_reset_reference_state` (mirror
+     the existing `_initial_obj_z` baseline pattern) and updated once per real
+     step inside `_compute_reward`/`_compute_reward_terminated` *after* reading
+     the previous value.
+   - This is the `gamma=1` telescoping special case of `Ng, Harada & Russell,
+     "Policy Invariance Under Reward Transformations: Theory and Application to
+     Reward Shaping," ICML 1999` (Theorem 1: `F(s,a,s') = gamma*Phi(s') -
+     Phi(s)` is necessary and sufficient for the shaped MDP's optimal policy to
+     equal the unshaped MDP's). Summed over an episode it telescopes to
+     `Phi(final) - Phi(initial)`, bounded regardless of dwell time, so standing
+     still nets ~0 further reward. Use `gamma=1` rather than a full discount
+     because the env does not know the training algorithm's `gamma`; this is
+     exact at `gamma=1` and a close approximation for `gamma` near 1 (typical
+     PPO/FPO settings, 0.95-0.99). If a term's potential is genuinely
+     phase/time-dependent (not just state-dependent), see `Devlin & Kudenko,
+     "Dynamic Potential-Based Reward Shaping," AAMAS 2012` (Eq. 4), which
+     extends the same guarantee to `Phi(s, t)`.
+   - **Do not soften `success`/`terminated` itself into a continuous proxy to
+     get partial credit.** Get partial credit from the *shaping* potential
+     instead. A soft success proxy that never has to cross the real threshold
+     just relocates the exploit to a new, not-yet-discovered shape (a policy
+     that maximizes the soft proxy without ever really finishing) -- this is
+     the mistake to avoid, not a hypothetical: see the "Concrete changes"
+     section of the design note above for the reasoning trail.
+4. **Terms that are NOT part of the completion surface** (e.g. a generic
+   TCP-to-object reach term while the object is still far away) can stay flat
+   dwelling terms at a modest budget weight; not everything needs potential
+   shaping, only the specific surface a policy could exploit to avoid
+   finishing. Reserve the biggest weight cut for `completion_bonus`, not the
+   dwelling terms, if you are tuning a budget split.
+5. **Verify `terminated == success`** in both backends' `step()` (already the
+   base-class contract) so a real completion always ends the episode -- a
+   potential-based term only closes the *dwelling* exploit; if the episode
+   never ends on success, dwelling on the terminal state itself becomes the new
+   exploit.
+6. **Write the regression test before you trust the fix.** Simulate "hover"
+   (call the reward computation twice with an unchanged potential) and assert
+   the potential-shaped facet of `info["reward_components"]` is ~0 on the
+   second call; then simulate genuine progress (potential increases) and assert
+   real credit is paid. See `test_pick_and_place_hovering_earns_no_dwelling_task_objective_reward`
+   in `tests/mujoco/test_envs.py` for the pattern.
+7. Consider the sparse-reward alternative. `Andrychowicz, Wolski, Ray,
+   Schneider, Fong, Welinder, McGrew, Tobin, Abbeel & Zaremba, "Hindsight
+   Experience Replay," NeurIPS 2017 (arXiv:1707.01495)` is the other major
+   line of attack on this class of problem: train off-policy on a sparse
+   binary success signal and relabel failed trajectories with the goal they
+   *actually* reached, removing the dense-shaping exploit surface entirely by
+   not having one. Not applicable to this repo's on-policy training recipes
+   today (HER needs an off-policy, replay-buffer algorithm and a
+   goal-conditioned value function), but worth naming when proposing a new
+   training recipe, not just a new env.
+
+## Citations (primary sources, read in full before citing further)
+
+- Amodei, Olah, Steinhardt, Christiano, Schulman & Mane, "Concrete Problems in
+  AI Safety," arXiv:1606.06565 (2016). https://arxiv.org/abs/1606.06565
+- Krakovna, Uesato, Mikulik, Rahtz, Everitt, Kumar, Kenton, Leike & Legg,
+  "Specification gaming: the flip side of AI ingenuity," Google DeepMind blog
+  (2020), with the maintained master list at tinyurl.com/specification-gaming.
+  https://deepmind.google/discover/blog/specification-gaming-the-flip-side-of-ai-ingenuity/
+- Ng, Harada & Russell, "Policy Invariance Under Reward Transformations: Theory
+  and Application to Reward Shaping," ICML 1999, pp. 278-287.
+  https://people.eecs.berkeley.edu/~pabbeel/cs287-fa09/readings/NgHaradaRussell-shaping-ICML1999.pdf
+- Devlin & Kudenko, "Dynamic Potential-Based Reward Shaping," AAMAS 2012,
+  pp. 433-440. https://eprints.whiterose.ac.uk/id/eprint/75121/2/p433_devlin.pdf
+- Popov, Heess, Lillicrap, Hafner, Barth-Maron, Vecerik, Lampe, Tassa, Erez &
+  Riedmiller, "Data-efficient Deep Reinforcement Learning for Dexterous
+  Manipulation," arXiv:1704.03073 (2017). https://arxiv.org/abs/1704.03073
+- Andrychowicz, Wolski, Ray, Schneider, Fong, Welinder, McGrew, Tobin, Abbeel &
+  Zaremba, "Hindsight Experience Replay," NeurIPS 2017, arXiv:1707.01495.
+  https://arxiv.org/abs/1707.01495
+
+## Worked example
+
+`docs/superpowers/plans/2026-07-12-potential-based-task-progress-shaping.md` is
+a complete worked application of this checklist to `PickAndPlaceEnv` and
+`PickLiftEnv` (both backends): problem diagnosis, the decision with citations
+mapped to concrete design choices, exact scope, and non-goals (why
+Touch/Move/LookAt were left unchanged). Read it alongside
+`so101_nexus/rewards.py`'s `potential_shaping` and `place_task_potential`
+docstrings for the concrete implementation pattern to copy.
+
+That plan's original "Non-goals" left `reaching`/`grasping` as flat dwelling
+terms, reasoning they carried a smaller combined budget and were not (yet) an
+exploited surface -- explicitly flagged to revisit "if evidence of the same
+failure mode surfaces there." It did:
+`docs/superpowers/plans/2026-07-16-pick-grasp-potential-shaping.md` is the
+follow-up that converts `reaching`/`grasping` to potential-shaped deltas too,
+once fixing `task_objective` alone made their combined flat budget the new
+dominant dwelling ceiling. Read both plans together; the second is a second
+application of this same checklist, not a different pattern.
+
+`docs/superpowers/plans/2026-07-16-monotone-place-potential.md` is the third
+application, and the origin of checklist step 3's monotonicity walk: with
+every facet correctly delta-shaped, a recorded teleop episode's step-reward
+graph exposed that the potential itself was not monotone along the ideal
+trajectory -- the mandatory lift paid -0.09, carrying toward the goal paid
+~1e-7 (stillness-muted product), and releasing on the goal paid -0.25, so a
+perfect demonstration earned nothing but the terminal bonus. The fix swapped
+the product potential for the staged additive `place_task_potential` and
+added the `is_obj_placed` successor holds. Lesson: the 0.4.8/0.4.9 fixes
+chose the right *mechanism* (deltas) around the wrong *potential*; audit both.
+
+## Discovery
+
+The skill source lives in-repo so it is versioned with the project. To make it
+discoverable, copy or symlink this directory into
+`${CODEX_HOME:-$HOME/.codex}/skills/reward-engineering`. Keeping the source
+in-repo keeps it in sync with the codebase.

--- a/src/so101_nexus/mujoco/pick_and_place.py
+++ b/src/so101_nexus/mujoco/pick_and_place.py
@@ -29,7 +29,12 @@ from so101_nexus.mujoco.base_env import SO101NexusMuJoCoBaseEnv
 from so101_nexus.mujoco.spawn_utils import hide_freejoint_slot, place_freejoint_slot
 from so101_nexus.object_slots import ObjectSlot, build_object_scene_xml, extract_object_slots
 from so101_nexus.objects import CubeObject, YCBObject
-from so101_nexus.rewards import potential_shaping, reach_progress
+from so101_nexus.rewards import (
+    place_grasp_potential,
+    place_reach_potential,
+    place_task_potential,
+    potential_shaping,
+)
 from so101_nexus.scene import MUJOCO_SCENE_OPTION_XML
 
 _SO101_DIR = get_so101_mujoco_model_dir()
@@ -173,29 +178,25 @@ class PickAndPlaceEnv(SO101NexusMuJoCoBaseEnv):
     def _task_potential(
         self, obj_pos: np.ndarray, target_pos: np.ndarray, is_grasped: float, is_obj_placed: bool
     ) -> float:
-        """``Phi_place(s)``: joint xy/height/stillness progress toward completion.
+        """``Phi_place(s)``: staged transport-then-settle progress toward completion.
 
-        Zero unless the object has been grasped or is already placed; otherwise
-        the product of three ``[0, 1]`` progress factors (goal xy proximity,
-        height back near rest, arm stillness), so credit only accrues when every
-        sub-goal improves together -- a smooth relaxation of ``success``'s hard
-        AND. Fed through ``rewards.potential_shaping`` as a step-to-step delta
-        rather than used directly as ``task_progress``, so dwelling at any fixed
-        state (e.g. hovering the grasped object above the goal without lowering
-        it) earns ~0 further reward instead of paying this value out every step.
-        See docs/superpowers/plans/2026-07-12-potential-based-task-progress-shaping.md.
+        Thin physics-query wrapper around ``rewards.place_task_potential``,
+        which is monotone non-decreasing along the ideal grasp-lift-carry-
+        lower-settle trajectory so ``rewards.potential_shaping`` pays a
+        positive delta for forward progress and ~0 for dwelling at any fixed
+        state. See docs/superpowers/plans/2026-07-16-monotone-place-potential.md.
         """
-        scale = self.config.reward.tanh_shaping_scale
-        vscale = self.config.reward.velocity_shaping_scale
         obj_to_target_dist, _ = self._obj_placement_state(obj_pos, target_pos)
         height_gap = max(0.0, float(obj_pos[2]) - self._initial_obj_z)
         arm_speed = float(np.linalg.norm(self.data.qvel[self._arm_qvel_addrs]))
-        gate = 1.0 if (is_grasped > 0.5 or is_obj_placed) else 0.0
-        return (
-            reach_progress(obj_to_target_dist, scale=scale)
-            * reach_progress(height_gap, scale=scale)
-            * reach_progress(arm_speed, scale=vscale)
-            * gate
+        return place_task_potential(
+            obj_to_target_dist,
+            height_gap,
+            arm_speed,
+            is_grasped,
+            is_obj_placed,
+            scale=self.config.reward.tanh_shaping_scale,
+            velocity_scale=self.config.reward.velocity_shaping_scale,
         )
 
     def _get_info(self) -> dict:
@@ -225,14 +226,16 @@ class PickAndPlaceEnv(SO101NexusMuJoCoBaseEnv):
 
     def _compute_reward(self, info: dict) -> float:
         scale = self.config.reward.tanh_shaping_scale
-        # reaching/grasping are potential-shaped deltas, not raw state values --
-        # like task_progress below, both are a strict subset of `success`'s
-        # completion surface (must reach and grasp before placing), so a raw
-        # (dwelling) value lets a policy park at "reached and grasped, carrying,
-        # never placed" and collect up to their combined budget every step
-        # forever. See docs/superpowers/plans/2026-07-16-pick-grasp-potential-shaping.md.
-        reach_now = reach_progress(info["tcp_to_obj_dist"], scale=scale)
-        grasp_now = float(info["is_grasped"] > 0.5)
+        # reaching/grasping are potential-shaped deltas, not raw state values
+        # (dwelling at "reached and grasped, never placed" must pay ~0/step, see
+        # docs/superpowers/plans/2026-07-16-pick-grasp-potential-shaping.md), and
+        # both potentials are held up by is_obj_placed so the mandatory release
+        # on the goal and the post-place retreat pay no negative delta (see
+        # docs/superpowers/plans/2026-07-16-monotone-place-potential.md).
+        reach_now = place_reach_potential(
+            info["tcp_to_obj_dist"], info["is_obj_placed"], scale=scale
+        )
+        grasp_now = place_grasp_potential(info["is_grasped"], info["is_obj_placed"])
         reach_delta = potential_shaping(reach_now, self._prev_reach_progress)
         grasp_delta = potential_shaping(grasp_now, self._prev_grasp_progress)
         self._prev_reach_progress = reach_now
@@ -266,8 +269,10 @@ class PickAndPlaceEnv(SO101NexusMuJoCoBaseEnv):
         )
         scale = self.config.reward.tanh_shaping_scale
         tcp_to_obj_dist = float(np.linalg.norm(obj_pos - self._get_tcp_pose()[:3]))
-        self._prev_reach_progress = reach_progress(tcp_to_obj_dist, scale=scale)
-        self._prev_grasp_progress = is_grasped
+        self._prev_reach_progress = place_reach_potential(
+            tcp_to_obj_dist, is_obj_placed, scale=scale
+        )
+        self._prev_grasp_progress = place_grasp_potential(is_grasped, is_obj_placed)
 
     def _task_reset(self) -> None:
         rng = self.np_random

--- a/src/so101_nexus/rewards.py
+++ b/src/so101_nexus/rewards.py
@@ -134,3 +134,103 @@ def potential_shaping(potential, prev_potential):
         Potential function value at the previous state, ``Phi(s)``.
     """
     return potential - prev_potential
+
+
+def _elementwise_max(a, b):
+    """Elementwise ``max(a, b)`` across Python floats, NumPy arrays, and torch tensors."""
+    diff = b - a
+    if hasattr(diff, "clamp"):  # torch.Tensor
+        return a + diff.clamp(min=0.0)
+    if isinstance(diff, np.ndarray):
+        return a + np.clip(diff, 0.0, None)
+    return max(a, b)
+
+
+def place_reach_potential(tcp_to_obj_dist, is_obj_placed, *, scale):
+    """Reach potential for place tasks: ``max(reach_progress, is_obj_placed)``.
+
+    Once the object rests on the goal the reach sub-goal is moot, so
+    ``is_obj_placed`` holds the potential at 1.0: retreating the arm after
+    delivery pays no negative ``potential_shaping`` delta, while knocking the
+    object off the goal still does. Accepts Python scalars, NumPy arrays, or
+    torch tensors (duck-typed like ``reach_progress``).
+
+    Parameters
+    ----------
+    tcp_to_obj_dist : float or numpy.ndarray or torch.Tensor
+        Distance from the TCP to the carried object (metres).
+    is_obj_placed : bool or numpy.ndarray or torch.Tensor
+        Whether the object currently rests on the goal.
+    scale : float
+        Positive shaping steepness (``RewardConfig.tanh_shaping_scale``).
+    """
+    return _elementwise_max(reach_progress(tcp_to_obj_dist, scale=scale), is_obj_placed * 1.0)
+
+
+def place_grasp_potential(is_grasped, is_obj_placed):
+    """Grasp potential for place tasks: 1.0 while the object is held or delivered.
+
+    Raw ``is_grasped`` treats the mandatory release on the goal as a
+    regression and pays a -1 ``potential_shaping`` delta at the finish; a
+    sub-goal that a later phase must undo has to be held up by its successor
+    condition. With the ``is_obj_placed`` hold, releasing on the goal pays 0
+    while dropping the object mid-carry still pays the full negative delta.
+    Accepts Python scalars, NumPy arrays, or torch tensors.
+
+    Parameters
+    ----------
+    is_grasped : float or numpy.ndarray or torch.Tensor
+        Whether the object is currently grasped (thresholded at 0.5).
+    is_obj_placed : bool or numpy.ndarray or torch.Tensor
+        Whether the object currently rests on the goal.
+    """
+    return ((is_grasped > 0.5) | is_obj_placed) * 1.0
+
+
+def place_task_potential(
+    obj_to_target_xy, height_gap, arm_speed, is_grasped, is_obj_placed, *, scale, velocity_scale
+):
+    """``Phi_place(s)``: staged transport-then-settle place progress in [0, 1].
+
+    ``gate * 0.5 * (transport + is_obj_placed * still)`` where ``transport =
+    reach_progress(max(obj_to_target_xy, height_gap))``, ``still =
+    reach_progress(arm_speed, velocity_scale)``, and ``gate`` is
+    grasped-or-placed. Monotone non-decreasing along the ideal
+    grasp-lift-carry-lower-settle trajectory, the property a potential fed
+    through ``potential_shaping`` needs for forward progress to pay a
+    positive per-step delta:
+
+    - The Chebyshev ``max`` distance makes the mandatory lift free while far
+      from the goal (xy dominates), unlike a height-back-near-rest factor
+      (which pays negative on lift-off) or a plain 3D norm (which still dips
+      slightly), and hands the gradient to lowering once above the goal.
+    - The stillness term is additive and gated on ``is_obj_placed``
+      (ManiSkill PickCube's ``static_reward * is_obj_placed``), so it shapes
+      only the final settle instead of multiplying the transport gradient
+      down to ~0 at realistic carry speeds, which a stillness *factor* does.
+
+    See docs/superpowers/plans/2026-07-16-monotone-place-potential.md for the
+    audit that motivated this shape. Accepts Python scalars, NumPy arrays, or
+    torch tensors.
+
+    Parameters
+    ----------
+    obj_to_target_xy : float or numpy.ndarray or torch.Tensor
+        Horizontal distance from the object to the goal centre (metres).
+    height_gap : float or numpy.ndarray or torch.Tensor
+        Object height above its per-episode rest baseline, clamped >= 0 (metres).
+    arm_speed : float or numpy.ndarray or torch.Tensor
+        Norm of the arm joint velocities (rad/s).
+    is_grasped : float or numpy.ndarray or torch.Tensor
+        Whether the object is currently grasped (thresholded at 0.5).
+    is_obj_placed : bool or numpy.ndarray or torch.Tensor
+        Whether the object currently rests on the goal.
+    scale : float
+        Positive shaping steepness (``RewardConfig.tanh_shaping_scale``).
+    velocity_scale : float
+        Stillness shaping steepness (``RewardConfig.velocity_shaping_scale``).
+    """
+    gate = (is_grasped > 0.5) | is_obj_placed
+    transport = reach_progress(_elementwise_max(obj_to_target_xy, height_gap), scale=scale)
+    still = reach_progress(arm_speed, scale=velocity_scale)
+    return gate * 0.5 * (transport + is_obj_placed * still)

--- a/src/so101_nexus/warp/pick_and_place.py
+++ b/src/so101_nexus/warp/pick_and_place.py
@@ -18,7 +18,12 @@ from so101_nexus.config import ControlMode, PickAndPlaceConfig, describe_place_t
 from so101_nexus.constants import COLOR_MAP
 from so101_nexus.objects import CubeObject
 from so101_nexus.observations import ObjectOffset, ObjectPose, TargetOffset, TargetPosition
-from so101_nexus.rewards import potential_shaping, reach_progress
+from so101_nexus.rewards import (
+    place_grasp_potential,
+    place_reach_potential,
+    place_task_potential,
+    potential_shaping,
+)
 from so101_nexus.warp.object_slots import sample_polar
 from so101_nexus.warp.pick_env import WarpPickLiftVectorEnv
 
@@ -119,30 +124,27 @@ class WarpPickAndPlaceVectorEnv(WarpPickLiftVectorEnv):
         is_grasped: torch.Tensor,
         is_obj_placed: torch.Tensor,
     ) -> torch.Tensor:
-        """``Phi_place(s)``: joint xy/height/stillness progress toward completion.
+        """``Phi_place(s)``: staged transport-then-settle progress toward completion.
 
-        Batched analogue of the MuJoCo backend's ``PickAndPlaceEnv._task_potential``
-        -- zero unless the object has been grasped or is already placed, otherwise
-        the product of three ``[0, 1]`` progress factors (goal xy proximity, height
-        back near rest, arm stillness). Fed through ``rewards.potential_shaping`` as
-        a step-to-step delta rather than used directly as ``task_progress``. See
-        docs/superpowers/plans/2026-07-12-potential-based-task-progress-shaping.md.
+        Batched physics-query wrapper around ``rewards.place_task_potential``,
+        the same formula as the MuJoCo backend's ``PickAndPlaceEnv._task_potential``.
+        See docs/superpowers/plans/2026-07-16-monotone-place-potential.md.
         """
-        scale = self.config.reward.tanh_shaping_scale
-        vscale = self.config.reward.velocity_shaping_scale
         obj_to_target, _ = self._obj_placement_state(obj_pos, target_pos)
         height_gap = (obj_pos[:, 2] - self._initial_obj_z).clamp(min=0.0)
         arm_speed = torch.linalg.norm(self.qvel.index_select(1, self._arm_dof_adr), dim=1)
-        gate = ((is_grasped > 0.5) | is_obj_placed).to(torch.float32)
-        return (
-            reach_progress(obj_to_target, scale=scale)
-            * reach_progress(height_gap, scale=scale)
-            * reach_progress(arm_speed, scale=vscale)
-            * gate
+        return place_task_potential(
+            obj_to_target,
+            height_gap,
+            arm_speed,
+            is_grasped,
+            is_obj_placed,
+            scale=self.config.reward.tanh_shaping_scale,
+            velocity_scale=self.config.reward.velocity_shaping_scale,
         )
 
     def _refresh_reset_reference_state(self, mask: torch.Tensor) -> None:
-        """Refresh the placement baseline and task potential from the post-settle pose."""
+        """Refresh the placement baseline and facet potentials from the post-settle pose."""
         super()._refresh_reset_reference_state(mask)
         idx = mask.nonzero(as_tuple=True)[0]
         if idx.numel() == 0:
@@ -153,6 +155,14 @@ class WarpPickAndPlaceVectorEnv(WarpPickLiftVectorEnv):
         _, is_obj_placed = self._obj_placement_state(obj_pos, target_pos)
         potential = self._task_potential(obj_pos, target_pos, is_grasped, is_obj_placed)
         self._prev_task_potential[idx] = potential[idx]
+        # Re-seed reach/grasp over the parent's raw pick-lift potentials with
+        # the is_obj_placed-held place forms, matching _compute_reward_terminated.
+        scale = self.config.reward.tanh_shaping_scale
+        tcp_to_obj = torch.linalg.norm(obj_pos - self._tcp_pos(), dim=1)
+        self._prev_reach_progress[idx] = place_reach_potential(
+            tcp_to_obj, is_obj_placed, scale=scale
+        )[idx]
+        self._prev_grasp_progress[idx] = place_grasp_potential(is_grasped, is_obj_placed)[idx]
 
     def _task_reset(self, mask: torch.Tensor) -> None:
         idx = mask.nonzero(as_tuple=True)[0]
@@ -223,19 +233,19 @@ class WarpPickAndPlaceVectorEnv(WarpPickLiftVectorEnv):
         is_robot_static = self._is_robot_static()
         success = is_obj_placed & is_robot_static
         scale = self.config.reward.tanh_shaping_scale
-        # reaching/grasping are potential-shaped deltas, not raw state values --
-        # like task_progress below, both are a strict subset of `success`'s
-        # completion surface (must reach and grasp before placing), so a raw
-        # (dwelling) value lets a policy park at "reached and grasped, carrying,
-        # never placed" and collect up to their combined budget every step
-        # forever. Baseline seeded post-settle by the inherited
-        # ``WarpPickLiftVectorEnv._refresh_reset_reference_state``. See
-        # docs/superpowers/plans/2026-07-16-pick-grasp-potential-shaping.md.
-        reach_now = reach_progress(tcp_to_obj, scale=scale)
+        # reaching/grasping are potential-shaped deltas, not raw state values
+        # (dwelling at "reached and grasped, never placed" must pay ~0/step, see
+        # docs/superpowers/plans/2026-07-16-pick-grasp-potential-shaping.md), and
+        # both potentials are held up by is_obj_placed so the mandatory release
+        # on the goal and the post-place retreat pay no negative delta (see
+        # docs/superpowers/plans/2026-07-16-monotone-place-potential.md).
+        # Baselines seeded post-settle by _refresh_reset_reference_state.
+        reach_now = place_reach_potential(tcp_to_obj, is_obj_placed, scale=scale)
+        grasp_now = place_grasp_potential(is_grasped, is_obj_placed)
         reach_delta = potential_shaping(reach_now, self._prev_reach_progress)
-        grasp_delta = potential_shaping(is_grasped, self._prev_grasp_progress)
+        grasp_delta = potential_shaping(grasp_now, self._prev_grasp_progress)
         self._prev_reach_progress = reach_now
-        self._prev_grasp_progress = is_grasped
+        self._prev_grasp_progress = grasp_now
         # task_progress is a potential-based delta (Ng, Harada & Russell, ICML
         # 1999; see _task_potential), not the raw potential -- dwelling at any
         # fixed state pays ~0 per step instead of the potential's full value.

--- a/tests/mujoco/test_envs.py
+++ b/tests/mujoco/test_envs.py
@@ -867,6 +867,7 @@ def test_pick_and_place_success_is_reward_maximum_regardless_of_task_progress():
                 "tcp_to_obj_dist": 0.0,
                 "is_grasped": float(is_grasped),
                 "success": success,
+                "is_obj_placed": success,
                 "task_potential": task_potential,
             }
 
@@ -905,6 +906,7 @@ def test_pick_and_place_hovering_earns_no_dwelling_task_objective_reward():
             return {
                 "tcp_to_obj_dist": 0.0,
                 "is_grasped": 1.0,
+                "is_obj_placed": False,
                 "success": False,
                 "task_potential": task_potential,
             }
@@ -925,6 +927,67 @@ def test_pick_and_place_hovering_earns_no_dwelling_task_objective_reward():
         env.close()
 
 
+def test_pick_and_place_reward_nonnegative_along_ideal_trajectory():
+    """Forward progress must never pay negative reward: the facet potentials
+    are monotone non-decreasing along the ideal pick-carry-place trajectory,
+    so the mandatory lift, the transport toward the goal at realistic arm
+    speed, and the release on the goal all score >= 0, and transport pays a
+    real gradient (the stillness-multiplied product formula left ~1e-7). See
+    docs/superpowers/plans/2026-07-16-monotone-place-potential.md.
+    """
+    env = gym.make("MuJoCoPickAndPlace-v1")
+    try:
+        inner = env.unwrapped
+        inner.reset(seed=0)
+        inner._initial_obj_z = 0.0
+        target_pos = np.zeros(3)
+
+        def stage(*, tcp_to_obj, obj_xy, height, arm_speed, grasped, placed):
+            inner.data.qvel[inner._arm_qvel_addrs] = arm_speed
+            obj_pos = np.array([obj_xy, 0.0, height])
+            info = {
+                "tcp_to_obj_dist": tcp_to_obj,
+                "is_grasped": float(grasped),
+                "is_obj_placed": placed,
+                "success": False,
+                "task_potential": inner._task_potential(
+                    obj_pos, target_pos, float(grasped), placed
+                ),
+            }
+            return inner._compute_reward(info), info
+
+        # Stages: label, tcp_to_obj, obj_xy_to_goal, height, arm_speed, grasped, placed.
+        trajectory = [
+            ("reset", 0.25, 0.15, 0.0, 0.0, False, False),
+            ("approach", 0.02, 0.15, 0.0, 0.5, False, False),
+            ("grasp", 0.01, 0.15, 0.0, 0.0, True, False),
+            ("lift", 0.01, 0.15, 0.05, 0.3, True, False),
+            ("carry", 0.01, 0.07, 0.05, 0.5, True, False),
+            ("hover", 0.01, 0.01, 0.05, 0.5, True, False),
+            ("lower", 0.01, 0.005, 0.005, 0.2, True, True),
+            ("release", 0.01, 0.005, 0.0, 0.1, False, True),
+        ]
+        rewards: dict[str, float] = {}
+        infos: dict[str, dict] = {}
+        for i, (label, tcp, xy, h, speed, grasped, placed) in enumerate(trajectory):
+            reward, info = stage(
+                tcp_to_obj=tcp, obj_xy=xy, height=h, arm_speed=speed, grasped=grasped, placed=placed
+            )
+            if i > 0:  # the reset stage only seeds the _prev_* baselines
+                rewards[label], infos[label] = reward, info
+
+        negative = {label: r for label, r in rewards.items() if r < -1e-9}
+        assert not negative, f"forward progress paid negative reward: {negative}"
+        # Carrying the object toward the goal pays a real gradient even while
+        # the arm is moving, not a stillness-muted ~0.
+        assert rewards["carry"] >= 0.005
+        # Releasing the grasp on the goal is forward progress, not a -0.25
+        # grasp regression: the grasp potential is held up by is_obj_placed.
+        assert infos["release"]["reward_components"]["grasping"] == pytest.approx(0.0, abs=1e-9)
+    finally:
+        env.close()
+
+
 def test_pick_and_place_reward_components_sum_through_terminal_clamp():
     """reward_components must still sum to the reward once success lifts it to
     the full budget, and once a penalty is large enough to trigger the
@@ -939,6 +1002,7 @@ def test_pick_and_place_reward_components_sum_through_terminal_clamp():
             "is_grasped": float(is_grasped),
             "success": success,
             "task_potential": task_potential,
+            "is_obj_placed": success,
         }
 
     env = gym.make("MuJoCoPickAndPlace-v1")

--- a/tests/warp/test_warp_cross_backend_reward.py
+++ b/tests/warp/test_warp_cross_backend_reward.py
@@ -143,8 +143,8 @@ def _pick_and_place_envs():
 @pytest.mark.parametrize(
     ("obj_xy", "height", "speed", "grasped", "placed"),
     [
-        (0.02, 0.05, 1.0, 1.0, False),  # elevated, arm fast -> low potential
-        (0.02, 0.05, 0.02, 1.0, False),  # elevated, arm nearly still -> partial credit
+        (0.02, 0.05, 1.0, 1.0, False),  # carrying: transport credit at full arm speed
+        (0.02, 0.05, 0.02, 1.0, False),  # nearly still but not placed: same transport credit
         (0.0, 0.0, 0.0, 1.0, True),  # placed and still -> full potential
         (0.3, 0.05, 0.5, 0.0, False),  # ungrasped, far -> gated to 0
     ],
@@ -186,7 +186,14 @@ def test_pick_and_place_task_potential_formula_matches_mujoco(
 
 
 def _set_pick_and_place_state(
-    m, w, *, tcp_to_obj_dist: float, is_grasped: float, task_potential: float, success: bool
+    m,
+    w,
+    *,
+    tcp_to_obj_dist: float,
+    is_grasped: float,
+    task_potential: float,
+    placed: bool,
+    static: bool,
 ):
     """Stub out the geometric potential itself (covered separately above) and
     pin both backends to the same reach/grasp/placement/staticness inputs.
@@ -198,8 +205,8 @@ def _set_pick_and_place_state(
     m._get_tcp_pose = lambda: np.array([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0])
     m._is_grasping = lambda: float(is_grasped)
     m._task_potential = lambda *a, **k: task_potential
-    m._obj_placement_state = lambda *a, **k: (0.0, success)
-    m._is_robot_static = lambda: success
+    m._obj_placement_state = lambda *a, **k: (0.0, placed)
+    m._is_robot_static = lambda: static
 
     w._target_pos = lambda: torch.tensor([obj] * NUM_ENVS, dtype=torch.float32)
     w._tcp_pos = lambda: torch.zeros(NUM_ENVS, 3)
@@ -208,42 +215,53 @@ def _set_pick_and_place_state(
     w._task_potential = lambda *a, **k: torch.full((NUM_ENVS,), task_potential)
     w._obj_placement_state = lambda *a, **k: (
         torch.zeros(NUM_ENVS),
-        torch.full((NUM_ENVS,), success),
+        torch.full((NUM_ENVS,), placed, dtype=torch.bool),
     )
-    w._is_robot_static = lambda: torch.full((NUM_ENVS,), success, dtype=torch.bool)
+    w._is_robot_static = lambda: torch.full((NUM_ENVS,), static, dtype=torch.bool)
 
 
 def test_pick_and_place_reward_matches_mujoco_across_trajectory():
-    """Reach, grasp, carry (dwelling on task potential), and place-to-success
-    all pay identical reward in both backends. Companion to the PickLift
-    trajectory test above for the other multi-phase task.
+    """Reach, grasp, carry (dwelling on task potential), release on the goal,
+    and place-to-success all pay identical reward in both backends. Companion
+    to the PickLift trajectory test above for the other multi-phase task.
     """
     import torch
 
     m_env, m, w = _pick_and_place_envs()
     try:
         _reset_prev_state(m, w)
-        trajectory: list[tuple[float, float, float, bool]] = [
-            (0.30, 0.0, 0.0, False),  # reaching
-            (0.02, 0.0, 0.0, False),  # reached
-            (0.02, 1.0, 0.0, False),  # grasp
-            (0.02, 1.0, 0.35, False),  # carrying toward the goal: genuine progress
-            (0.02, 1.0, 0.35, False),  # dwell: hovering at the same potential -- must plateau
-            (0.02, 1.0, 1.0, True),  # placed and static -> success
+        trajectory: list[tuple[float, float, float, bool, bool]] = [
+            (0.30, 0.0, 0.0, False, False),  # reaching
+            (0.02, 0.0, 0.0, False, False),  # reached
+            (0.02, 1.0, 0.0, False, False),  # grasp
+            (0.02, 1.0, 0.35, False, False),  # carrying toward the goal: genuine progress
+            (
+                0.02,
+                1.0,
+                0.35,
+                False,
+                False,
+            ),  # dwell: hovering at the same potential -- must plateau
+            (0.02, 1.0, 0.9, True, False),  # lowered onto the goal, still grasped
+            (0.02, 0.0, 0.9, True, False),  # released on the goal: no grasp penalty either side
+            (0.02, 0.0, 1.0, True, True),  # static -> success
         ]
         zero = torch.zeros(NUM_ENVS)
-        for tcp_to_obj_dist, is_grasped, task_potential, success in trajectory:
+        for tcp_to_obj_dist, is_grasped, task_potential, placed, static in trajectory:
+            success = placed and static
             _set_pick_and_place_state(
                 m,
                 w,
                 tcp_to_obj_dist=tcp_to_obj_dist,
                 is_grasped=is_grasped,
                 task_potential=task_potential,
-                success=success,
+                placed=placed,
+                static=static,
             )
             info_m = {
                 "tcp_to_obj_dist": tcp_to_obj_dist,
                 "is_grasped": is_grasped,
+                "is_obj_placed": placed,
                 "task_potential": task_potential,
                 "success": success,
             }
@@ -254,7 +272,8 @@ def test_pick_and_place_reward_matches_mujoco_across_trajectory():
                 tcp_to_obj_dist,
                 is_grasped,
                 task_potential,
-                success,
+                placed,
+                static,
             )
             assert success == bool(success_w[0])
     finally:


### PR DESCRIPTION
…ectory

- Replace non-monotone Phi_place (height-back-near-rest x stillness product) with additive staged potential: gate * 0.5 * (transport + placed * still), where transport = reach_progress(max(xy_dist, height_gap)). Lift is now free (Chebyshev max), carry pays real gradient at any arm speed (stillness no longer multiplies transport), settle stillness is additive and gated on placed. Matches ManiSkill PickCube dense reward structure.

- Reach/grasp facets gain placed-hold: place_reach_potential = max(reach, placed), place_grasp_potential = grasped OR placed. Release on goal pays 0 (was -0.25); retreat after delivery pays no penalty.

- Shared tensor-agnostic formulas moved to rewards.py (place_task_potential, place_reach_potential, place_grasp_potential); both backends delegate.

- Regression test: test_pick_and_place_reward_nonnegative_along_ideal_trajectory asserts lift/carry/release stages all >= 0 and carry >= 0.005. Cross-backend trajectory test gains released-on-goal stage.

- Skill updated: added monotonicity walk step; corrected product-over-sum guidance (products mute gradients under delta-shaping); documented three traps: undo-factors, gradient-muting products, missing successor holds.

- Changelog entry under [Unreleased].
