### PR TITLE
chore: prepare 0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ for the public-API and deprecation policy.
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Removed
+
+## [0.5.0] - 2026-07-31
+
+### Added
+
 - `so101_nexus.envhub.make_env`: a [LeRobot EnvHub](https://huggingface.co/docs/lerobot/en/envhub) entry point returning LeRobot's `{env_id: {0: vector_env}}` mapping for any registered environment on either backend. Observations use the gym-side convention `lerobot.envs.utils.preprocess_observation` consumes (`agent_pos`, `environment_state`, `pixels`), success is mirrored to `info["final_info"]["is_success"]`, and `task_description` is re-exposed on each sub-environment, so a LeRobot rollout reads instructions and success without any adaptation. Options come from an `EnvConfig` (`task`, `obs_type`, `observation_width`, `observation_height`, `episode_length`, `disable_env_checker`, plus a free-form `kwargs` dict) and from keyword arguments, which accept the same options under the name `env_id` instead of `task` and add `control_mode`, `render_mode`, `device` (Warp only) and `config` (a prebuilt `EnvironmentConfig` that takes precedence over `obs_type` and the camera resolution). Warp ids are bridged from batched torch tensors to NumPy, which costs a host copy per step; train against `gymnasium.make_vec` directly instead.
 - `envhub/`: the Hub payload published to [johnsutor/so101-nexus-envs](https://huggingface.co/johnsutor/so101-nexus-envs), one entry-point file per registered env id plus a root `env.py`. Each file is a shim over `so101_nexus.envhub`, so the environment code stays in the released package. `python scripts/publish_envhub.py` uploads it.
 - `so101_nexus.component_slice`: the flat-state slice occupied by an observation component, promoted out of `so101_nexus.testing` because the EnvHub adapter needs the same layout lookup at runtime. The public function takes the component list (`component_slice(config.observations, JointPositions)`); `so101_nexus.testing.component_slice` keeps its env-shaped signature, now delegates, and raises `ValueError` instead of `AssertionError` when the component is absent.
@@ -404,7 +414,8 @@ for the public-API and deprecation policy.
 
 - Initial release: SO-101 MuJoCo simulation with cameras, GitHub Actions CI, and the core project structure.
 
-[Unreleased]: https://github.com/johnsutor/so101-nexus/compare/0.4.13...HEAD
+[Unreleased]: https://github.com/johnsutor/so101-nexus/compare/0.5.0...HEAD
+[0.5.0]: https://github.com/johnsutor/so101-nexus/compare/0.4.13...0.5.0
 [0.4.13]: https://github.com/johnsutor/so101-nexus/compare/0.4.12...0.4.13
 [0.4.12]: https://github.com/johnsutor/so101-nexus/compare/0.4.11...0.4.12
 [0.4.11]: https://github.com/johnsutor/so101-nexus/compare/0.4.10...0.4.11

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,13 +3,13 @@
 ## Supported versions
 
 SO101-Nexus is pre-1.0 and under active development. Security fixes are applied to
-the latest released minor version, currently the `0.4.x` series. Please upgrade to
+the latest released minor version, currently the `0.5.x` series. Please upgrade to
 the most recent release before reporting an issue.
 
 | Version | Supported |
 | ------- | --------- |
-| 0.4.x   | Yes       |
-| < 0.4   | No        |
+| 0.5.x   | Yes       |
+| < 0.5   | No        |
 
 ## Reporting a vulnerability
 

--- a/docs/content/docs/api/stability.mdx
+++ b/docs/content/docs/api/stability.mdx
@@ -23,11 +23,11 @@ Import public objects from `so101_nexus`, not from backend submodules.
 
 ## Versioning policy
 
-- **Patch** (`0.4.x`): bug fixes and additive, backward-compatible changes only.
+- **Patch** (`0.5.x`): bug fixes and additive, backward-compatible changes only.
 - **Minor** (`0.x.0`): new features. While the project is pre-1.0, a minor release may include a documented breaking change to the public API.
 - **Major** (`x.0.0`, from 1.0.0 onward): reserved for breaking changes to the public API.
 
-Until 1.0.0 the public API is still stabilizing, so pin a version range (for example `so101-nexus~=0.4`) if you need reproducible behavior. Every change is recorded in the [changelog](https://github.com/johnsutor/so101-nexus/blob/main/CHANGELOG.md).
+Until 1.0.0 the public API is still stabilizing, so pin a version range (for example `so101-nexus~=0.5`) if you need reproducible behavior. Every change is recorded in the [changelog](https://github.com/johnsutor/so101-nexus/blob/main/CHANGELOG.md).
 
 ## Deprecation process
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "so101-nexus"
-version = "0.4.13"
+version = "0.5.0"
 description = "End-to-end simulation and training stack for the SO-101 arm: record demonstrations, clone behavior, and reinforce with GPU-parallel MuJoCo / MuJoCo Warp environments, built on LeRobot"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -3504,7 +3504,7 @@ wheels = [
 
 [[package]]
 name = "so101-nexus"
-version = "0.4.13"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "gymnasium" },


### PR DESCRIPTION
## What changed

Release preparation only. No library code is touched.

| File | Change |
| --- | --- |
| `pyproject.toml` | `version` `0.4.13` -> `0.5.0` |
| `uv.lock` | regenerated with `uv lock` (self-entry only) |
| `CHANGELOG.md` | `[Unreleased]` body cut under a dated `## [0.5.0] - 2026-07-31` heading, fresh empty scaffold, `[Unreleased]` compare link retargeted to `0.5.0...HEAD`, `[0.5.0]` compare link added |
| `SECURITY.md` | supported series `0.4.x` -> `0.5.x` (prose and table) |
| `docs/content/docs/api/stability.mdx` | patch example `0.4.x` -> `0.5.x`, pin example `so101-nexus~=0.4` -> `~=0.5` |

Follows steps 1 and 2 of the release process in `CONTRIBUTING.md`.

## Why

0.5.0 rather than 0.4.14. The six changes since 0.4.13 (#144, #145, #146, #147, #148, #149) include five documented breaks:

- default observation dimensions grew (pick-lift and touch 30 -> 31, pick-and-place and stack-cube 36 -> 43, look-at 22 -> 23)
- the gaze ray is anchored at the wrist camera instead of the gripper tip
- `GraspState` now requires opposing contact normals
- `so101_nexus.policy_adapters.MolmoActPolicy` and the `molmoact` extra are removed
- documentation URLs moved in the progressive-disclosure restructure

The pre-1.0 policy on the stability page puts a documented break in a minor release, so the patch series has to roll over. That also makes the `0.4.x` supported-series and `~=0.4` pin examples stale, hence the `SECURITY.md` and `stability.mdx` edits.

Two things were checked and deliberately left alone:

- `envhub/requirements.txt` and `envhub/README.md` already pin `so101-nexus>=0.5.0`; #148 landed them in anticipation of this release.
- `examples/bc_ppo_warp.py` cites `so101-nexus==0.4.10` as the version a validated 3-seed recipe was measured on. That is provenance, not a supported floor.

All six PRs since 0.4.13 touched `CHANGELOG.md`, so nothing was missing from `[Unreleased]`.

## Validation

- `make format lint typecheck` - clean, no reformatting
- `make test` - 1501 passed, 2 skipped (visual tests, no model configured), coverage 92.80% against the 84% gate
- `make test-warp` - 223 passed
- `uv build` - builds `so101_nexus-0.5.0.tar.gz` and `so101_nexus-0.5.0-py3-none-any.whl`
- `uv run pytest tests/test_docs_consistency.py -q` - 15 passed (nav reachability, internal links, API headings, American English)
- `uv run python -c "import so101_nexus; print(so101_nexus.__version__)"` - `0.5.0`

## Notes for the tagger

Tag this `0.5.0`, not `v0.5.0`. The repository has one stray `v0.4.10` tag, but every `CHANGELOG.md` compare link assumes the unprefixed form and a `v`-prefixed tag would 404 them.

Publishing the EnvHub payload is a separate manual step (`python scripts/publish_envhub.py`); it is not part of the publish workflow.

## Checklist

- [ ] Tests added or updated (regression test for a fix; happy path plus an edge case for new behavior). Not applicable: version and documentation metadata only, no behavior change. The existing suite covers the bumped package.
- [x] `make format lint typecheck` and the relevant tests pass locally.
- [x] Documentation updated if the public API or behavior changed.
- [x] `CHANGELOG.md` `## [Unreleased]` entry added for any user-facing change.
- [x] No em dashes or emoji in prose, docs, or comments.

