### PR TITLE
feat(teleop): add stack-cube color customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ for the public-API and deprecation policy.
 - Side camera for human rendering and rollout video collection (MuJoCo backend; the Warp backend implements no `render()`). `RenderConfig` gains `camera` (`"overhead"` default, or `"side"` for an angled tabletop bystander view), `side_azimuth_deg`, and `side_elevation_deg`; the selected view drives `render_mode="rgb_array"` frames and the initial `render_mode="human"` viewer viewpoint. The side view is visualization-only and never enters the observation space or policy inputs.
 - `RolloutRecorder(record_side_video=True)`: record the env's configured render view as an `observation.images.side` video channel alongside policy rollout datasets (requires `render_mode="rgb_array"`); `FieldSelection` gains `side_image` (default off, existing schemas unchanged) and `teleop.dataset` exposes `SIDE_KEY`.
 - `SimCameraConfig(source="render")`: a sentinel source that reads `env.render()` instead of an observation key, so LeRobot recording flows can capture the visualization render view (e.g. the side camera) as a dataset camera.
+- Teleop stack-cube customization: `TeleopConfigOverrides.cube_a_colors`/`cube_b_colors`, UI checkbox groups ("Stack Cube A Colors" / "Stack Cube B Colors") shown for `StackCubeConfig` environments, and a `[stack_cube]` config-profile section, mirroring the existing pick-and-place cube/target color controls.
 
 ### Changed
 

--- a/docs/content/docs/teleoperation/overview.mdx
+++ b/docs/content/docs/teleoperation/overview.mdx
@@ -138,13 +138,16 @@ The **Advanced Settings** section exposes common options:
   teleop observation and recorded frame. The default is 5.
 - `Pick-and-Place Cube Colors` and `Pick-and-Place Target Colors`:
   sampled cube/target colors for pick-and-place tasks
+- `Stack Cube A Colors` and `Stack Cube B Colors`: sampled colors for the
+  two stack-cube task cubes
 - `Max Steps`: overrides the episode's step cap (default 1024)
 - `Success Hold (s)`: seconds to keep recording after the env reports success before auto-stopping (default 0.5 s, 0 = stop immediately)
 
 Options that do not apply to the selected environment are ignored after
 customization is enabled. For example, pick-object settings apply to
-`PickConfig` environments, while pick-and-place color settings apply to
-`PickAndPlaceConfig` environments.
+`PickConfig` environments, pick-and-place color settings apply to
+`PickAndPlaceConfig` environments, and stack-cube color settings apply to
+`StackCubeConfig` environments.
 
 `Reset Settle Frames` is applied to the environment config before camera
 observations are wired, so the first saved demonstration frame is captured
@@ -157,7 +160,7 @@ JSON or TOML and are merged in this order:
 
 1. flat top-level override keys
 2. `common`
-3. matching task section, either `pick` or `pick_and_place`
+3. matching task section: `pick`, `pick_and_place`, or `stack_cube`
 4. `envs.<env_id>`
 
 Later sections override earlier sections.
