### PR TITLE
fix(examples): rebuild the env from the checkpoint observation layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ for the public-API and deprecation policy.
 ### Fixed
 
 - `examples/eval_warp.py` and `examples/ppo_warp.py`'s `rollout_video_from_checkpoint` now rebuild the environment from the observation layout the checkpoint records (`env_state_names`), instead of always using the environment's current default. A demo-seeded `examples/bc_ppo_warp.py` checkpoint pins the layout its demo dataset declares, so since the 0.5.0 default-observation growth (`gaze_state`, `object_velocity`) evaluating one raised `RuntimeError: size mismatch for actor_mean.0.weight`. This is the evaluation step both Colab notebooks and the training guide's quick start run. `eval_warp.py` also prints a line when the pinned layout is not the current default, since a silently stale layout otherwise reports plausible-looking numbers. `examples/ppo_warp.py` gained the `observations=` keyword on `_make_envs` and `evaluate_mujoco` plus the `_mujoco_config` helper, so it stays a byte-identical mirror of `examples/bc_ppo_warp.py` for every shared helper.
+- Docs and the BC Colab notebook told readers to disable demo seeding with `--use-demos false`, which `tyro` rejects as an unrecognized option. The flag is `--no-use-demos`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ for the public-API and deprecation policy.
 
 ### Fixed
 
+- `examples/eval_warp.py` and `examples/ppo_warp.py`'s `rollout_video_from_checkpoint` now rebuild the environment from the observation layout the checkpoint records (`env_state_names`), instead of always using the environment's current default. A demo-seeded `examples/bc_ppo_warp.py` checkpoint pins the layout its demo dataset declares, so since the 0.5.0 default-observation growth (`gaze_state`, `object_velocity`) evaluating one raised `RuntimeError: size mismatch for actor_mean.0.weight`. This is the evaluation step both Colab notebooks and the training guide's quick start run. `eval_warp.py` also prints a line when the pinned layout is not the current default, since a silently stale layout otherwise reports plausible-looking numbers. `examples/ppo_warp.py` gained the `observations=` keyword on `_make_envs` and `evaluate_mujoco` plus the `_mujoco_config` helper, so it stays a byte-identical mirror of `examples/bc_ppo_warp.py` for every shared helper.
+
 ### Removed
 
 ## [0.5.0] - 2026-07-31

--- a/docs/content/docs/workflow/training.mdx
+++ b/docs/content/docs/workflow/training.mdx
@@ -7,7 +7,7 @@ Two scripts cover the clone and reinforce stages. `examples/bc_ppo_warp.py` is t
 recommendation: it BC-pretrains the actor on teleoperation demonstrations, then runs
 GPU-parallel PPO with a persistent BC loss anchoring the actor to those demos.
 `examples/ppo_warp.py` is the same recipe with no demos, trained from scratch, and
-`--use-demos false` makes `bc_ppo_warp.py` recover it exactly. `examples/ppo.py` is a slow
+`--no-use-demos` makes `bc_ppo_warp.py` recover it exactly. `examples/ppo.py` is a slow
 single-environment MuJoCo reference, useful for sanity checks but not the recommended path.
 
 ## Quick start
@@ -117,7 +117,7 @@ uv run --extra warp --extra train python examples/bc_ppo_warp.py \
 | Flag | Default | Meaning |
 | --- | --- | --- |
 | `--demo-repo` | `johnsutor/MuJoCoPickLift-v1` | Dataset the actor is cloned from |
-| `--use-demos` | `true` | Seed the actor from demos before PPO. `false` gives pure PPO |
+| `--use-demos` / `--no-use-demos` | `--use-demos` | Seed the actor from demos before PPO. `--no-use-demos` gives pure PPO |
 | `--bc-pretrain-updates` | `2000` | Supervised steps regressing the actor mean onto demo actions |
 | `--bc-pretrain-lr` | `1e-3` | Learning rate for the pretrain phase |
 | `--bc-coef` | `0.1` | Weight of the persistent BC loss added to every PPO minibatch |
