### PR TITLE
feat(rocm): add so101-nexus[rocm] extra for AMD GPU training

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,30 @@ jobs:
           MUJOCO_GL: egl
         run: make test-warp
 
+  rocm-lock:
+    name: rocm-lock
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          enable-cache: true
+          cache-dependency-glob: ${{ env.UV_CACHE_DEPENDENCY_GLOB }}
+          cache-suffix: ci-rocm-lock
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Verify rocm extra resolves (no AMD GPU on this runner, dry-run only)
+        run: uv sync --locked --extra rocm --no-default-groups --dry-run
+
   docs:
     name: docs
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ for the public-API and deprecation policy.
 - `RolloutRecorder(record_side_video=True)`: record the env's configured render view as an `observation.images.side` video channel alongside policy rollout datasets (requires `render_mode="rgb_array"`); `FieldSelection` gains `side_image` (default off, existing schemas unchanged) and `teleop.dataset` exposes `SIDE_KEY`.
 - `SimCameraConfig(source="render")`: a sentinel source that reads `env.render()` instead of an observation key, so LeRobot recording flows can capture the visualization render view (e.g. the side camera) as a dataset camera.
 - Teleop stack-cube customization: `TeleopConfigOverrides.cube_a_colors`/`cube_b_colors`, UI checkbox groups ("Stack Cube A Colors" / "Stack Cube B Colors") shown for `StackCubeConfig` environments, and a `[stack_cube]` config-profile section, mirroring the existing pick-and-place cube/target color controls.
+- `so101-nexus[rocm]`: optional extra that routes the `train` extra's `torch` dependency (plus `pytorch-triton-rocm`/`triton-rocm`) to AMD's ROCm 7.2 PyTorch wheel index on Linux x86_64, via `tool.uv.sources`/`tool.uv.index`, for behavior-cloning and PPO training on the MuJoCo backend on AMD GPUs (`uv sync --extra train --extra rocm --no-default-groups`). No effect on the default CUDA/CPU install path for `train`/`warp`; the Warp backend remains NVIDIA-only (NVIDIA Warp has no ROCm support). `rocm` conflicts with `teleop`/`dev`/`test`, whose pinned `lerobot<0.6` requires `torch<2.11`, incompatible with the ROCm 7.2 build.
+
+### Removed
+
+- An earlier `examples/tdmpc2_warp.py` (demo-augmented TD-MPC2, MPPI planning over a learned world model) was built, smoke-tested, and then dropped before landing on `bc_ppo_warp.py` above. TD-MPC2's MPC planning is kernel-launch-latency-bound (many small sequential forward passes per action), so it does not benefit from GPU-batched Warp collection the way PPO's rollout collection does: measured steady-state throughput was ~17-70 env-steps/sec versus PPO's ~100k+ on identical hardware, and it never reliably solved this task even with demo BC-anchoring. Kept as a documented decision, not shipped.
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: format lint typecheck test test-warp test-visual test-visual-qwen coverage docs-check
+.PHONY: format lint typecheck test test-warp test-visual test-visual-qwen coverage docs-check rocm-sync rocm-verify
 
 COV_FAIL_UNDER ?= 84
 export COV_FAIL_UNDER
@@ -18,6 +18,16 @@ test:
 
 test-warp:
 	uv run --extra warp pytest tests/warp tests/core/test_rewards_tensor.py -q