@@ -181,6 +184,10 @@ objects = [
 [pick_and_place]
 cube_colors = ["red", "green"]
 target_colors = ["blue"]
+
+[stack_cube]
+cube_a_colors = ["red", "orange"]
+cube_b_colors = ["blue", "green"]
 
 [envs.MuJoCoPickLift-v1]
 spawn_angle_half_range_deg = 60.0

--- a/src/so101_nexus/teleop/app.py
+++ b/src/so101_nexus/teleop/app.py
@@ -78,6 +78,7 @@ class CustomizationUIState:
     common_visible: bool = False
     pick_visible: bool = False
     pick_and_place_visible: bool = False
+    stack_visible: bool = False
     object_specs: list[str] = field(default_factory=lambda: ["cube:red"])
     n_distractors: int = 0
     ground_colors: list[str] = field(default_factory=lambda: ["gray"])
@@ -89,6 +90,8 @@ class CustomizationUIState:
     success_hold_seconds: float = 0.5
     cube_colors: list[str] = field(default_factory=lambda: ["red"])
     target_colors: list[str] = field(default_factory=lambda: ["blue"])
+    cube_a_colors: list[str] = field(default_factory=lambda: ["red"])
+    cube_b_colors: list[str] = field(default_factory=lambda: ["blue"])
 
 
 def _progress_text(completed: int, total: int) -> str:
@@ -201,7 +204,8 @@ def _customization_ui_state_from_config(config: object | None) -> CustomizationU
     common_visible = bool(common_keys & set(attrs))
     pick_visible = "objects" in attrs and "n_distractors" in attrs
     pick_and_place_visible = "cube_colors" in attrs or "target_colors" in attrs
-    customize_visible = common_visible or pick_visible or pick_and_place_visible
+    stack_visible = "cube_a_colors" in attrs or "cube_b_colors" in attrs
+    customize_visible = common_visible or pick_visible or pick_and_place_visible or stack_visible
 
     return CustomizationUIState(
         customize_visible=customize_visible,
@@ -209,6 +213,7 @@ def _customization_ui_state_from_config(config: object | None) -> CustomizationU
         common_visible=common_visible,
         pick_visible=pick_visible,
         pick_and_place_visible=pick_and_place_visible,
+        stack_visible=stack_visible,
         object_specs=_object_specs_from_config(attrs.get("objects")),
         n_distractors=int(attrs.get("n_distractors", 0)),
         ground_colors=_color_config_to_names(attrs.get("ground_colors"), ["gray"]),
@@ -220,6 +225,8 @@ def _customization_ui_state_from_config(config: object | None) -> CustomizationU
         success_hold_seconds=float(attrs.get("success_hold_seconds", 0.5)),
         cube_colors=_color_config_to_names(attrs.get("cube_colors"), ["red"]),
         target_colors=_color_config_to_names(attrs.get("target_colors"), ["blue"]),
+        cube_a_colors=_color_config_to_names(attrs.get("cube_a_colors"), ["red"]),
+        cube_b_colors=_color_config_to_names(attrs.get("cube_b_colors"), ["blue"]),
     )
 
 
@@ -465,6 +472,8 @@ def _normalized_init_config(
     reset_settle_frames: float,
     cube_color_value: list[str],
     target_color_value: list[str],
+    cube_a_color_value: list[str],
+    cube_b_color_value: list[str],
     *,
     success_hold_seconds: float = 0.5,
 ) -> dict:
@@ -502,6 +511,16 @@ def _normalized_init_config(
             target_colors=_optional_color_tuple(
                 target_color_value,
                 field_name="target_colors",
+                cube_only=True,
+            ),
+            cube_a_colors=_optional_color_tuple(
+                cube_a_color_value,
+                field_name="cube_a_colors",
+                cube_only=True,
+            ),
+            cube_b_colors=_optional_color_tuple(
+                cube_b_color_value,
+                field_name="cube_b_colors",
                 cube_only=True,
             ),
         )
@@ -603,6 +622,8 @@ def _cb_start_init(
     reset_settle_frames: float,
     cube_color_value: list[str],
     target_color_value: list[str],
+    cube_a_color_value: list[str],
+    cube_b_color_value: list[str],
     success_hold_seconds: float = 0.5,
 ):
     """Validate inputs and launch the init worker thread."""
@@ -638,6 +659,8 @@ def _cb_start_init(
         reset_settle_frames,
         cube_color_value,
         target_color_value,
+        cube_a_color_value,
+        cube_b_color_value,
         success_hold_seconds=success_hold_seconds,
     )
     if config["max_steps"] < 1:
@@ -671,6 +694,9 @@ def _cb_update_customization_for_env(env_id: str):
         gr.update(visible=state.common_visible),
         gr.update(visible=state.pick_visible),
         gr.update(visible=state.pick_and_place_visible),
+        gr.update(value=state.cube_a_colors),
+        gr.update(value=state.cube_b_colors),
+        gr.update(visible=state.stack_visible),
     )
 
 
@@ -1155,6 +1181,34 @@ def _cb_prepare_finalize_and_close():
     return gr.update(value="Finalizing dataset...", visible=True)
 
 