@@ -166,12 +166,14 @@ deterministic.
 
 <Callout type="warn">
 **Observation layout is pinned by the dataset.** A policy has to consume exactly the state
-layout its demonstrations recorded, so with `--use-demos true` the script builds both the Warp
-training env and the MuJoCo evaluator from the layout the dataset declares, not from the
-environment's current default. When the two differ, for example a dataset recorded before
-`gaze_state` joined the defaults, the run prints the pinned width and the missing components
-at startup, and the resulting checkpoint only loads against that layout. Re-record the demos
-to train on the current default. See [Observations](/docs/concepts/observations).
+layout its demonstrations recorded, so with demo seeding on (the default) the script builds
+both the Warp training env and the MuJoCo evaluator from the layout the dataset declares, not
+from the environment's current default. When the two differ, for example a dataset recorded
+before `gaze_state` joined the defaults, the run prints the pinned width and the missing
+components at startup, and the resulting checkpoint only loads against that layout. The
+checkpoint records that layout, so `eval_warp.py` and `rollout_video_from_checkpoint` rebuild
+a matching env automatically. Re-record the demos to train on the current default. See
+[Observations](/docs/concepts/observations).
 </Callout>
 
 <Callout type="warn">

--- a/examples/README.md
+++ b/examples/README.md
@@ -184,6 +184,10 @@ uv run --extra warp python examples/eval_warp.py \
   --checkpoint "runs/WarpPickLift-v1__*/best_agent.pt"
 ```
 
+This works for `bc_ppo_warp.py` checkpoints too: a checkpoint records the observation
+layout it was trained on, so the evaluator rebuilds a matching environment instead of
+assuming the environment's current default.
+
 ### Train in Colab
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/johnsutor/so101-nexus/blob/main/examples/ppo_warp_colab.ipynb)
@@ -236,7 +240,7 @@ alternative is designed but not yet built; see
   before the PPO loop starts; the persistent `--bc-coef` term adds the same MSE loss
   into every PPO minibatch update afterward, optionally annealed via
   `--bc-anneal-steps`.
-- **`--use-demos false` recovers `ppo_warp.py` exactly** (same Agent, same env
+- **`--no-use-demos` recovers `ppo_warp.py` exactly** (same Agent, same env
   helpers, same PPO loss): this file is a strict superset, not a fork with
   behavior drift.
 
@@ -253,7 +257,7 @@ above, plus:
 
 | Argument | Value |
 |---|---:|
-| `--use-demos` | `true` |
+| `--use-demos` / `--no-use-demos` | `--use-demos` |
 | `--bc-pretrain-updates` | `2000` |
 | `--bc-pretrain-lr` | `1e-3` |
 | `--bc-coef` | `0.1` |

--- a/examples/bc_ppo_warp_colab.ipynb
+++ b/examples/bc_ppo_warp_colab.ipynb
@@ -200,7 +200,7 @@
    "source": [
     "## Next steps\n",
     "\n",
-    "- Compare against vanilla PPO by rerunning with `--use-demos false`.\n",
+    "- Compare against vanilla PPO by rerunning with `--no-use-demos`.\n",
     "- Full walkthrough: [Training with PPO](https://so101-nexus.com/docs/training/ppo)."
    ]
   }

--- a/examples/eval_warp.py
+++ b/examples/eval_warp.py
@@ -1,4 +1,4 @@
-"""Deterministic evaluation of a `ppo_warp.py` checkpoint on the Warp backend.
+"""Deterministic evaluation of a `ppo_warp.py` / `bc_ppo_warp.py` checkpoint on Warp.
 
 Loads a saved agent + obs-normalization stats, runs the *deterministic* policy
 (mean action, no exploration noise) for full fixed-horizon episodes across a batch of
@@ -11,6 +11,11 @@ Usage::
 
     uv run --extra warp python examples/eval_warp.py --checkpoint runs/.../best_agent.pt
     uv run --extra warp python examples/eval_warp.py  # globs the latest best_agent.pt
+
+When a checkpoint records the observation layout it was trained on, the env is rebuilt
+with that layout so the saved network's input width still matches. ``bc_ppo_warp.py``
+records the layout its demo dataset declares, which is narrower than the env default
+whenever a component joined the defaults after the demos were recorded.
 """
 
 from __future__ import annotations
@@ -25,10 +30,16 @@ from dataclasses import dataclass
 import numpy as np
 import torch
 
+from so101_nexus import observations_from_feature_names, privileged_state_feature_names
+
 try:
-    from examples.ppo_warp import Agent, _make_envs
+    from examples.ppo_warp import Agent, _make_envs, _resolve_env_cls
 except ImportError:  # when run as `python examples/eval_warp.py`
-    from ppo_warp import Agent, _make_envs  # ty: ignore[unresolved-import]
+    from ppo_warp import (  # ty: ignore[unresolved-import]
+        Agent,
+        _make_envs,
+        _resolve_env_cls,
+    )
 
 
 @dataclass
@@ -36,7 +47,7 @@ class Args:
     """Deterministic-eval configuration."""
 
     checkpoint: str = "runs/WarpPickLift-v1__*/best_agent.pt"
-    """path or glob to a `ppo_warp.py` checkpoint (latest match is used for a glob)"""
+    """path or glob to a training checkpoint (latest match is used for a glob)"""
     env_id: str = "WarpPickLift-v1"
     num_envs: int = 512
     episode_length: int = 512
@@ -58,6 +69,15 @@ def main():
     ckpt = torch.load(path, map_location=device, weights_only=False)
     print(f"[eval] checkpoint={path} trained_step={ckpt['step']} saved_success={ckpt['success']}")
 
+    names = ckpt.get("env_state_names")
+    default = privileged_state_feature_names(
+        _resolve_env_cls(args.env_id).default_config_cls().observations
+    )
+    if names and list(names) != default:
+        # Silently evaluating a stale layout would report plausible-looking numbers.
+        print(
+            f"[eval] checkpoint pins a {len(names)}-dim layout, not the {len(default)}-dim default"
+        )
     envs = _make_envs(
         args.env_id,
         args.num_envs,
@@ -65,6 +85,7 @@ def main():
         args.seed,
         control_mode=args.control_mode,
         episode_length=args.episode_length,
+        observations=None if not names else observations_from_feature_names(names),
     )
     obs_dim = int(np.prod(envs.single_observation_space.shape))
     act_dim = int(np.prod(envs.single_action_space.shape))

--- a/examples/ppo_warp.py
+++ b/examples/ppo_warp.py
@@ -56,6 +56,7 @@ import numpy as np
 import torch
 from torch import nn
 
+from so101_nexus import observations_from_feature_names
 from so101_nexus._reproducibility import seed_everything
 
 
@@ -254,17 +255,30 @@ class Agent(nn.Module):
         return action, logprob, entropy, self.critic(x).squeeze(-1)
 
 
-def _resolve_env_cls(env_id: str):
-    """Return the batched Warp env class registered under *env_id*."""
+def _env_cls_from_spec(env_id: str, attr: str):
+    """Import the env class a Gymnasium spec's ``attr`` entry point names."""
     import gymnasium as gym
 
+    import so101_nexus.mujoco
     import so101_nexus.warp  # noqa: F401  registers Warp*-v1
 
-    entry = gym.spec(env_id).vector_entry_point
+    entry = getattr(gym.spec(env_id), attr)
     if not isinstance(entry, str):
-        raise ValueError(f"{env_id} has no string vector_entry_point; not a Warp env")
+        raise ValueError(f"{env_id} has no string {attr}")
     module_path, class_name = entry.split(":")
     return getattr(importlib.import_module(module_path), class_name)
+
+
+def _resolve_env_cls(env_id: str):
+    """Return the batched Warp env class registered under *env_id*."""
+    return _env_cls_from_spec(env_id, "vector_entry_point")
+
+
+def _mujoco_config(mujoco_env_id: str, observations):
+    """Build the MuJoCo env's config with a pinned observation layout."""
+    return _env_cls_from_spec(mujoco_env_id, "entry_point").default_config_cls(
+        observations=observations
+    )
 
 
 def _fixed_horizon(env_cls):
@@ -292,14 +306,22 @@ def _make_envs(
     control_mode="pd_joint_delta_pos",
     episode_length=512,
     terminate_on_success=False,
+    observations=None,
 ):
-    """Build the batched Warp training env with the all-observation default config."""
+    """Build the batched Warp training env.
+
+    ``observations=None`` takes the env's all-observation default config (the
+    privileged state this script trains on); otherwise the layout is pinned, which
+    is what evaluating a checkpoint trained against a different layout needs, such
+    as a ``bc_ppo_warp.py`` run pinned to its demo dataset's recorded components.
+    """
     env_cls = _resolve_env_cls(env_id)
+    config = None if observations is None else env_cls.default_config_cls(observations=observations)
     if not terminate_on_success:
         env_cls = _fixed_horizon(env_cls)
     return env_cls(
         num_envs=num_envs,
-        config=None,  # env builds its all-observation default (privileged state)
+        config=config,
         control_mode=control_mode,
         device=str(device),
         max_episode_steps=episode_length,
@@ -318,12 +340,14 @@ def evaluate_mujoco(
     eval_episodes,
     seed,
     capture_video,
+    observations=None,
 ):
     """Deterministic eval in the matching ``MuJoCo*`` backend (a transfer figure).
 
     Warp's render() is a no-op, so eval rollouts are rendered in the MuJoCo backend
-    with the same default (all-observation) config and control mode; the saved Warp
-    policy + obs-norm stats transfer directly (slight physics gap: Warp uses
+    with the same config and control mode as training (``observations=None`` takes
+    the all-observation default, otherwise the training layout is pinned); the saved
+    Warp policy + obs-norm stats transfer directly (slight physics gap: Warp uses
     implicit/no-noslip). Returns (eval_metrics, frames) where frames is one episode's
     HxWx3 uint8 arrays (None when capture_video is False).
     """
@@ -331,11 +355,13 @@ def evaluate_mujoco(
 
     import so101_nexus.mujoco  # noqa: F401 registers MuJoCo* envs
 
+    mujoco_id = env_id.replace("Warp", "MuJoCo")
     env = gym.make(
-        env_id.replace("Warp", "MuJoCo"),
+        mujoco_id,
         control_mode=control_mode,
         render_mode="rgb_array" if capture_video else None,
         max_episode_steps=episode_length,
+        **({} if observations is None else {"config": _mujoco_config(mujoco_id, observations)}),
     )
     mean = obs_norm.rms.mean.to(device).float()
     var = obs_norm.rms.var.to(device).float()
@@ -402,9 +428,10 @@ def rollout_video_from_checkpoint(
     """Render one deterministic MuJoCo rollout of a saved Warp PPO policy to mp4.
 
     The Warp backend steps thousands of worlds in parallel and does not render, so the
-    rollout is shown in the matching ``MuJoCo*`` backend (same default all-observation
-    config and control mode). It is a transfer figure: the saved policy and obs-norm
-    stats transfer directly, with a slight physics gap versus Warp. Returns
+    rollout is shown in the matching ``MuJoCo*`` backend (same control mode, and the
+    observation layout the checkpoint records, falling back to the env default for a
+    checkpoint written without it). It is a transfer figure: the saved policy and
+    obs-norm stats transfer directly, with a slight physics gap versus Warp. Returns
     ``(metrics, video_path)`` where ``video_path`` is the written mp4, or ``None`` when
     ``capture_video`` is False.
     """
@@ -415,13 +442,18 @@ def rollout_video_from_checkpoint(
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     ckpt = torch.load(checkpoint, map_location=device, weights_only=False)
 
+    names = ckpt.get("env_state_names")
+    observations = None if not names else observations_from_feature_names(names)
+
     # Probe a throwaway MuJoCo env for obs/act dimensions (flat privileged state,
-    # matching the Warp training obs). The checkpoint stores only the policy and
-    # obs-norm stats, not the dims.
+    # matching the Warp training obs). The checkpoint stores the policy, obs-norm
+    # stats, and the layout names, but not the dims.
+    mujoco_id = env_id.replace("Warp", "MuJoCo")
     probe = gym.make(
-        env_id.replace("Warp", "MuJoCo"),
+        mujoco_id,
         control_mode=control_mode,
         max_episode_steps=episode_length,
+        **({} if observations is None else {"config": _mujoco_config(mujoco_id, observations)}),
     )
     obs_shape = probe.observation_space.shape
     act_shape = probe.action_space.shape
@@ -449,6 +481,7 @@ def rollout_video_from_checkpoint(
         eval_episodes=1,
         seed=seed,
         capture_video=capture_video,
+        observations=observations,
     )
     video_path = write_video(frames, out_path, fps=fps) if capture_video else None
     return metrics, video_path

--- a/tests/mujoco/test_rollout_video.py
+++ b/tests/mujoco/test_rollout_video.py
@@ -16,6 +16,8 @@ import numpy as np
 import pytest
 import torch
 
+from so101_nexus import privileged_state_feature_names
+
 pytest.importorskip("mujoco")
 pytest.importorskip("so101_nexus.mujoco")
 
@@ -28,12 +30,21 @@ EPISODE_LENGTH = 16
 HIDDEN_DIM = 64
 
 
-def _probe_dims():
+def _probe_dims(observations=None):
     import gymnasium as gym
 
     import so101_nexus.mujoco  # noqa: F401 registers MuJoCo* envs
 
-    env = gym.make(MUJOCO_ID, control_mode="pd_joint_delta_pos", max_episode_steps=EPISODE_LENGTH)
+    env = gym.make(
+        MUJOCO_ID,
+        control_mode="pd_joint_delta_pos",
+        max_episode_steps=EPISODE_LENGTH,
+        **(
+            {}
+            if observations is None
+            else {"config": ppo_mod._mujoco_config(MUJOCO_ID, observations)}
+        ),
+    )
     obs_shape = env.observation_space.shape
     act_shape = env.action_space.shape
     if obs_shape is None or act_shape is None:
@@ -44,18 +55,18 @@ def _probe_dims():
     return obs_dim, act_dim
 
 
-def _write_synthetic_checkpoint(path, obs_dim, act_dim):
+def _write_synthetic_checkpoint(path, obs_dim, act_dim, env_state_names=None):
     agent = ppo_mod.Agent(obs_dim, act_dim, HIDDEN_DIM)
-    torch.save(
-        {
-            "model": agent.state_dict(),
-            "obs_mean": torch.zeros(obs_dim, dtype=torch.float64),
-            "obs_var": torch.ones(obs_dim, dtype=torch.float64),
-            "step": 0,
-            "success": 0.0,
-        },
-        path,
-    )
+    payload = {
+        "model": agent.state_dict(),
+        "obs_mean": torch.zeros(obs_dim, dtype=torch.float64),
+        "obs_var": torch.ones(obs_dim, dtype=torch.float64),
+        "step": 0,
+        "success": 0.0,
+    }
+    if env_state_names is not None:
+        payload["env_state_names"] = env_state_names
+    torch.save(payload, path)
     return agent
 
 
@@ -80,6 +91,7 @@ def test_rollout_video_from_checkpoint_wires_checkpoint(tmp_path, monkeypatch):
         eval_episodes,
         seed,
         capture_video,
+        observations=None,
     ):
         captured["kwargs"] = {
             "env_id": env_id,
@@ -88,6 +100,7 @@ def test_rollout_video_from_checkpoint_wires_checkpoint(tmp_path, monkeypatch):
             "eval_episodes": eval_episodes,
             "seed": seed,
             "capture_video": capture_video,
+            "observations": observations,
         }
         captured["obs_norm_mean"] = obs_norm.rms.mean.detach().cpu().clone()
         captured["obs_norm_var"] = obs_norm.rms.var.detach().cpu().clone()
@@ -124,6 +137,7 @@ def test_rollout_video_from_checkpoint_wires_checkpoint(tmp_path, monkeypatch):
         "eval_episodes": 1,
         "seed": 12345,
         "capture_video": True,
+        "observations": None,  # no env_state_names recorded: env default layout
     }
     # Saved obs-norm stats and policy weights must load unchanged into the rollout.
     assert torch.allclose(captured["obs_norm_mean"], torch.zeros(obs_dim, dtype=torch.float64))
@@ -163,3 +177,43 @@ def test_rollout_video_from_checkpoint_renders_mp4(tmp_path):
     assert out_path.is_file()
     assert out_path.stat().st_size > 0
     assert set(metrics) >= {"eval/return", "eval/success_rate", "eval/ep_len"}
+
+
+def test_rollout_video_from_checkpoint_honors_recorded_layout(tmp_path, monkeypatch):
+    """A checkpoint recording a narrower layout must size the probe and Agent to it.
+
+    Regression: the helper always probed the env's current default, so rendering a
+    demo-pinned ``bc_ppo_warp.py`` checkpoint raised ``RuntimeError: size mismatch``
+    once a component joined the defaults after the demos were recorded.
+    """
+    default_cls = ppo_mod._env_cls_from_spec(MUJOCO_ID, "entry_point").default_config_cls
+    observations = list(default_cls().observations)[:-1]
+    names = privileged_state_feature_names(observations)
+    obs_dim, act_dim = _probe_dims(observations)
+    default_dim, _ = _probe_dims()
+    assert obs_dim < default_dim, "narrowed layout must differ from the env default"
+
+    ckpt_path = tmp_path / "best_agent.pt"
+    expected_agent = _write_synthetic_checkpoint(ckpt_path, obs_dim, act_dim, names)
+    captured: dict = {}
+
+    def fake_evaluate_mujoco(agent, obs_norm, device, *, observations=None, **kwargs):
+        captured["observations"] = observations
+        captured["agent_weight"] = agent.actor_mean[0].weight.detach().cpu().clone()
+        return {"eval/return": 0.0, "eval/success_rate": 0.0, "eval/ep_len": 1.0}, []
+
+    monkeypatch.setattr(ppo_mod, "evaluate_mujoco", fake_evaluate_mujoco)
+    monkeypatch.setattr(ppo_mod, "write_video", lambda frames, path, fps=30: path)
+
+    ppo_mod.rollout_video_from_checkpoint(
+        str(ckpt_path),
+        ENV_ID,
+        control_mode="pd_joint_delta_pos",
+        episode_length=EPISODE_LENGTH,
+        hidden_dim=HIDDEN_DIM,
+        out_path=str(tmp_path / "rollout.mp4"),
+    )
+
+    assert privileged_state_feature_names(captured["observations"]) == names
+    assert captured["agent_weight"].shape[1] == obs_dim
+    assert torch.allclose(captured["agent_weight"], expected_agent.actor_mean[0].weight.detach())

--- a/tests/warp/test_eval_warp_smoke.py
+++ b/tests/warp/test_eval_warp_smoke.py
@@ -1,0 +1,103 @@
+"""Tests for ``examples/eval_warp.py``, the deterministic checkpoint evaluator.
+
+``eval_warp.py`` is documented (and used by both Colab notebooks) to evaluate
+checkpoints from ``ppo_warp.py`` *and* ``bc_ppo_warp.py``. The latter pins the
+observation layout its demo dataset declares, which is narrower than the env
+default whenever a component joined the defaults after the demos were recorded,
+so the evaluator has to rebuild the env from the layout the checkpoint records
+rather than the env's current default.
+"""
+
+import importlib
+
+import pytest
+import torch
+
+from so101_nexus import privileged_state_feature_names
+
+pytestmark = pytest.mark.warp
+
+
+def _default_observations(env_id="WarpPickLift-v1"):
+    mod = importlib.import_module("examples.ppo_warp")
+    return list(mod._resolve_env_cls(env_id).default_config_cls().observations)
+
+
+def _obs_dim(env_id, observations):
+    mod = importlib.import_module("examples.ppo_warp")
+    envs = mod._make_envs(env_id, 1, torch.device("cpu"), 0, observations=observations)
+    try:
+        return int(envs.single_observation_space.shape[0])
+    finally:
+        envs.close()
+
+
+def test_make_envs_pins_the_requested_observation_layout():
+    """A pinned layout must narrow the env's observation width, not be ignored."""
+    env_id = "WarpPickLift-v1"
+    default = _default_observations(env_id)
+    narrowed = default[:-1]
+
+    default_dim = _obs_dim(env_id, None)
+    narrowed_dim = _obs_dim(env_id, narrowed)
+
+    assert default_dim == len(privileged_state_feature_names(default))
+    assert narrowed_dim == len(privileged_state_feature_names(narrowed))
+    assert narrowed_dim < default_dim
+
+
+def _write_checkpoint(path, obs_dim, act_dim, hidden_dim, env_state_names):
+    mod = importlib.import_module("examples.ppo_warp")
+    agent = mod.Agent(obs_dim, act_dim, hidden_dim)
+    torch.save(
+        {
+            "model": agent.state_dict(),
+            "obs_mean": torch.zeros(obs_dim),
+            "obs_var": torch.ones(obs_dim),
+            "step": 0,
+            "success": 0.0,
+            "env_state_names": env_state_names,
+        },
+        path,
+    )
+
+
+@pytest.mark.parametrize("pinned", [True, False])
+def test_eval_warp_rebuilds_the_env_from_the_checkpoint_layout(tmp_path, monkeypatch, pinned):
+    """A checkpoint trained on a narrower (demo-pinned) layout must still evaluate.
+
+    Regression: ``eval_warp.py`` built the env from the env's default layout and
+    crashed with a ``size mismatch`` ``RuntimeError`` on every ``bc_ppo_warp.py``
+    checkpoint whose demos predate a default observation component.
+    """
+    env_id = "WarpPickLift-v1"
+    hidden_dim = 8
+    observations = _default_observations(env_id)
+    if pinned:
+        observations = observations[:-1]
+    names = privileged_state_feature_names(observations)
+
+    checkpoint = tmp_path / "agent.pt"
+    # Width comes from the names, not from `_make_envs`, so the pinned case fails
+    # on the real `load_state_dict` size mismatch when the evaluator ignores them.
+    _write_checkpoint(checkpoint, len(names), 6, hidden_dim, names if pinned else None)
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "eval_warp.py",
+            "--checkpoint",
+            str(checkpoint),
+            "--env-id",
+            env_id,
+            "--num-envs",
+            "2",
+            "--episode-length",
+            "2",
+            "--hidden-dim",
+            str(hidden_dim),
+        ],
+    )
+
+    importlib.import_module("examples.eval_warp").main()


### PR DESCRIPTION
## What changed

The bundled example training scripts no longer work against the released library. Two independent breakages, both on the documented clone-reinforce-evaluate path.

**Checkpoint observation layout (`examples/eval_warp.py`, `examples/ppo_warp.py`)**

- `eval_warp.py` reads `env_state_names` from the checkpoint and rebuilds the env with that layout, falling back to the env default when the key is absent. It prints a notice when the pinned layout is not the current default.
- `ppo_warp.py`'s `rollout_video_from_checkpoint` does the same for its probe env and MuJoCo eval.
- `ppo_warp.py` gains `_env_cls_from_spec`, `_mujoco_config`, and the `observations=` keyword on `_make_envs` and `evaluate_mujoco`, all copied verbatim from `bc_ppo_warp.py`. Every helper shared by the two single-file recipes is byte-identical again.

**`--use-demos false` is not a valid flag (docs only)**

`tyro` renders the bool field as `--use-demos` / `--no-use-demos`, so the documented invocation exits with `Unrecognized options: false`. Corrected in `examples/README.md`, `examples/bc_ppo_warp_colab.ipynb`, and `docs/content/docs/workflow/training.mdx`, including the two flag tables that listed `true` as a value to pass.

## Why

Release 0.5.0 grew the default observation layouts (`gaze_state` in #146, `object_velocity`): pick-lift and touch 30 -> 31 dims, pick-and-place and stack-cube 36 -> 43, look-at 22 -> 23.

`bc_ppo_warp.py` correctly pins its env to the layout its demo dataset declares, because a BC policy has to consume exactly the components its demonstrations recorded, and stores that layout in the checkpoint as `env_state_names` precisely so consumers can rebuild it. The published `johnsutor/MuJoCoPickLift-v1` demos declare 30 dims against the current 31-dim default.

`eval_warp.py` ignored the field and built the default layout:

```
RuntimeError: Error(s) in loading state_dict for Agent:
  size mismatch for critic.0.weight: copying a param with shape torch.Size([256, 30]) from checkpoint, the shape in current model is torch.Size([256, 31]).
  size mismatch for actor_mean.0.weight: copying a param with shape torch.Size([256, 30]) from checkpoint, the shape in current model is torch.Size([256, 31]).