+
+rocm-sync:
+	uv sync --extra rocm --no-default-groups
+
+rocm-verify: rocm-sync
+	uv run --extra rocm --no-default-groups python -c "\
+import torch; \
+hip = getattr(torch.version, 'hip', None); \
+assert hip, 'ROCm/HIP not detected in this torch build'; \
+print(f'torch {torch.__version__}  ROCm/HIP {hip}  GPU available: {torch.cuda.is_available()}')"
 
 coverage:
 	uv run pytest --cov=so101_nexus --cov-report=term-missing --cov-report=html --cov-fail-under=$(COV_FAIL_UNDER)

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ MuJoCo is the default backend. An optional MuJoCo Warp backend (`so101-nexus[war
 - **Gymnasium environments**: run SO-101 MuJoCo tasks for touch, look-at, move, pick-lift, pick-and-place, and stack-cube.
 - **Configurable curricula**: swap objects, add distractors, randomize colors, tune rewards, and choose observation components.
 - **Training and evaluation hooks**: start with the PPO baseline, LeRobot processors, and policy adapters for real-policy evaluation.
-- **GPU-parallel Warp backend** (optional, experimental): batched `Warp*-v1` vector environments for large-scale RL, installed with `so101-nexus[warp]`.
+- **GPU-parallel Warp backend** (optional, experimental): batched `Warp*-v1` vector environments for large-scale RL, installed with `so101-nexus[warp]` (NVIDIA/CUDA only).
+- **ROCm training** (optional): install PyTorch from AMD's ROCm 7.2 wheel index instead of CUDA with `so101-nexus[rocm]`, for behavior cloning and PPO on the MuJoCo backend.
 
 ## Installation
 
@@ -137,6 +138,16 @@ obs, info = envs.reset(seed=0)
 obs, reward, terminated, truncated, info = envs.step(envs.action_space.sample())
 envs.close()
 ```
+
+### Train on an AMD GPU (ROCm)
+
+`so101-nexus[rocm]` installs PyTorch from the [ROCm 7.2 wheel index](https://download.pytorch.org/whl/rocm7.2) instead of the default CUDA build, for behavior-cloning and PPO training on the (CPU-simulated) MuJoCo backend on Linux x86_64. It targets the `train` extra's torch dependency, not the GPU-parallel Warp backend: Warp is built on NVIDIA Warp, which has no ROCm/AMD support and always requires a CUDA GPU.
+
+```bash
+uv sync --extra train --extra rocm --no-default-groups
+```
+
+`--no-default-groups` skips the `dev` dependency group, which pins `lerobot<0.6` (and therefore `torch<2.11`) for the test suite, a version range incompatible with the ROCm 7.2 torch build. `uv` rejects combining `rocm` with `teleop`, `dev`, or `test` for the same reason.
 
 ### Train a policy
 

--- a/docs/content/docs/concepts/backend-support.mdx
+++ b/docs/content/docs/concepts/backend-support.mdx
@@ -36,7 +36,9 @@ MuJoCo envs support Gymnasium `render_mode="human"` and `render_mode="rgb_array"
 
 Vectorized worlds may carry different tasks, so `env.task_descriptions` holds one string per world and `info["task_description"]` is returned from `reset()` and `step()`. `env.task_description` reduces to the shared string, or a generic family string when worlds differ.
 
-The physics also diverges: Warp uses the implicit integrator without the noslip constraint, so policies may need re-tuning when moving between backends. Install the backend with the `warp` extra (`pip install "so101-nexus[warp]"`), which needs an NVIDIA GPU and CUDA >= 12.4 for GPU execution.
+The physics also diverges: Warp uses the implicit integrator without the noslip constraint, so policies may need re-tuning when moving between backends. Install the backend with the `warp` extra (`pip install "so101-nexus[warp]"`), which needs an NVIDIA GPU and CUDA >= 12.4 for GPU execution: Warp has no ROCm/AMD support, so the `rocm` extra (below) does not enable it.
+
+To train on an AMD GPU instead, install `so101-nexus[rocm]`, which routes the `train` extra's torch dependency to the ROCm 7.2 wheel index on Linux x86_64. This only affects the MuJoCo backend's training loop (behavior cloning, PPO); it has no effect on the Warp backend.
 
 ## Objects
 

--- a/docs/content/docs/getting-started/stability.mdx
+++ b/docs/content/docs/getting-started/stability.mdx
@@ -41,7 +41,8 @@ Before a public name or behavior is removed:
 
 - **Python**: 3.12 and 3.13, verified in continuous integration.
 - **Operating systems**: Linux and macOS are exercised in continuous integration for the MuJoCo backend.
-- **Backends**: the MuJoCo backend is stable. The MuJoCo Warp backend (`so101-nexus[warp]`) is experimental; its API and physics may change between minor releases, and it requires an NVIDIA GPU with CUDA >= 12.4 for GPU execution.
+- **Backends**: the MuJoCo backend is stable. The MuJoCo Warp backend (`so101-nexus[warp]`) is experimental; its API and physics may change between minor releases, and it requires an NVIDIA GPU with CUDA >= 12.4 for GPU execution. Warp has no ROCm/AMD support.
+- **Accelerators**: `so101-nexus[rocm]` installs PyTorch from AMD's ROCm 7.2 index for training on the MuJoCo backend (Linux x86_64 only); it cannot be combined with `teleop`, `dev`, or `test`, whose pinned `lerobot` version requires `torch<2.11`.
 
 ## Determinism
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,28 @@ warp = [
     "mujoco-warp>=3.9.0.1,<3.10",
     "torch",
 ]
+rocm = [
+    "torch; sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "pytorch-triton-rocm; sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "triton-rocm; sys_platform == 'linux' and platform_machine == 'x86_64'",
+]
+
+[tool.uv]
+conflicts = [
+    [{ extra = "rocm" }, { extra = "teleop" }],
+    [{ extra = "rocm" }, { group = "test" }],
+    [{ extra = "rocm" }, { group = "dev" }],
+]
+
+[tool.uv.sources]
+torch = [{ index = "pytorch-rocm", extra = "rocm" }]
+pytorch-triton-rocm = [{ index = "pytorch-rocm", extra = "rocm" }]
+triton-rocm = [{ index = "pytorch-rocm", extra = "rocm" }]
+
+[[tool.uv.index]]
+name = "pytorch-rocm"
+url = "https://download.pytorch.org/whl/rocm7.2"
+explicit = true
 
 [project.scripts]
 so101-nexus = "so101_nexus.cli:main"

--- a/tests/test_rocm_extra.py
+++ b/tests/test_rocm_extra.py
@@ -1,0 +1,59 @@
+"""Packaging checks for the ``rocm`` optional-dependency extra.
+
+Verifies ``uv sync --extra train --extra warp`` keeps resolving torch from the
+default index (no accidental breaking change) while ``--extra rocm`` is wired
+to the ROCm PyTorch index, and that the accelerator extras cannot silently
+combine with dependency sets that pin an incompatible torch range.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+ROCM_INDEX_URL = "https://download.pytorch.org/whl/rocm7.2"
+
+
+def test_rocm_extra_declared() -> None:
+    """The ``rocm`` extra exists and pulls torch plus its Triton companions."""
+    extras = PYPROJECT["project"]["optional-dependencies"]
+    assert "rocm" in extras
+    names = {dep.split(";")[0].split(">")[0].split("=")[0].strip() for dep in extras["rocm"]}
+    assert names == {"torch", "pytorch-triton-rocm", "triton-rocm"}
+
+
+def test_default_extras_do_not_reference_rocm_index() -> None:
+    """``train``/``warp`` still declare bare ``torch``, unaffected by rocm."""
+    extras = PYPROJECT["project"]["optional-dependencies"]
+    for extra in ("train", "warp"):
+        assert extras[extra].count("torch") == 1
+        assert "torch" in extras[extra]
+
+
+def test_torch_sources_route_only_the_rocm_extra_to_the_rocm_index() -> None:
+    """``tool.uv.sources`` only redirects torch (and Triton) when rocm is active."""
+    sources = PYPROJECT["tool"]["uv"]["sources"]
+    for package in ("torch", "pytorch-triton-rocm", "triton-rocm"):
+        entries = sources[package]
+        assert len(entries) == 1
+        assert entries[0]["index"] == "pytorch-rocm"
+        assert entries[0]["extra"] == "rocm"
+
+
+def test_rocm_index_is_explicit_and_points_at_rocm72() -> None:
+    """The pytorch-rocm index is explicit so it never leaks into unrelated deps."""
+    indexes = {entry["name"]: entry for entry in PYPROJECT["tool"]["uv"]["index"]}
+    assert indexes["pytorch-rocm"]["url"] == ROCM_INDEX_URL
+    assert indexes["pytorch-rocm"]["explicit"] is True
+
+
+def test_rocm_conflicts_with_extras_and_groups_pinning_incompatible_torch() -> None:
+    """rocm (torch>=2.11) can never resolve alongside lerobot's torch<2.11 pin."""
+    conflicts = PYPROJECT["tool"]["uv"]["conflicts"]
+    rocm_pairs = [{frozenset(m.items()) for m in pair} for pair in conflicts]
+    assert frozenset({("extra", "rocm")}) in {p for pair in rocm_pairs for p in pair}
+    assert {frozenset({("extra", "rocm")}), frozenset({("extra", "teleop")})} in rocm_pairs
+    assert {frozenset({("extra", "rocm")}), frozenset({("group", "test")})} in rocm_pairs
+    assert {frozenset({("extra", "rocm")}), frozenset({("group", "dev")})} in rocm_pairs

--- a/uv.lock
+++ b/uv.lock
@@ -2,25 +2,55 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform == 'darwin'",
-    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.13' and sys_platform == 'win32'",
-    "python_full_version < '3.13' and sys_platform == 'emscripten'",
-    "python_full_version < '3.13' and sys_platform == 'darwin'",
-    "python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.13' and sys_platform == 'darwin' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version < '3.14' and sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version < '3.14' and sys_platform == 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version < '3.14' and sys_platform == 'emscripten' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.14' and sys_platform == 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.14' and sys_platform == 'emscripten' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
 ]
+conflicts = [[
+    { package = "so101-nexus", extra = "rocm" },
+    { package = "so101-nexus", extra = "teleop" },
+], [
+    { package = "so101-nexus", extra = "rocm" },
+    { package = "so101-nexus", group = "test" },
+], [
+    { package = "so101-nexus", extra = "rocm" },
+    { package = "so101-nexus", group = "dev" },
+]]
 
 [[package]]
 name = "absl-py"
@@ -42,7 +72,8 @@ dependencies = [
     { name = "psutil" },
     { name = "pyyaml" },
     { name = "safetensors" },
-    { name = "torch" },
+    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "torch", version = "2.13.0+rocm7.2", source = { registry = "https://download.pytorch.org/whl/rocm7.2" }, marker = "extra == 'extra-11-so101-nexus-rocm'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ca/14/787e5498cd062640f0f3d92ef4ae4063174f76f9afd29d13fc52a319daae/accelerate-1.13.0.tar.gz", hash = "sha256:d631b4e0f5b3de4aff2d7e9e6857d164810dfc3237d54d017f075122d057b236", size = 402835, upload-time = "2026-03-04T19:34:12.359Z" }
 wheels = [
@@ -158,7 +189,7 @@ version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "frozenlist" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
@@ -189,7 +220,7 @@ version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
 wheels = [
@@ -307,11 +338,11 @@ dependencies = [
     { name = "narwhals" },
     { name = "numpy" },
     { name = "packaging" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
     { name = "pillow" },
     { name = "pyyaml" },
-    { name = "tornado", marker = "sys_platform != 'emscripten'" },
+    { name = "tornado", marker = "sys_platform != 'emscripten' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
     { name = "xyzservices" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e4/31/7ee0c4dfd0255631b0624ce01be178704f91f763f02a1879368eb109befd/bokeh-3.8.2.tar.gz", hash = "sha256:8e7dcacc21d53905581b54328ad2705954f72f2997f99fc332c1de8da53aa3cc", size = 6529251, upload-time = "2026-01-06T00:20:06.568Z" }
@@ -371,7 +402,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -485,7 +516,7 @@ name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
 wheels = [
@@ -691,14 +722,24 @@ name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
+    { name = "cuda-pathfinder", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c2/65bfd79292b8ff18be4dd7f7442cea37bcbc1a228c1886f1dea515c45b67/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:694ba35023846625ef471257e6b5a4bc8af690f961d197d77d34b1d1db393f56", size = 11760260, upload-time = "2025-10-21T14:51:40.79Z" },
     { url = "https://files.pythonhosted.org/packages/a9/c1/dabe88f52c3e3760d861401bb994df08f672ec893b8f7592dc91626adcf3/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fda147a344e8eaeca0c6ff113d2851ffca8f7dfc0a6c932374ee5c47caa649c8", size = 12151019, upload-time = "2025-10-21T14:51:43.167Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6b/9c1b1a6c01392bfdd758e9486f52a1a72bc8f49e98f9355774ef98b5fb4e/cuda_bindings-12.9.4-cp312-cp312-win_amd64.whl", hash = "sha256:696ca75d249ddf287d01b9a698b8e2d8a05046495a9c051ca15659dc52d17615", size = 11586961, upload-time = "2025-10-21T14:51:45.394Z" },
+    { url = "https://files.pythonhosted.org/packages/05/8b/b4b2d1c7775fa403b64333e720cfcfccef8dcb9cdeb99947061ca5a77628/cuda_bindings-12.9.4-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf8bfaedc238f3b115d957d1fd6562b7e8435ba57f6d0e2f87d0e7149ccb2da5", size = 11570071, upload-time = "2025-10-21T14:51:47.472Z" },
     { url = "https://files.pythonhosted.org/packages/63/56/e465c31dc9111be3441a9ba7df1941fe98f4aa6e71e8788a3fb4534ce24d/cuda_bindings-12.9.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:32bdc5a76906be4c61eb98f546a6786c5773a881f3b166486449b5d141e4a39f", size = 11906628, upload-time = "2025-10-21T14:51:49.905Z" },
+    { url = "https://files.pythonhosted.org/packages/05/d0/d0e4e2e047d8e899f023fa15ad5e9894ce951253f4c894f1cd68490fdb14/cuda_bindings-12.9.4-cp313-cp313-win_amd64.whl", hash = "sha256:a2e82c8985948f953c2be51df45c3fe11c812a928fca525154fb9503190b3e64", size = 11556719, upload-time = "2025-10-21T14:51:52.248Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/07/6aff13bc1e977e35aaa6b22f52b172e2890c608c6db22438cf7ed2bf43a6/cuda_bindings-12.9.4-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3adf4958dcf68ae7801a59b73fb00a8b37f8d0595060d66ceae111b1002de38d", size = 11566797, upload-time = "2025-10-21T14:51:54.581Z" },
     { url = "https://files.pythonhosted.org/packages/a3/84/1e6be415e37478070aeeee5884c2022713c1ecc735e6d82d744de0252eee/cuda_bindings-12.9.4-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56e0043c457a99ac473ddc926fe0dc4046694d99caef633e92601ab52cbe17eb", size = 11925991, upload-time = "2025-10-21T14:51:56.535Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/3c/972edfddb4ae8a9fccd3c3766ed47453b6f805b6026b32f10209dd4b8ad4/cuda_bindings-12.9.4-cp313-cp313t-win_amd64.whl", hash = "sha256:b32d8b685f0e66f5658bcf4601ef034e89fc2843582886f0a58784a4302da06c", size = 11894363, upload-time = "2025-10-21T14:51:58.633Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/b5/96a6696e20c4ffd2b327f54c7d0fde2259bdb998d045c25d5dedbbe30290/cuda_bindings-12.9.4-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1f53a7f453d4b2643d8663d036bafe29b5ba89eb904c133180f295df6dc151e5", size = 11624530, upload-time = "2025-10-21T14:52:01.539Z" },
     { url = "https://files.pythonhosted.org/packages/d1/af/6dfd8f2ed90b1d4719bc053ff8940e494640fe4212dc3dd72f383e4992da/cuda_bindings-12.9.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8b72ee72a9cc1b531db31eebaaee5c69a8ec3500e32c6933f2d3b15297b53686", size = 11922703, upload-time = "2025-10-21T14:52:03.585Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/87/652796522cc1a7af559460e1ce59b642e05c1468b9c08522a9a096b4cf04/cuda_bindings-12.9.4-cp314-cp314-win_amd64.whl", hash = "sha256:53a10c71fdbdb743e0268d07964e5a996dd00b4e43831cbfce9804515d97d575", size = 11517716, upload-time = "2025-10-21T14:52:06.013Z" },
+    { url = "https://files.pythonhosted.org/packages/39/73/d2fc40c043bac699c3880bf88d3cebe9d88410cd043795382826c93a89f0/cuda_bindings-12.9.4-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20f2699d61d724de3eb3f3369d57e2b245f93085cab44fd37c3bea036cea1a6f", size = 11565056, upload-time = "2025-10-21T14:52:08.338Z" },
     { url = "https://files.pythonhosted.org/packages/6c/19/90ac264acc00f6df8a49378eedec9fd2db3061bf9263bf9f39fd3d8377c3/cuda_bindings-12.9.4-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d80bffc357df9988dca279734bc9674c3934a654cab10cadeed27ce17d8635ee", size = 11924658, upload-time = "2025-10-21T14:52:10.411Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/52/a30f46e822bfa6b4a659d1e8de8c4a4adf908ea075dac568b55362541bd8/cuda_bindings-12.9.4-cp314-cp314t-win_amd64.whl", hash = "sha256:53e11991a92ff6f26a0c8a98554cd5d6721c308a6b7bfb08bebac9201e039e43", size = 12055608, upload-time = "2025-10-21T14:52:12.335Z" },
 ]
 
 [[package]]
@@ -714,21 +755,21 @@ name = "datasets"
 version = "4.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dill" },
-    { name = "filelock" },
-    { name = "fsspec", extra = ["http"] },
-    { name = "httpx" },
-    { name = "huggingface-hub" },
-    { name = "multiprocess" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pyarrow" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "tqdm" },
-    { name = "xxhash" },
+    { name = "dill", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "filelock", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "fsspec", extra = ["http"], marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "httpx", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "huggingface-hub", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "multiprocess", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "numpy", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "packaging", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "pyarrow", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "pyyaml", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "requests", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "tqdm", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "xxhash", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d7/94/eb81c6fe32e9b6ef92223141b5a553aeff2e9456968424a8533cbe88f476/datasets-4.6.1.tar.gz", hash = "sha256:140ce500bc41939ff6ce995702d66b1f4b2ee7f117bb9b07512fab6804d4070a", size = 593865, upload-time = "2026-02-27T23:26:49.482Z" }
 wheels = [
@@ -749,7 +790,7 @@ name = "deepdiff"
 version = "8.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "orderly-set" },
+    { name = "orderly-set", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/76/36c9aab3d5c19a94091f7c6c6e784efca50d87b124bf026c36e94719f33c/deepdiff-8.6.1.tar.gz", hash = "sha256:ec56d7a769ca80891b5200ec7bd41eec300ced91ebcc7797b41eb2b3f3ff643a", size = 634054, upload-time = "2025-09-03T19:40:41.461Z" }
 wheels = [
@@ -761,14 +802,14 @@ name = "diffusers"
 version = "0.35.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock" },
-    { name = "huggingface-hub" },
-    { name = "importlib-metadata" },
-    { name = "numpy" },
-    { name = "pillow" },
-    { name = "regex" },
-    { name = "requests" },
-    { name = "safetensors" },
+    { name = "filelock", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "huggingface-hub", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "importlib-metadata", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "numpy", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "pillow", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "regex", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "requests", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "safetensors", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/03/68/288ca23c7c05c73e87ffe5efffc282400ac9b017f7a9bb03883f4310ea15/diffusers-0.35.2.tar.gz", hash = "sha256:30ecd552303edfcfe1724573c3918a8462ee3ab4d529bdbd4c0045f763affded", size = 3366711, upload-time = "2025-10-15T04:05:17.213Z" }
 wheels = [
@@ -807,11 +848,11 @@ name = "draccus"
 version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mergedeep" },
-    { name = "pyyaml" },
-    { name = "pyyaml-include" },
-    { name = "toml" },
-    { name = "typing-inspect" },
+    { name = "mergedeep", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "pyyaml", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "pyyaml-include", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "toml", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "typing-inspect", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4e/e2/f5012fda17ee5d1eaf3481b6ca3e11dffa5348e5e08ab745538fdc8041bb/draccus-0.10.0.tar.gz", hash = "sha256:8dd08304219becdcd66cd16058ba98e9c3e6b7bfe48ccb9579dae39f8d37ae19", size = 62243, upload-time = "2025-02-05T07:27:48.182Z" }
 wheels = [
@@ -921,7 +962,7 @@ name = "feetech-servo-sdk"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyserial" },
+    { name = "pyserial", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5f/8e/c53d6f9a8bf3a86a635b58eeb675723f1b040f1665a0681467756c8989aa/feetech-servo-sdk-1.0.0.tar.gz", hash = "sha256:d4d3832e4b1b22a8222133a414db9f868224c2fb639426a1b11d96ddfe84e69c", size = 8392, upload-time = "2022-11-08T03:44:45.269Z" }
 
@@ -1043,7 +1084,7 @@ wheels = [
 
 [package.optional-dependencies]
 http = [
-    { name = "aiohttp" },
+    { name = "aiohttp", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
 ]
 
 [[package]]
@@ -1122,8 +1163,8 @@ dependencies = [
     { name = "numpy" },
     { name = "orjson" },
     { name = "packaging" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
     { name = "pillow" },
     { name = "pydantic" },
     { name = "pydub" },
@@ -1300,7 +1341,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
     { name = "httpx" },
     { name = "packaging" },
     { name = "pyyaml" },
@@ -1482,7 +1523,7 @@ name = "jsonlines"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
+    { name = "attrs", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/35/87/bcda8e46c88d0e34cad2f09ee2d0c7f5957bccdb9791b0b934ec84d84be4/jsonlines-4.0.0.tar.gz", hash = "sha256:0c6d2c09117550c089995247f605ae4cf77dd1533041d366351f6f298822ea74", size = 11359, upload-time = "2023-09-01T12:34:44.187Z" }
 wheels = [
@@ -1521,30 +1562,30 @@ name = "lerobot"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "accelerate" },
-    { name = "av" },
-    { name = "cmake" },
-    { name = "datasets" },
-    { name = "deepdiff" },
-    { name = "diffusers" },
-    { name = "draccus" },
-    { name = "einops" },
-    { name = "gymnasium" },
-    { name = "huggingface-hub" },
-    { name = "imageio", extra = ["ffmpeg"] },
-    { name = "jsonlines" },
-    { name = "numpy" },
-    { name = "opencv-python-headless" },
-    { name = "packaging" },
-    { name = "pynput" },
-    { name = "pyserial" },
-    { name = "rerun-sdk" },
-    { name = "setuptools" },
-    { name = "termcolor" },
-    { name = "torch" },
-    { name = "torchcodec", marker = "(platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l' and sys_platform == 'linux') or (platform_machine != 'x86_64' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')" },
-    { name = "torchvision" },
-    { name = "wandb" },
+    { name = "accelerate", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "av", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "cmake", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "datasets", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "deepdiff", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "diffusers", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "draccus", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "einops", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "gymnasium", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "huggingface-hub", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "imageio", extra = ["ffmpeg"], marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "jsonlines", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "numpy", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "opencv-python-headless", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "packaging", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "pynput", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "pyserial", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "rerun-sdk", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "setuptools", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "termcolor", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "torchcodec", marker = "(platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (platform_machine != 'x86_64' and sys_platform == 'darwin' and extra != 'extra-11-so101-nexus-rocm') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-11-so101-nexus-rocm') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test') or (sys_platform == 'darwin' and extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (sys_platform == 'darwin' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (sys_platform == 'darwin' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test') or (sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test') or (sys_platform == 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (sys_platform == 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (sys_platform == 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "torchvision", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "wandb", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8b/5f/b1f02490a6cdfc513b047effe60eee2c8fb1d1be311b9e139fb293360c45/lerobot-0.5.0.tar.gz", hash = "sha256:eab3667a0b95d60b6873d56ab95f8985ac9ac8720fe0b7e0acf9393f14f8cf3e", size = 856839, upload-time = "2026-03-09T11:19:17.1Z" }
 wheels = [
@@ -1553,7 +1594,7 @@ wheels = [
 
 [package.optional-dependencies]
 feetech = [
-    { name = "feetech-servo-sdk" },
+    { name = "feetech-servo-sdk", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
 ]
 
 [[package]]
@@ -1858,7 +1899,7 @@ name = "multiprocess"
 version = "0.70.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dill" },
+    { name = "dill", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/72/fd/2ae3826f5be24c6ed87266bc4e59c46ea5b059a103f3d7e7eb76a52aeecb/multiprocess-0.70.18.tar.gz", hash = "sha256:f9597128e6b3e67b23956da07cf3d2e5cba79e2f4e0fba8d7903636663ec6d0d", size = 1798503, upload-time = "2025-04-17T03:11:27.742Z" }
 wheels = [
@@ -1940,7 +1981,9 @@ name = "nvidia-cublas-cu12"
 version = "12.8.4.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/99/db44d685f0e257ff0e213ade1964fc459b4a690a73293220e98feb3307cf/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b86f6dd8935884615a0683b663891d43781b819ac4f2ba2b0c9604676af346d0", size = 590537124, upload-time = "2025-03-07T01:43:53.556Z" },
     { url = "https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142", size = 594346921, upload-time = "2025-03-07T01:44:31.254Z" },
+    { url = "https://files.pythonhosted.org/packages/70/61/7d7b3c70186fb651d0fbd35b01dbfc8e755f69fd58f817f3d0f642df20c3/nvidia_cublas_cu12-12.8.4.1-py3-none-win_amd64.whl", hash = "sha256:47e9b82132fa8d2b4944e708049229601448aaad7e6f296f630f2d1a32de35af", size = 567544208, upload-time = "2025-03-07T01:53:30.535Z" },
 ]
 
 [[package]]
@@ -1948,7 +1991,9 @@ name = "nvidia-cuda-cupti-cu12"
 version = "12.8.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/1f/b3bd73445e5cb342727fd24fe1f7b748f690b460acadc27ea22f904502c8/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4412396548808ddfed3f17a467b104ba7751e6b58678a4b840675c56d21cf7ed", size = 9533318, upload-time = "2025-03-07T01:40:10.421Z" },
     { url = "https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182", size = 10248621, upload-time = "2025-03-07T01:40:21.213Z" },
+    { url = "https://files.pythonhosted.org/packages/41/bc/83f5426095d93694ae39fe1311431b5d5a9bb82e48bf0dd8e19be2765942/nvidia_cuda_cupti_cu12-12.8.90-py3-none-win_amd64.whl", hash = "sha256:bb479dcdf7e6d4f8b0b01b115260399bf34154a1a2e9fe11c85c517d87efd98e", size = 7015759, upload-time = "2025-03-07T01:51:11.355Z" },
 ]
 
 [[package]]
@@ -1957,6 +2002,8 @@ version = "12.8.93"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994", size = 88040029, upload-time = "2025-03-07T01:42:13.562Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d1/e50d0acaab360482034b84b6e27ee83c6738f7d32182b987f9c7a4e32962/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc1fec1e1637854b4c0a65fb9a8346b51dd9ee69e61ebaccc82058441f15bce8", size = 43106076, upload-time = "2025-03-07T01:41:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/45/51/52a3d84baa2136cc8df15500ad731d74d3a1114d4c123e043cb608d4a32b/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-win_amd64.whl", hash = "sha256:7a4b6b2904850fe78e0bd179c4b655c404d4bb799ef03ddc60804247099ae909", size = 73586838, upload-time = "2025-03-07T01:52:13.483Z" },
 ]
 
 [[package]]
@@ -1964,7 +2011,9 @@ name = "nvidia-cuda-runtime-cu12"
 version = "12.8.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/75/f865a3b236e4647605ea34cc450900854ba123834a5f1598e160b9530c3a/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:52bf7bbee900262ffefe5e9d5a2a69a30d97e2bc5bb6cc866688caa976966e3d", size = 965265, upload-time = "2025-03-07T01:39:43.533Z" },
     { url = "https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90", size = 954765, upload-time = "2025-03-07T01:40:01.615Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a5/a515b7600ad361ea14bfa13fb4d6687abf500adc270f19e89849c0590492/nvidia_cuda_runtime_cu12-12.8.90-py3-none-win_amd64.whl", hash = "sha256:c0c6027f01505bfed6c3b21ec546f69c687689aad5f1a377554bc6ca4aa993a8", size = 944318, upload-time = "2025-03-07T01:51:01.794Z" },
 ]
 
 [[package]]
@@ -1972,10 +2021,12 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/41/e79269ce215c857c935fd86bcfe91a451a584dfc27f1e068f568b9ad1ab7/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c9132cc3f8958447b4910a1720036d9eff5928cc3179b0a51fb6d167c6cc87d8", size = 705026878, upload-time = "2025-06-06T21:52:51.348Z" },
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/90/0bd6e586701b3a890fd38aa71c387dab4883d619d6e5ad912ccbd05bfd67/nvidia_cudnn_cu12-9.10.2.21-py3-none-win_amd64.whl", hash = "sha256:c6288de7d63e6cf62988f0923f96dc339cea362decb1bf5b3141883392a7d65e", size = 692992268, upload-time = "2025-06-06T21:55:18.114Z" },
 ]
 
 [[package]]
@@ -1983,10 +2034,12 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/bc/7771846d3a0272026c416fbb7e5f4c1f146d6d80704534d0b187dd6f4800/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a", size = 193109211, upload-time = "2025-03-07T01:44:56.873Z" },
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ec/ce1629f1e478bb5ccd208986b5f9e0316a78538dd6ab1d0484f012f8e2a1/nvidia_cufft_cu12-11.3.3.83-py3-none-win_amd64.whl", hash = "sha256:7a64a98ef2a7c47f905aaf8931b69a3a43f27c55530c698bb2ed7c75c0b42cb7", size = 192216559, upload-time = "2025-03-07T01:53:57.106Z" },
 ]
 
 [[package]]
@@ -1995,6 +2048,7 @@ version = "1.13.1.3"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bb/fe/1bcba1dfbfb8d01be8d93f07bfc502c93fa23afa6fd5ab3fc7c1df71038a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc", size = 1197834, upload-time = "2025-03-07T01:45:50.723Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f5/5607710447a6fe9fd9b3283956fceeee8a06cda1d2f56ce31371f595db2a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:4beb6d4cce47c1a0f1013d72e02b0994730359e17801d395bdcbf20cfb3bb00a", size = 1120705, upload-time = "2025-03-07T01:45:41.434Z" },
 ]
 
 [[package]]
@@ -2002,7 +2056,9 @@ name = "nvidia-curand-cu12"
 version = "10.3.9.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/5e/92aa15eca622a388b80fbf8375d4760738df6285b1e92c43d37390a33a9a/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:dfab99248034673b779bc6decafdc3404a8a6f502462201f2f31f11354204acd", size = 63625754, upload-time = "2025-03-07T01:46:10.735Z" },
     { url = "https://files.pythonhosted.org/packages/fb/aa/6584b56dc84ebe9cf93226a5cde4d99080c8e90ab40f0c27bda7a0f29aa1/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9", size = 63619976, upload-time = "2025-03-07T01:46:23.323Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/75/70c05b2f3ed5be3bb30b7102b6eb78e100da4bbf6944fd6725c012831cab/nvidia_curand_cu12-10.3.9.90-py3-none-win_amd64.whl", hash = "sha256:f149a8ca457277da854f89cf282d6ef43176861926c7ac85b2a0fbd237c587ec", size = 62765309, upload-time = "2025-03-07T01:54:20.478Z" },
 ]
 
 [[package]]
@@ -2010,12 +2066,14 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "nvidia-cusparse-cu12", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/32/f7cd6ce8a7690544d084ea21c26e910a97e077c9b7f07bf5de623ee19981/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0", size = 267229841, upload-time = "2025-03-07T01:46:54.356Z" },
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c0/76ca8551b8a84146ffa189fec81c26d04adba4bc0dbe09cd6e6fd9b7de04/nvidia_cusolver_cu12-11.7.3.90-py3-none-win_amd64.whl", hash = "sha256:4a550db115fcabc4d495eb7d39ac8b58d4ab5d8e63274d3754df1c0ad6a22d34", size = 256720438, upload-time = "2025-03-07T01:54:39.898Z" },
 ]
 
 [[package]]
@@ -2023,10 +2081,12 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/f7/cd777c4109681367721b00a106f491e0d0d15cfa1fd59672ce580ce42a97/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc", size = 288117129, upload-time = "2025-03-07T01:47:40.407Z" },
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
+    { url = "https://files.pythonhosted.org/packages/62/07/f3b2ad63f8e3d257a599f422ae34eb565e70c41031aecefa3d18b62cabd1/nvidia_cusparse_cu12-12.5.8.93-py3-none-win_amd64.whl", hash = "sha256:9a33604331cb2cac199f2e7f5104dfbb8a5a898c367a53dfda9ff2acb6b6b4dd", size = 284937404, upload-time = "2025-03-07T01:55:07.742Z" },
 ]
 
 [[package]]
@@ -2034,7 +2094,9 @@ name = "nvidia-cusparselt-cu12"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/b9/598f6ff36faaece4b3c50d26f50e38661499ff34346f00e057760b35cc9d/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8878dce784d0fac90131b6817b607e803c36e629ba34dc5b433471382196b6a5", size = 283835557, upload-time = "2025-02-26T00:16:54.265Z" },
     { url = "https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623", size = 287193691, upload-time = "2025-02-26T00:15:44.104Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/d8/a6b0d0d0c2435e9310f3e2bb0d9c9dd4c33daef86aa5f30b3681defd37ea/nvidia_cusparselt_cu12-0.7.1-py3-none-win_amd64.whl", hash = "sha256:f67fbb5831940ec829c9117b7f33807db9f9678dc2a617fbe781cac17b4e1075", size = 271020911, upload-time = "2025-02-26T00:14:47.204Z" },
 ]
 
 [[package]]
@@ -2042,6 +2104,7 @@ name = "nvidia-nccl-cu12"
 version = "2.27.5"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/1c/857979db0ef194ca5e21478a0612bcdbbe59458d7694361882279947b349/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:31432ad4d1fb1004eb0c56203dc9bc2178a1ba69d1d9e02d64a6938ab5e40e7a", size = 322400625, upload-time = "2025-06-26T04:11:04.496Z" },
     { url = "https://files.pythonhosted.org/packages/6e/89/f7a07dc961b60645dbbf42e80f2bc85ade7feb9a491b11a1e973aa00071f/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ad730cf15cb5d25fe849c6e6ca9eb5b76db16a80f13f425ac68d8e2e55624457", size = 322348229, upload-time = "2025-06-26T04:11:28.385Z" },
 ]
 
@@ -2051,6 +2114,8 @@ version = "12.8.93"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88", size = 39254836, upload-time = "2025-03-07T01:49:55.661Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/a2/8cee5da30d13430e87bf99bb33455d2724d0a4a9cb5d7926d80ccb96d008/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:adccd7161ace7261e01bb91e44e88da350895c270d23f744f0820c818b7229e7", size = 38386204, upload-time = "2025-03-07T01:49:43.612Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/d7/34f02dad2e30c31b10a51f6b04e025e5dd60e5f936af9045a9b858a05383/nvidia_nvjitlink_cu12-12.8.93-py3-none-win_amd64.whl", hash = "sha256:bd93fbeeee850917903583587f4fc3a4eafa022e34572251368238ab5e6bd67f", size = 268553710, upload-time = "2025-03-07T01:56:24.13Z" },
 ]
 
 [[package]]
@@ -2058,6 +2123,7 @@ name = "nvidia-nvshmem-cu12"
 version = "3.4.5"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/6a/03aa43cc9bd3ad91553a88b5f6fb25ed6a3752ae86ce2180221962bc2aa5/nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0b48363fc6964dede448029434c6abed6c5e37f823cb43c3bcde7ecfc0457e15", size = 138936938, upload-time = "2025-09-06T00:32:05.589Z" },
     { url = "https://files.pythonhosted.org/packages/b5/09/6ea3ea725f82e1e76684f0708bbedd871fc96da89945adeba65c3835a64c/nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:042f2500f24c021db8a06c5eec2539027d57460e1c1a762055a6554f72c369bd", size = 139103095, upload-time = "2025-09-06T00:32:31.266Z" },
 ]
 
@@ -2066,7 +2132,9 @@ name = "nvidia-nvtx-cu12"
 version = "12.8.90"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/c0/1b303feea90d296f6176f32a2a70b5ef230f9bdeb3a72bddb0dc922dc137/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d7ad891da111ebafbf7e015d34879f7112832fc239ff0d7d776b6cb685274615", size = 91161, upload-time = "2025-03-07T01:42:23.922Z" },
     { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/99/4c9c0c329bf9fc125008c3b54c7c94c0023518d06fc025ae36431375e1fe/nvidia_nvtx_cu12-12.8.90-py3-none-win_amd64.whl", hash = "sha256:619c8304aedc69f02ea82dd244541a83c3d9d40993381b3b590f1adaed3db41e", size = 56492, upload-time = "2025-03-07T01:52:24.69Z" },
 ]
 
 [[package]]
@@ -2111,7 +2179,7 @@ name = "opencv-python-headless"
 version = "4.11.0.86"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/36/2f/5b2b3ba52c864848885ba988f24b7f105052f68da9ab0e693cc7c25b0b30/opencv-python-headless-4.11.0.86.tar.gz", hash = "sha256:996eb282ca4b43ec6a3972414de0e2331f5d9cda2b41091a49739c19fb843798", size = 95177929, upload-time = "2025-01-16T13:53:40.22Z" }
 wheels = [
@@ -2199,18 +2267,28 @@ name = "pandas"
 version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform == 'darwin'",
-    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version >= '3.14'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.14'" },
-    { name = "pytz", marker = "python_full_version >= '3.14'" },
-    { name = "tzdata", marker = "python_full_version >= '3.14'" },
+    { name = "numpy", marker = "python_full_version >= '3.14' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.14' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "pytz", marker = "python_full_version >= '3.14' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "tzdata", marker = "python_full_version >= '3.14' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -2254,23 +2332,33 @@ name = "pandas"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.13' and sys_platform == 'win32'",
-    "python_full_version < '3.13' and sys_platform == 'emscripten'",
-    "python_full_version < '3.13' and sys_platform == 'darwin'",
-    "python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.13' and sys_platform == 'darwin' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.14' and sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version < '3.14' and sys_platform == 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version < '3.14' and sys_platform == 'emscripten' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.14' and sys_platform == 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.14' and sys_platform == 'emscripten' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.14'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.14'" },
-    { name = "tzdata", marker = "(python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32')" },
+    { name = "numpy", marker = "python_full_version < '3.14' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "python-dateutil", marker = "python_full_version < '3.14' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "tzdata", marker = "(python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test') or (sys_platform == 'emscripten' and extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (sys_platform == 'emscripten' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (sys_platform == 'emscripten' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test') or (sys_platform == 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (sys_platform == 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (sys_platform == 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/0c/b28ed414f080ee0ad153f848586d61d1878f91689950f037f976ce15f6c8/pandas-3.0.1.tar.gz", hash = "sha256:4186a699674af418f655dbd420ed87f50d56b4cd6603784279d9eef6627823c8", size = 4641901, upload-time = "2026-02-17T22:20:16.434Z" }
 wheels = [
@@ -2712,11 +2800,11 @@ name = "pynput"
 version = "1.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "evdev", marker = "'linux' in sys_platform" },
+    { name = "evdev", marker = "('linux' in sys_platform and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
     { name = "pyobjc-framework-applicationservices", marker = "sys_platform == 'darwin'" },
     { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
-    { name = "python-xlib", marker = "'linux' in sys_platform" },
-    { name = "six" },
+    { name = "python-xlib", marker = "('linux' in sys_platform and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "six", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f0/c3/dccf44c68225046df5324db0cc7d563a560635355b3e5f1d249468268a6f/pynput-1.8.1.tar.gz", hash = "sha256:70d7c8373ee98911004a7c938742242840a5628c004573d84ba849d4601df81e", size = 82289, upload-time = "2025-03-17T17:12:01.481Z" }
 wheels = [
@@ -2845,7 +2933,7 @@ name = "pytest-cov"
 version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "coverage" },
+    { name = "coverage", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
     { name = "pluggy" },
     { name = "pytest" },
 ]
@@ -2889,11 +2977,23 @@ name = "python-xlib"
 version = "0.33"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "six" },
+    { name = "six", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/86/f5/8c0653e5bb54e0cbdfe27bf32d41f27bc4e12faa8742778c17f2a71be2c0/python-xlib-0.33.tar.gz", hash = "sha256:55af7906a2c75ce6cb280a584776080602444f75815a7aff4d287bb2d7018b32", size = 269068, upload-time = "2022-12-25T18:53:00.824Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/b8/ff33610932e0ee81ae7f1269c890f697d56ff74b9f5b2ee5d9b7fa2c5355/python_xlib-0.33-py2.py3-none-any.whl", hash = "sha256:c3534038d42e0df2f1392a1b30a15a4ff5fdc2b86cfa94f072bf11b10a164398", size = 182185, upload-time = "2022-12-25T18:52:58.662Z" },
+]
+
+[[package]]
+name = "pytorch-triton-rocm"
+version = "3.5.1"
+source = { registry = "https://download.pytorch.org/whl/rocm7.2" }
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/pytorch_triton_rocm-3.5.1-cp312-cp312-linux_x86_64.whl", upload-time = "2025-11-11T19:18:19Z" },
+    { url = "https://download-r2.pytorch.org/whl/pytorch_triton_rocm-3.5.1-cp313-cp313-linux_x86_64.whl", upload-time = "2025-11-11T19:18:19Z" },
+    { url = "https://download-r2.pytorch.org/whl/pytorch_triton_rocm-3.5.1-cp313-cp313t-linux_x86_64.whl", upload-time = "2025-11-11T19:18:19Z" },
+    { url = "https://download-r2.pytorch.org/whl/pytorch_triton_rocm-3.5.1-cp314-cp314-linux_x86_64.whl", upload-time = "2025-11-11T19:18:26Z" },
+    { url = "https://download-r2.pytorch.org/whl/pytorch_triton_rocm-3.5.1-cp314-cp314t-linux_x86_64.whl", upload-time = "2025-11-11T19:18:26Z" },
 ]
 
 [[package]]
@@ -2956,7 +3056,7 @@ name = "pyyaml-include"
 version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyyaml" },
+    { name = "pyyaml", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7f/be/2d07ad85e3d593d69640876a8686eae2c533db8cb7bf298d25c421b4d2d5/pyyaml-include-1.4.1.tar.gz", hash = "sha256:1a96e33a99a3e56235f5221273832464025f02ff3d8539309a3bf00dec624471", size = 20592, upload-time = "2024-03-25T14:56:43.748Z" }
 wheels = [
@@ -2993,7 +3093,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "rpds-py" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
@@ -3108,11 +3208,11 @@ name = "rerun-sdk"
 version = "0.26.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
-    { name = "numpy" },
-    { name = "pillow" },
-    { name = "pyarrow" },
-    { name = "typing-extensions" },
+    { name = "attrs", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "numpy", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "pillow", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "pyarrow", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "typing-extensions", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/4a/767c20e1529d74d9be5b5e55c6c26b63a6918ef3c1709fc422d08a460114/rerun_sdk-0.26.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:3d4151c9a3484e112b53d1df90c8fa07397dc7b8bfbb420f09e011eff20f1ef2", size = 93349439, upload-time = "2025-10-27T11:34:10.745Z" },
@@ -3424,16 +3524,22 @@ molmoact = [
     { name = "pillow" },
     { name = "transformers" },
 ]
+rocm = [
+    { name = "pytorch-triton-rocm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "torch", version = "2.13.0+rocm7.2", source = { registry = "https://download.pytorch.org/whl/rocm7.2" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "triton-rocm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+]
 teleop = [
     { name = "gradio" },
-    { name = "lerobot", extra = ["feetech"] },
+    { name = "lerobot", extra = ["feetech"], marker = "extra == 'extra-11-so101-nexus-teleop' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
     { name = "opencv-python" },
     { name = "pillow" },
     { name = "plotly" },
 ]
 train = [
     { name = "tensorboard" },
-    { name = "torch" },
+    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "torch", version = "2.13.0+rocm7.2", source = { registry = "https://download.pytorch.org/whl/rocm7.2" }, marker = "extra == 'extra-11-so101-nexus-rocm'" },
     { name = "wandb", extra = ["media"] },
 ]
 viz = [
@@ -3441,14 +3547,15 @@ viz = [
 ]
 warp = [
     { name = "mujoco-warp" },
-    { name = "torch" },
+    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "torch", version = "2.13.0+rocm7.2", source = { registry = "https://download.pytorch.org/whl/rocm7.2" }, marker = "extra == 'extra-11-so101-nexus-rocm'" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "hypothesis" },
-    { name = "imageio", extra = ["ffmpeg"] },
-    { name = "lerobot", extra = ["feetech"] },
+    { name = "imageio", extra = ["ffmpeg"], marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "lerobot", extra = ["feetech"], marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
     { name = "pillow" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -3457,8 +3564,8 @@ dev = [
 ]
 test = [
     { name = "hypothesis" },
-    { name = "imageio", extra = ["ffmpeg"] },
-    { name = "lerobot", extra = ["feetech"] },
+    { name = "imageio", extra = ["ffmpeg"], marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "lerobot", extra = ["feetech"], marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
     { name = "pillow" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -3485,16 +3592,19 @@ requires-dist = [
     { name = "pillow", marker = "extra == 'teleop'" },
     { name = "pillow", marker = "extra == 'viz'" },
     { name = "plotly", marker = "extra == 'teleop'", specifier = ">=6.0.0" },
+    { name = "pytorch-triton-rocm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'rocm'", index = "https://download.pytorch.org/whl/rocm7.2", conflict = { package = "so101-nexus", extra = "rocm" } },
     { name = "scipy", specifier = "<2" },
     { name = "tensorboard", marker = "extra == 'train'", specifier = ">=2.0.0" },
+    { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'rocm'", index = "https://download.pytorch.org/whl/rocm7.2", conflict = { package = "so101-nexus", extra = "rocm" } },
     { name = "torch", marker = "extra == 'train'" },
     { name = "torch", marker = "extra == 'warp'" },
     { name = "transformers", marker = "extra == 'molmoact'", specifier = ">=5.8" },
     { name = "trimesh", specifier = "<5" },
+    { name = "triton-rocm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'rocm'", index = "https://download.pytorch.org/whl/rocm7.2", conflict = { package = "so101-nexus", extra = "rocm" } },
     { name = "tyro", specifier = ">=0.9.0,<2" },
     { name = "wandb", extras = ["media"], marker = "extra == 'train'", specifier = ">=0.16.0" },
 ]
-provides-extras = ["viz", "teleop", "molmoact", "train", "warp"]
+provides-extras = ["viz", "teleop", "molmoact", "train", "warp", "rocm"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3708,31 +3818,63 @@ wheels = [
 name = "torch"
 version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.13' and sys_platform == 'darwin' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.14' and sys_platform == 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.14' and sys_platform == 'emscripten' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+    "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
+]
 dependencies = [
-    { name = "cuda-bindings", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx" },
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "setuptools" },
-    { name = "sympy" },
-    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions" },
+    { name = "cuda-bindings", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "filelock", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "fsspec", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "jinja2", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "networkx", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "nvidia-cublas-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-cudnn-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-cufft-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-cufile-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-curand-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-cusolver-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-cusparse-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-cusparselt-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-nccl-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-nvshmem-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-nvtx-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "setuptools", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "sympy", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "triton", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "typing-extensions", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
@@ -3765,16 +3907,52 @@ wheels = [
 ]
 
 [[package]]
+name = "torch"
+version = "2.13.0+rocm7.2"
+source = { registry = "https://download.pytorch.org/whl/rocm7.2" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'linux'",
+    "python_full_version < '3.14' and sys_platform == 'linux'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "filelock", marker = "extra == 'extra-11-so101-nexus-rocm'" },
+    { name = "fsspec", marker = "extra == 'extra-11-so101-nexus-rocm'" },
+    { name = "jinja2", marker = "extra == 'extra-11-so101-nexus-rocm'" },
+    { name = "networkx", marker = "extra == 'extra-11-so101-nexus-rocm'" },
+    { name = "setuptools", marker = "extra == 'extra-11-so101-nexus-rocm'" },
+    { name = "sympy", marker = "extra == 'extra-11-so101-nexus-rocm'" },
+    { name = "triton-rocm", marker = "(python_full_version < '3.15' and sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm') or (python_full_version >= '3.15' and extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (python_full_version >= '3.15' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (python_full_version >= '3.15' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test') or (sys_platform != 'linux' and extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (sys_platform != 'linux' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (sys_platform != 'linux' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "typing-extensions", marker = "extra == 'extra-11-so101-nexus-rocm'" },
+]
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/rocm7.2/torch-2.13.0%2Brocm7.2-cp312-cp312-manylinux_2_28_x86_64.whl", upload-time = "2026-07-08T11:26:11Z" },
+    { url = "https://download-r2.pytorch.org/whl/rocm7.2/torch-2.13.0%2Brocm7.2-cp313-cp313-manylinux_2_28_x86_64.whl", upload-time = "2026-07-08T11:26:11Z" },
+    { url = "https://download-r2.pytorch.org/whl/rocm7.2/torch-2.13.0%2Brocm7.2-cp314-cp314-manylinux_2_28_x86_64.whl", upload-time = "2026-07-08T11:26:20Z" },
+    { url = "https://download-r2.pytorch.org/whl/rocm7.2/torch-2.13.0%2Brocm7.2-cp314-cp314t-manylinux_2_28_x86_64.whl", upload-time = "2026-07-08T11:26:32Z" },
+    { url = "https://download-r2.pytorch.org/whl/rocm7.2/torch-2.13.0%2Brocm7.2-cp315-cp315-manylinux_2_28_x86_64.whl", upload-time = "2026-07-08T11:26:43Z" },
+    { url = "https://download-r2.pytorch.org/whl/rocm7.2/torch-2.13.0%2Brocm7.2-cp315-cp315t-manylinux_2_28_x86_64.whl", upload-time = "2026-07-08T11:28:26Z" },
+]
+
+[[package]]
 name = "torchcodec"
 version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/ff/2b27797e039673156710e5a0febe87cafc203722acafa3d34db283b40cf9/torchcodec-0.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b35fa4061c5757f8d714187c040a90a11669de6470a644bb04e3cd335ff1c110", size = 4073213, upload-time = "2026-01-22T15:41:45.485Z" },
     { url = "https://files.pythonhosted.org/packages/29/34/ccc711b6dc581e43b8d8d227e4173a8826994ee7b68d6b3d82291f307325/torchcodec-0.10.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6e43184d83ccced965b31cad5bb6200c779646fee2ec153a6d784b4def40c91b", size = 2083121, upload-time = "2026-01-22T15:41:37.947Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/6c/9af3bd945a610d6c757d898aa4624e0f5135cc8a6992d0a1d846f1084576/torchcodec-0.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:e4f022fa53d91b414b4177fe87b0afc40a806092da4595d24de4b245d6fb0fba", size = 2225338, upload-time = "2026-01-22T15:41:52.094Z" },
     { url = "https://files.pythonhosted.org/packages/d2/b6/b1041c8ccb175b08779b3e2d3e60f838bbcbfe2398d49e3673b6a66f0649/torchcodec-0.10.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:be3ce7cc667effecd06da9d0d6c5e9e347c5f376b705934e7b82378a65cf6eef", size = 4043681, upload-time = "2026-01-22T15:41:47.236Z" },
     { url = "https://files.pythonhosted.org/packages/fd/85/fc44f6d702dfd344e6859a9a4d713aaaa991578eb74677a80297d9ae8a07/torchcodec-0.10.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:71f25caf9ab89a434ae2008b1374fd98557a6864b8313b103bae53af3e6fd17f", size = 2088572, upload-time = "2026-01-22T15:41:39.203Z" },
+    { url = "https://files.pythonhosted.org/packages/df/9d/b73a0f47e11b66a1d23c7d867f12f8bb41b1b5e707d7e23d8f54793e3267/torchcodec-0.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:9e077146e894f373b805972da96aee42ff8bb87b1a3f3fb64d26925cd9e64184", size = 2225208, upload-time = "2026-01-22T15:41:53.233Z" },
     { url = "https://files.pythonhosted.org/packages/90/c9/4b6242e3456bae148f4086337d3e43d98c4e79c04091de3462db9f5eb67a/torchcodec-0.10.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bb882c12ca07dcf6d82833db67e6b565693a4bccfeab6696697620e43e465556", size = 3821202, upload-time = "2026-01-22T15:41:48.627Z" },
     { url = "https://files.pythonhosted.org/packages/96/a2/5fe0e62b208a367f741361881321c1b25de487318a44f870f326747585a1/torchcodec-0.10.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:bec2b938ad4b294bd71d0b0ab4976037c740be0c80be79e67803ebed4eff270e", size = 2089647, upload-time = "2026-01-22T15:41:40.711Z" },
+    { url = "https://files.pythonhosted.org/packages/93/71/0fc10230965e319552e064d66f1c8675b471d1b98c4a94c529e771b3c165/torchcodec-0.10.0-cp314-cp314-win_amd64.whl", hash = "sha256:4734eb82146516049e1070152eb3013d7b9689159ef35db7c0894d130d4e335d", size = 2226749, upload-time = "2026-01-22T15:41:54.393Z" },
 ]
 
 [[package]]
@@ -3782,9 +3960,9 @@ name = "torchvision"
 version = "0.25.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "pillow" },
-    { name = "torch" },
+    { name = "numpy", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "pillow", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/3a/6ea0d73f49a9bef38a1b3a92e8dd455cea58470985d25635beab93841748/torchvision-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c2abe430c90b1d5e552680037d68da4eb80a5852ebb1c811b2b89d299b10573b", size = 1874920, upload-time = "2026-01-21T16:27:45.348Z" },
@@ -3833,7 +4011,7 @@ name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
@@ -3877,11 +4055,29 @@ name = "triton"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/5d/08201db32823bdf77a0e2b9039540080b2e5c23a20706ddba942924ebcd6/triton-3.6.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:374f52c11a711fd062b4bfbb201fd9ac0a5febd28a96fb41b4a0f51dde3157f4", size = 176128243, upload-time = "2026-01-20T16:16:07.857Z" },
     { url = "https://files.pythonhosted.org/packages/ab/a8/cdf8b3e4c98132f965f88c2313a4b493266832ad47fb52f23d14d4f86bb5/triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74caf5e34b66d9f3a429af689c1c7128daba1d8208df60e81106b115c00d6fca", size = 188266850, upload-time = "2026-01-20T16:00:43.041Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/12/34d71b350e89a204c2c7777a9bba0dcf2f19a5bfdd70b57c4dbc5ffd7154/triton-3.6.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:448e02fe6dc898e9e5aa89cf0ee5c371e99df5aa5e8ad976a80b93334f3494fd", size = 176133521, upload-time = "2026-01-20T16:16:13.321Z" },
     { url = "https://files.pythonhosted.org/packages/f9/0b/37d991d8c130ce81a8728ae3c25b6e60935838e9be1b58791f5997b24a54/triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c7f76c6e72d2ef08df639e3d0d30729112f47a56b0c81672edc05ee5116ac9", size = 188289450, upload-time = "2026-01-20T16:00:49.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/4e/41b0c8033b503fd3cfcd12392cdd256945026a91ff02452bef40ec34bee7/triton-3.6.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1722e172d34e32abc3eb7711d0025bb69d7959ebea84e3b7f7a341cd7ed694d6", size = 176276087, upload-time = "2026-01-20T16:16:18.989Z" },
     { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296, upload-time = "2026-01-20T16:00:56.042Z" },
+    { url = "https://files.pythonhosted.org/packages/49/55/5ecf0dcaa0f2fbbd4420f7ef227ee3cb172e91e5fede9d0ecaddc43363b4/triton-3.6.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef5523241e7d1abca00f1d240949eebdd7c673b005edbbce0aca95b8191f1d43", size = 176138577, upload-time = "2026-01-20T16:16:25.426Z" },
     { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063, upload-time = "2026-01-20T16:01:07.278Z" },
+    { url = "https://files.pythonhosted.org/packages/48/db/56ee649cab5eaff4757541325aca81f52d02d4a7cd3506776cad2451e060/triton-3.6.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b3a97e8ed304dfa9bd23bb41ca04cdf6b2e617d5e782a8653d616037a5d537d", size = 176274804, upload-time = "2026-01-20T16:16:31.528Z" },
     { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994, upload-time = "2026-01-20T16:01:14.236Z" },
+]
+
+[[package]]
+name = "triton-rocm"
+version = "3.7.1"
+source = { registry = "https://download.pytorch.org/whl/rocm7.2" }
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/triton_rocm-3.7.1-cp312-cp312-linux_x86_64.whl", hash = "sha256:b200ade2418b8450e4e3e69c33c804e2cc07d1e36dc9678ac8ac1dd65f9e10e1", upload-time = "2026-06-17T17:05:14Z" },
+    { url = "https://download-r2.pytorch.org/whl/triton_rocm-3.7.1-cp313-cp313-linux_x86_64.whl", hash = "sha256:10f87eb1fc3fe4bbad89697c19a4e0cb8dff91e2610bd3c76a9f1fd18850d3f1", upload-time = "2026-06-17T17:05:37Z" },
+    { url = "https://download-r2.pytorch.org/whl/triton_rocm-3.7.1-cp314-cp314-linux_x86_64.whl", hash = "sha256:9165b042e35edd1201f5e579fa6074a783280b137287f47e4cdcd850c4633a54", upload-time = "2026-06-17T17:05:58Z" },
+    { url = "https://download-r2.pytorch.org/whl/triton_rocm-3.7.1-cp314-cp314t-linux_x86_64.whl", hash = "sha256:63f72fa709f2109f27438fe67a35147967d3ad1bb58fa318d9be19a45c0fb884", upload-time = "2026-06-17T17:06:22Z" },
+    { url = "https://download-r2.pytorch.org/whl/triton_rocm-3.7.1-cp315-cp315-linux_x86_64.whl", hash = "sha256:502892fc13cec6714aad5fdc757f4edcc67c61875de75003d9431d1b810ee12a", upload-time = "2026-06-17T17:06:42Z" },
+    { url = "https://download-r2.pytorch.org/whl/triton_rocm-3.7.1-cp315-cp315t-linux_x86_64.whl", hash = "sha256:fafbefa900e8e931ba8451727d1bc3c6e5819bd9cebf73a0756676b1d769a4aa", upload-time = "2026-06-17T17:07:27Z" },
 ]
 
 [[package]]
@@ -3949,8 +4145,8 @@ name = "typing-inspect"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mypy-extensions" },
-    { name = "typing-extensions" },
+    { name = "mypy-extensions", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "typing-extensions", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825, upload-time = "2023-05-24T20:25:47.612Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Adds an optional `so101-nexus[rocm]` extra that routes the `train` extra's `torch` dependency (plus `pytorch-triton-rocm`/`triton-rocm`) to AMD's ROCm 7.2 PyTorch wheel index via `tool.uv.sources`/`tool.uv.index`, gated behind the `rocm` extra so the default CUDA/CPU `train`/`warp` install path is unaffected. No install script or second venv, unlike the alternative proposed in #104.

- `rocm` extra: `torch`, `pytorch-triton-rocm`, `triton-rocm` (Linux x86_64 only)
- `tool.uv.conflicts`: `rocm` cannot combine with `teleop`/`dev`/`test`, whose pinned `lerobot<0.6` requires `torch<2.11`, incompatible with the ROCm 7.2 build
- `Makefile`: `rocm-sync`, `rocm-verify` targets
- CI: new `rocm-lock` job dry-run validates resolution (no AMD runners available)
- Docs: README, `backend-support.mdx`, `stability.mdx` clarify the Warp backend stays NVIDIA-only regardless of this extra
- `tests/test_rocm_extra.py`: packaging regression coverage

## Rebase notes

This branch was stale (15 commits behind `main`, spanning stack-cube, side-camera, potential-shaping, and teleop changes). Rebased onto current `main`:

- `CHANGELOG.md`: merged the new `Unreleased` entry into the current section; dropped stale duplicate entries from this branch's old `Unreleased` list that already shipped in 0.4.7-0.4.10 on `main`.
- `README.md` / `backend-support.mdx` / `stability.mdx`: merged cleanly against current content, re-read in full for coherence with the shipped feature set.
- `.github/workflows/ci.yml`: re-pinned the new `rocm-lock` job's `actions/checkout`, `astral-sh/setup-uv`, and `actions/setup-python` to the same hashes the rest of the workflow already carries (post the recent dependabot action-pin bump), so it isn't reintroducing stale pins.
- `uv.lock`: regenerated with `uv lock` against the merged `pyproject.toml` (textual rebase auto-merge produced an identical lock, confirmed via diff).

## Validation

- `uv lock` (regenerated, no diff vs. rebase auto-merge)
- `uv sync --locked --extra rocm --no-default-groups --dry-run` -- resolves `torch==2.13.0+rocm7.2`, `triton-rocm==3.7.1` from the ROCm index
- `make format lint typecheck` -- clean
- `make test` -- 1038 passed, 8 skipped (includes the 5 new `tests/test_rocm_extra.py` cases)
- `uv run pytest tests/test_docs_consistency.py` -- 9 passed