+def _build_cube_pair_color_group(
+    gr,
+    *,
+    visible: bool,
+    first_value: list[str],
+    first_label: str,
+    second_value: list[str],
+    second_label: str,
+):
+    """Build a visibility-gated row of two cube-color checkbox groups.
+
+    Shared by the pick-and-place (cube/target) and stack-cube (A/B) color
+    controls, which are structurally identical.
+    """
+    with gr.Group(visible=visible) as group, gr.Row():
+        first_input = gr.CheckboxGroup(
+            choices=default_cube_color_choices(),
+            value=first_value,
+            label=first_label,
+        )
+        second_input = gr.CheckboxGroup(
+            choices=default_cube_color_choices(),
+            value=second_value,
+            label=second_label,
+        )
+    return group, first_input, second_input
+
+
 def _build_setup_screen(
     gr,
     all_env_ids: list[str],
@@ -1303,22 +1357,26 @@ def _build_setup_screen(
                     step=1,
                     label="Reset Settle Frames",
                 )
-        with (
-            gr.Group(
-                visible=customization_state.pick_and_place_visible
-            ) as pick_and_place_customization_group,
-            gr.Row(),
-        ):
-            cube_colors_input = gr.CheckboxGroup(
-                choices=default_cube_color_choices(),
-                value=customization_state.cube_colors,
-                label="Pick-and-Place Cube Colors",
+        pick_and_place_customization_group, cube_colors_input, target_colors_input = (
+            _build_cube_pair_color_group(
+                gr,
+                visible=customization_state.pick_and_place_visible,
+                first_value=customization_state.cube_colors,
+                first_label="Pick-and-Place Cube Colors",
+                second_value=customization_state.target_colors,
+                second_label="Pick-and-Place Target Colors",
             )
-            target_colors_input = gr.CheckboxGroup(
-                choices=default_cube_color_choices(),
-                value=customization_state.target_colors,
-                label="Pick-and-Place Target Colors",
+        )
+        stack_customization_group, cube_a_colors_input, cube_b_colors_input = (
+            _build_cube_pair_color_group(
+                gr,
+                visible=customization_state.stack_visible,
+                first_value=customization_state.cube_a_colors,
+                first_label="Stack Cube A Colors",
+                second_value=customization_state.cube_b_colors,
+                second_label="Stack Cube B Colors",
             )
+        )
 
     init_btn = gr.Button("Initialize Session", variant="primary")
 
@@ -1357,6 +1415,9 @@ def _build_setup_screen(
         pick_and_place_customization_group,
         port_status,
         recheck_port_btn,
+        cube_a_colors_input,
+        cube_b_colors_input,
+        stack_customization_group,
     )
 
 
@@ -1667,6 +1728,9 @@ def main(
                     pick_and_place_customization_group,
                     port_status,
                     recheck_port_btn,
+                    cube_a_colors_input,
+                    cube_b_colors_input,
+                    stack_customization_group,
                 ) = _build_setup_screen(
                     gr, all_env_ids, leader_id_default, wrist_roll_offset, leader_port
                 )
@@ -1730,6 +1794,8 @@ def main(
             reset_settle_frames_input,
             cube_colors_input,
             target_colors_input,
+            cube_a_colors_input,
+            cube_b_colors_input,
             success_hold_seconds_input,
         ]
 
@@ -1759,6 +1825,9 @@ def main(
                 common_customization_group,
                 pick_customization_group,
                 pick_and_place_customization_group,
+                cube_a_colors_input,
+                cube_b_colors_input,
+                stack_customization_group,
             ],
             init_log=init_log,
             retry_btn=retry_btn,

--- a/src/so101_nexus/teleop/config_customization.py
+++ b/src/so101_nexus/teleop/config_customization.py
@@ -43,6 +43,8 @@ class TeleopConfigOverrides:
     reset_settle_frames: int | None = None
     cube_colors: tuple[ColorName, ...] | None = None
     target_colors: tuple[ColorName, ...] | None = None
+    cube_a_colors: tuple[ColorName, ...] | None = None
+    cube_b_colors: tuple[ColorName, ...] | None = None
 
     def __post_init__(self) -> None:
         """Validate override combinations that dataclass types cannot express."""
@@ -63,7 +65,7 @@ class ConfigFactoryUpdate:
 
 
 _OVERRIDE_KEYS = {field.name for field in fields(TeleopConfigOverrides)}
-_PROFILE_SECTION_KEYS = {"common", "pick", "pick_and_place", "envs"}
+_PROFILE_SECTION_KEYS = {"common", "pick", "pick_and_place", "stack_cube", "envs"}
 
 
 def default_color_choices() -> list[str]:
@@ -161,7 +163,7 @@ def apply_config_overrides[ConfigT](
     if overrides.n_distractors is not None and "n_distractors" in attrs:
         attrs["n_distractors"] = overrides.n_distractors
 
-    for name in ("cube_colors", "target_colors"):
+    for name in ("cube_colors", "target_colors", "cube_a_colors", "cube_b_colors"):
         value = _as_color_config(getattr(overrides, name))
         if value is not None and name in attrs:
             attrs[name] = value
@@ -183,6 +185,8 @@ def load_profile_overrides(
     base_attrs = vars(base_config)
     if "cube_colors" in base_attrs:
         merged.update(_mapping_section(profile, "pick_and_place"))
+    elif "cube_a_colors" in base_attrs:
+        merged.update(_mapping_section(profile, "stack_cube"))
     elif "objects" in base_attrs and "n_distractors" in base_attrs:
         merged.update(_mapping_section(profile, "pick"))
 
@@ -208,7 +212,14 @@ def overrides_from_mapping(raw: Mapping[str, Any]) -> TeleopConfigOverrides:
         kwargs["object_specs"] = tuple(str(spec) for spec in _as_sequence(raw["object_specs"]))
     if "n_distractors" in raw:
         kwargs["n_distractors"] = _as_nonnegative_int(raw["n_distractors"], "n_distractors")
-    for key in ("ground_colors", "robot_colors", "cube_colors", "target_colors"):
+    for key in (
+        "ground_colors",
+        "robot_colors",
+        "cube_colors",
+        "target_colors",
+        "cube_a_colors",
+        "cube_b_colors",
+    ):
         if key in raw:
             kwargs[key] = _color_tuple(raw[key], key)
     for key in ("spawn_min_radius", "spawn_max_radius", "spawn_angle_half_range_deg"):
@@ -255,6 +266,8 @@ def overrides_to_mapping(overrides: TeleopConfigOverrides) -> dict[str, Any]:
         "robot_colors",
         "cube_colors",
         "target_colors",
+        "cube_a_colors",
+        "cube_b_colors",
         "spawn_min_radius",
         "spawn_max_radius",
         "spawn_angle_half_range_deg",

--- a/tests/core/test_teleop_app_helpers.py
+++ b/tests/core/test_teleop_app_helpers.py
@@ -16,7 +16,7 @@ import numpy as np
 import pytest
 
 import so101_nexus.teleop.app as teleop_app
-from so101_nexus.config import PickAndPlaceConfig, PickConfig
+from so101_nexus.config import PickAndPlaceConfig, PickConfig, StackCubeConfig
 from so101_nexus.objects import CubeObject, YCBObject
 from so101_nexus.teleop.app import (
     _build_field_selection,
@@ -431,7 +431,7 @@ def test_update_customization_for_env_updates_success_hold_seconds(
 
     outputs = teleop_app._cb_update_customization_for_env("MuJoCoTouch-v1")
 
-    assert len(outputs) == 15
+    assert len(outputs) == 18
     assert outputs[11]["value"] == 1.2
 
 
@@ -493,6 +493,8 @@ def test_normalized_init_config_includes_env_overrides() -> None:
         5,
         ["red", "green"],
         ["blue"],
+        ["green"],
+        ["purple"],
     )
 
     overrides = config["env_overrides"]
@@ -506,6 +508,8 @@ def test_normalized_init_config_includes_env_overrides() -> None:
     assert overrides.reset_settle_frames == 5
     assert overrides.cube_colors == ("red", "green")
     assert overrides.target_colors == ("blue",)
+    assert overrides.cube_a_colors == ("green",)
+    assert overrides.cube_b_colors == ("purple",)
 
 
 def test_normalized_init_config_rounds_reset_settle_frames_from_ui_float() -> None:
@@ -535,6 +539,8 @@ def test_normalized_init_config_rounds_reset_settle_frames_from_ui_float() -> No
         0.30,
         90,
         2.999,
+        ["red"],
+        ["blue"],
         ["red"],
         ["blue"],
     )
@@ -571,6 +577,8 @@ def test_normalized_init_config_leaves_env_overrides_disabled_by_default() -> No
         5,
         ["red"],
         ["blue"],
+        ["red"],
+        ["blue"],
     )
 
     assert config["env_overrides"] is None
@@ -603,6 +611,8 @@ def test_normalized_init_config_includes_success_hold_seconds() -> None:
         0.30,
         90,
         5,
+        ["red"],
+        ["blue"],
         ["red"],
         ["blue"],
         success_hold_seconds=0.8,
@@ -661,6 +671,25 @@ def test_customization_ui_state_for_pick_and_place_hides_pick_controls() -> None
     assert state.robot_colors == ["yellow", "orange"]
 
 
+def test_customization_ui_state_for_stack_cube_shows_stack_colors() -> None:
+    state = teleop_app._customization_ui_state_from_config(
+        StackCubeConfig(
+            cube_a_colors=["red", "orange"],
+            cube_b_colors="blue",
+            ground_colors="gray",
+        )
+    )
+
+    assert state.customize_visible is True
+    assert state.customize_value is True
+    assert state.common_visible is True
+    assert state.pick_visible is False
+    assert state.pick_and_place_visible is False
+    assert state.stack_visible is True
+    assert state.cube_a_colors == ["red", "orange"]
+    assert state.cube_b_colors == ["blue"]
+
+
 def test_customization_ui_state_without_config_hides_customization() -> None:
     state = teleop_app._customization_ui_state_from_config(None)
 
@@ -715,6 +744,8 @@ def test_normalized_init_config_rejects_invalid_ui_color() -> None:
             5,
             ["red"],
             ["blue"],
+            ["red"],
+            ["blue"],
         )
 
 
@@ -747,6 +778,8 @@ def test_normalized_init_config_rejects_gray_pick_and_place_ui_color() -> None:
             90,
             5,
             ["gray"],
+            ["blue"],
+            ["red"],
             ["blue"],
         )
 

--- a/tests/core/test_teleop_config_customization.py
+++ b/tests/core/test_teleop_config_customization.py
@@ -122,21 +122,35 @@ def test_apply_config_overrides_ignores_pick_specific_options_for_non_pick_confi
     assert vars(cfg) == vars(base)
 
 
-def test_apply_config_overrides_applies_common_fields_to_stack_cube() -> None:
-    """StackCubeConfig has no dedicated override keys (unlike cube_colors/target_colors
-    for PickAndPlaceConfig), but still picks up common overrides generically."""
-    base = StackCubeConfig()
-
+def test_apply_config_overrides_updates_stack_cube_colors_and_common_fields() -> None:
     cfg = apply_config_overrides(
-        base,
-        TeleopConfigOverrides(ground_colors=("white",), spawn_min_radius=0.2),
+        StackCubeConfig(),
+        TeleopConfigOverrides(
+            cube_a_colors=("green",),
+            cube_b_colors=("purple",),
+            ground_colors=("white",),
+            spawn_min_radius=0.2,
+        ),
     )
 
     assert isinstance(cfg, StackCubeConfig)
+    assert cfg.cube_a_colors == ["green"]
+    assert cfg.cube_b_colors == ["purple"]
     assert cfg.ground_colors == ["white"]
     assert cfg.spawn_min_radius == 0.2
-    assert cfg.cube_a_colors == base.cube_a_colors
-    assert cfg.cube_b_colors == base.cube_b_colors
+
+
+def test_apply_config_overrides_ignores_stack_cube_colors_for_non_stack_config() -> None:
+    """cube_a_colors/cube_b_colors only apply to configs that declare those attrs."""
+    base = PickAndPlaceConfig()
+
+    cfg = apply_config_overrides(
+        base,
+        TeleopConfigOverrides(cube_a_colors=("green",), cube_b_colors=("purple",)),
+    )
+
+    assert isinstance(cfg, PickAndPlaceConfig)
+    assert vars(cfg) == vars(base)
 
 
 def test_apply_config_overrides_rejects_negative_distractors() -> None:
@@ -201,6 +215,19 @@ def test_load_profile_toml_supports_pick_and_place(tmp_path) -> None:
 
     assert overrides.cube_colors == ("red", "green")
     assert overrides.target_colors == ("blue",)
+
+
+def test_load_profile_toml_supports_stack_cube(tmp_path) -> None:
+    path = tmp_path / "profile.toml"
+    path.write_text(
+        "[stack_cube]\ncube_a_colors=['green']\ncube_b_colors=['purple']\n",
+        encoding="utf-8",
+    )
+
+    overrides = load_profile_overrides(path, "MuJoCoStackCube-v1", StackCubeConfig())
+
+    assert overrides.cube_a_colors == ("green",)
+    assert overrides.cube_b_colors == ("purple",)
 
 
 def test_load_profile_accepts_uppercase_suffix(tmp_path) -> None:

--- a/tests/mujoco/test_teleop_env_kwargs.py
+++ b/tests/mujoco/test_teleop_env_kwargs.py
@@ -65,3 +65,18 @@ def test_recording_env_kwargs_applies_pick_overrides() -> None:
     assert kwargs["config"].objects[0].color == "green"
     assert isinstance(kwargs["config"].objects[1], YCBObject)
     assert kwargs["config"].objects[1].model_id == "011_banana"
+
+
+def test_recording_env_kwargs_applies_stack_cube_overrides() -> None:
+    kwargs = _recording_env_kwargs(
+        "MuJoCoStackCube-v1",
+        (320, 240),
+        (640, 480),
+        overrides=TeleopConfigOverrides(
+            cube_a_colors=("green",),
+            cube_b_colors=("purple",),
+        ),
+    )
+
+    assert kwargs["config"].cube_a_colors == ["green"]
+    assert kwargs["config"].cube_b_colors == ["purple"]


### PR DESCRIPTION
Wire StackCubeConfig's cube_a_colors/cube_b_colors through the teleop recorder: TeleopConfigOverrides gains dedicated override fields, the Gradio UI shows Stack Cube A/B Colors checkbox groups (extracted a shared _build_cube_pair_color_group helper reused by the existing pick-and-place color row), and config profiles gain a [stack_cube] section, mirroring the existing pick-and-place cube/target color pattern end to end.