```

That is cell 12 of both Colab notebooks, the `examples/README.md` "Evaluate a checkpoint" section, and the training guide's quick start. `ppo_warp.py`'s `rollout_video_from_checkpoint` had the identical gap and is cell 14 of `ppo_warp_colab.ipynb`; only `bc_ppo_warp.py`'s copy honored the field. Fixing just the evaluator would have left that second trap in place while making the surrounding docs read as though it were gone.

The pinned-layout notice exists because the failure mode after the fix is worse than a crash: a stale-layout checkpoint would otherwise evaluate silently and report plausible-looking numbers.

## Validation

Reproduced both failures before fixing, then confirmed the repaired path.

- Pre-fix crash reproduced against the committed file, on a real demo-pinned checkpoint:
  `git show HEAD~2:examples/ppo_warp.py` -> `rollout_video_from_checkpoint` raises `size mismatch for actor_mean.0.weight`. Post-fix it renders.
- Regression tests, red-green verified by stashing the fix:
  - `tests/warp/test_eval_warp_smoke.py` (new, 3 tests): `_make_envs` pinning narrows the observation width; `eval_warp.main()` evaluates both a default-layout and a demo-pinned checkpoint. The pinned case fails pre-fix on the genuine `load_state_dict` size mismatch.
  - `tests/mujoco/test_rollout_video.py`: new `test_rollout_video_from_checkpoint_honors_recorded_layout`; existing wiring test updated for the new kwarg.
- End-to-end smoke of every example entry point on real GPU Warp plus MuJoCo, tiny step budgets:

  | Script | Result |
  |---|---|
  | `list_envs.py` | 12 env ids |
  | `ppo.py` | trains |
  | `ppo_warp.py` | trains, MuJoCo transfer eval, mp4, on all 6 `Warp*-v1` ids |
  | `bc_ppo_warp.py` | demo download, BC pretrain, PPO, eval; plus the documented `WarpPickAndPlace-v1` command and `--no-use-demos` |
  | `eval_warp.py` | both `ppo_warp` and `bc_ppo_warp` checkpoints, notice fires only on a differing layout |
  | both `rollout_video_from_checkpoint` helpers | render a demo-pinned checkpoint |

- `--target-kl None` from the README confirmed to parse.
- `make format lint typecheck` clean. `make test`: 1505 passed, 2 skipped, coverage 92.80%.

## Notes for the reviewer

Out of scope, found while checking helper parity between the two scripts: `bc_ppo_warp.evaluate_mujoco`'s `norm()` sanitizes with `torch.nan_to_num`, `ppo_warp`'s does not. `docs/superpowers/plans/2026-07-16-pick-grasp-potential-shaping.md` (lines 93-96) claims the NaN sanitization landed in both scripts; the eval path in `ppo_warp.py` was missed. Pre-existing and unrelated to this bug, so it wants its own change and regression test.

Baselines were not re-measured. These runs prove the scripts execute, not that the quoted success rates still reproduce; `WarpPickLift-v1` at 30M steps is about 25 minutes per seed.

## Checklist

- [x] Tests added or updated (regression test for a fix; happy path plus an edge case for new behavior).
- [x] `make format lint typecheck` and the relevant tests pass locally.
- [x] Documentation updated if the public API or behavior changed.
- [x] `CHANGELOG.md` `## [Unreleased]` entry added for any user-facing change.
- [x] No em dashes or emoji in prose, docs, or comments.
