### PR TITLE
feat: pick-and-place distractors + release 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,37 @@ for the public-API and deprecation policy.
 
 ### Fixed
 
+### Removed
+
+## [0.5.1] - 2026-08-02
+
+### Added
+
+- `n_distractors`, `distractors`, and `min_object_separation` on `PickAndPlaceConfig` (both
+  backends): place non-target clutter alongside the carried object, drawn without replacement
+  each episode from the `distractors` pool.
+  - `distractors` defaults to green, yellow, and purple cubes sharing `cube_half_size` /
+    `cube_mass`, with colors disjoint from the default carried cube and goal disc.
+  - Distractors keep `min_object_target_separation` from the goal disc center, so clutter does
+    not spawn on the goal, and `min_object_separation` (0.04 m, matching `PickConfig`) is the
+    gap between the carried object and the distractors.
+  - Slots are only compiled when `n_distractors > 0`, so the default single-object scene and its
+    Warp contact budget are unchanged.
+  - The count is exposed in the teleop UI and the `[pick_and_place]` profile section.
+  - Passing a distractor cube whose color is also a carried cube color warns, since the task
+    description names the carried object by color alone.
+  - Distractors never enter the observation, the task description, the success predicate, or the
+    reward. On the Warp backend `reset(options={"target_index": k})` still indexes the carried
+    pool alone, so distractor slots cannot be pinned as the carried object.
+
+### Changed
+
+- `PickAndPlaceConfig` now rejects a non-positive `cube_mass` with a `cube_mass must be > 0`
+  error, matching `StackCubeConfig`. Previously the invalid value surfaced indirectly as
+  `mass must be positive` from the default distractor pool's cubes.
+
+### Fixed
+
 - `examples/eval_warp.py` and `examples/ppo_warp.py`'s `rollout_video_from_checkpoint` now rebuild the environment from the observation layout the checkpoint records (`env_state_names`), instead of always using the environment's current default. A demo-seeded `examples/bc_ppo_warp.py` checkpoint pins the layout its demo dataset declares, so since the 0.5.0 default-observation growth (`gaze_state`, `object_velocity`) evaluating one raised `RuntimeError: size mismatch for actor_mean.0.weight`. This is the evaluation step both Colab notebooks and the training guide's quick start run. `eval_warp.py` also prints a line when the pinned layout is not the current default, since a silently stale layout otherwise reports plausible-looking numbers. `examples/ppo_warp.py` gained the `observations=` keyword on `_make_envs` and `evaluate_mujoco` plus the `_mujoco_config` helper, so it stays a byte-identical mirror of `examples/bc_ppo_warp.py` for every shared helper.
 - Docs and the BC Colab notebook told readers to disable demo seeding with `--use-demos false`, which `tyro` rejects as an unrecognized option. The flag is `--no-use-demos`.
 
@@ -417,7 +448,8 @@ for the public-API and deprecation policy.
 
 - Initial release: SO-101 MuJoCo simulation with cameras, GitHub Actions CI, and the core project structure.
 
-[Unreleased]: https://github.com/johnsutor/so101-nexus/compare/0.5.0...HEAD
+[Unreleased]: https://github.com/johnsutor/so101-nexus/compare/0.5.1...HEAD
+[0.5.1]: https://github.com/johnsutor/so101-nexus/compare/0.5.0...0.5.1
 [0.5.0]: https://github.com/johnsutor/so101-nexus/compare/0.4.13...0.5.0
 [0.4.13]: https://github.com/johnsutor/so101-nexus/compare/0.4.12...0.4.13
 [0.4.12]: https://github.com/johnsutor/so101-nexus/compare/0.4.11...0.4.12

--- a/docs/content/docs/api/configs.mdx
+++ b/docs/content/docs/api/configs.mdx
@@ -377,6 +377,15 @@ These are in addition to all `EnvironmentConfig` parameters.
 | `cube_half_size` | `float` | `0.0125` | Half-size of the default cube(s) (meters) |
 | `cube_mass` | `float` | `0.01` | Mass of the default cube(s) (kg) |
 | `min_cube_target_separation` | `float` | `0.0375` | Deprecated alias for `min_object_target_separation` |
+| `distractors` | `list[SceneObject] \| SceneObject \| None` | `None` | Pool of non-target objects distractors are drawn from. Defaults to green, yellow, and purple cubes sharing `cube_half_size` / `cube_mass` |
+| `n_distractors` | `int` | `0` | Number of distractor objects placed alongside the carried object each episode, sampled without replacement from `distractors` |
+| `min_object_separation` | `float` | `0.04` | Minimum spawn separation between the carried object and the distractors (meters), on top of their bounding radii |
+
+Distractor slots are only compiled when `n_distractors > 0`, so the default
+scene holds exactly one object. Distractors keep
+`min_object_target_separation` from the disc, so clutter never spawns on the
+goal. A distractor cube whose color is also a carried cube color warns,
+because the task description names the carried object by color alone.
 
 ### Default Observations
 

--- a/docs/content/docs/concepts/backends.mdx
+++ b/docs/content/docs/concepts/backends.mdx
@@ -21,7 +21,7 @@ MuJoCo envs support Gymnasium `render_mode="human"` and `render_mode="rgb_array"
 
 ## Object Pools and the Batched Model
 
-`WarpPickLift` and `WarpTouch` accept the same heterogeneous object pools as MuJoCo (`CubeObject`, `YCBObject`, `MeshObject`, plus `n_distractors`), `WarpPickAndPlace` accepts a carried-object pool, and `WarpStackCube` compiles one cube slot per configured color in `cube_a_colors`/`cube_b_colors` plus one slot per `distractors` pool entry when `n_distractors > 0`. Each pool object is compiled as a freejoint slot, the per-world target (or, for stack-cube, one slot per role plus the sampled distractors) is selected at reset, and inactive slots are parked off-world.
+`WarpPickLift` and `WarpTouch` accept the same heterogeneous object pools as MuJoCo (`CubeObject`, `YCBObject`, `MeshObject`, plus `n_distractors`), `WarpPickAndPlace` accepts a carried-object pool plus one slot per `distractors` pool entry when `n_distractors > 0`, and `WarpStackCube` compiles one cube slot per configured color in `cube_a_colors`/`cube_b_colors` plus the same distractor slots. Each pool object is compiled as a freejoint slot, the per-world target (or, for pick-and-place and stack-cube, the role slots plus the sampled distractors) is selected at reset, and inactive slots are parked off-world. A pick-and-place target is only ever drawn from the carried pool, so `reset(options={"target_index": k})` indexes that pool alone.
 
 Because all worlds share one compiled model, per-episode `geom_rgba` color randomization of a single object is unsupported. Distinct colored cube slots still give per-world color variation through selection (this is how `WarpStackCube` matches the MuJoCo backend's per-episode resampling of both cube colors), and the `WarpPickAndPlace` goal disc color is fixed to the first configured color.
 
@@ -37,4 +37,4 @@ Install the backend with the `warp` extra, which needs an NVIDIA GPU and CUDA >=
 
 ## Objects
 
-Both backends support `CubeObject`, `YCBObject`, and `MeshObject`, configured through the same object-pool fields (`objects`, `n_distractors`). See [Customization](/docs/concepts/customization) for the recipes and [Objects](/docs/api/objects) for the constructor reference.
+Both backends support `CubeObject`, `YCBObject`, and `MeshObject`, configured through the same object-pool fields (`objects`, `n_distractors`, and `distractors` on the pick-and-place and stack-cube families). See [Customization](/docs/concepts/customization) for the recipes and [Objects](/docs/api/objects) for the constructor reference.

--- a/docs/content/docs/concepts/customization.mdx
+++ b/docs/content/docs/concepts/customization.mdx
@@ -94,6 +94,22 @@ config = PickConfig(
 )
 ```
 
+Pick-and-place and stack-cube have role-fixed task objects, so their distractors come
+from a separate `distractors` pool instead of `objects`. It defaults to green, yellow,
+and purple cubes matching the task cube geometry, which covers `n_distractors` up to 3
+with no extra configuration.
+
+```python
+from so101_nexus import CubeObject, PickAndPlaceConfig
+
+config = PickAndPlaceConfig(
+    cube_colors="red",
+    target_colors="blue",
+    distractors=[CubeObject(color="green"), CubeObject(color="yellow")],
+    n_distractors=2,
+)
+```
+
 ### Custom meshes
 
 `MeshObject` loads an arbitrary mesh file and works on both backends.

--- a/docs/content/docs/environments/index.mdx
+++ b/docs/content/docs/environments/index.mdx
@@ -135,11 +135,14 @@ Default observation (43): `JointPositions` (6), `JointVelocities` (6), `EndEffec
 settling term of the success check, so keep it if you shrink the observation.
 
 Objects: one colored cube plus a flat target disc. Both colors are sampled per episode
-from `PickAndPlaceConfig` and named in the task description.
+from `PickAndPlaceConfig` and named in the task description. `n_distractors` draws extra
+objects without replacement from the `distractors` pool; they stay clear of the disc and
+never enter the observation or the task description.
 
 Task-specific fields: `goal_thresh` (0.025 m, the XY placement tolerance),
-`target_disc_radius` (0.05 m), `cube_half_size`, `cube_mass`, and
-`min_cube_target_separation` (0.0375 m, the minimum spawn gap between cube and disc).
+`target_disc_radius` (0.05 m), `cube_half_size`, `cube_mass`,
+`min_cube_target_separation` (0.0375 m, the minimum spawn gap between cube and disc), and
+`min_object_separation` (0.04 m, the gap between the carried object and distractors).
 Full field list in [Configs](/docs/api/configs).
 
 Overhead camera:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "so101-nexus"
-version = "0.5.0"
+version = "0.5.1"
 description = "End-to-end simulation and training stack for the SO-101 arm: record demonstrations, clone behavior, and reinforce with GPU-parallel MuJoCo / MuJoCo Warp environments, built on LeRobot"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/so101_nexus/config.py
+++ b/src/so101_nexus/config.py
@@ -925,11 +925,11 @@ def _normalize_objects(
     return normalized
 
 
-def _default_stack_distractors(half_size: float, mass: float) -> list[SceneObject]:
-    """Return the default stack-cube distractor pool.
+def _default_distractor_cubes(half_size: float, mass: float) -> list[SceneObject]:
+    """Return the default distractor pool for the cube-based tasks.
 
     The cubes share the task cubes' geometry and differ only in color (disjoint
-    from the default cube A/B colors), so a distractor cannot be told apart from
+    from the default task-cube colors), so a distractor cannot be told apart from
     a task cube by size alone.
     """
     return [
@@ -938,12 +938,20 @@ def _default_stack_distractors(half_size: float, mass: float) -> list[SceneObjec
     ]
 
 
+def _require_non_negative(**values: float) -> None:
+    """Raise ``ValueError`` naming the first keyword whose value is negative."""
+    for name, value in values.items():
+        if value < 0:
+            raise ValueError(f"{name} must be >= 0, got {value}")
+
+
 def _validate_distractor_pool(
     distractors: list[SceneObject],
     n_distractors: int,
     target_colors: Collection[str],
+    target_colors_field: str = "cube_a_colors/cube_b_colors",
 ) -> None:
-    """Validate a distractor count against its pool and the target cube colors."""
+    """Validate a distractor count against its pool and the task cube colors."""
     if n_distractors < 0:
         raise ValueError(f"n_distractors must be >= 0, got {n_distractors}")
     if n_distractors > len(distractors):
@@ -956,7 +964,7 @@ def _validate_distractor_pool(
     ambiguous = {o.color for o in distractors if isinstance(o, CubeObject)} & set(target_colors)
     if n_distractors > 0 and ambiguous:
         warnings.warn(
-            f"distractor cubes share {ambiguous} with cube_a_colors/cube_b_colors; "
+            f"distractor cubes share {ambiguous} with {target_colors_field}; "
             "the task description may be ambiguous in some episodes",
             stacklevel=3,
         )
@@ -1105,6 +1113,20 @@ class PickAndPlaceConfig(EnvironmentConfig):
     object_static_ang_threshold : float
         Maximum angular speed (rad/s) at which the carried object still counts
         as static for the success check. Mirrors ManiSkill's ``ang_thresh=0.5``.
+    distractors : list[SceneObject] | SceneObject | None
+        Pool of non-target objects to sample distractors from. Defaults to
+        green, yellow, and purple cubes sharing ``cube_half_size`` /
+        ``cube_mass`` (colors disjoint from the default carried cube and goal
+        disc). Only compiled into the scene when ``n_distractors > 0``.
+    n_distractors : int
+        Number of distractor objects placed alongside the carried object each
+        episode, drawn without replacement from ``distractors``. 0 means the
+        single-object scene. Distractors keep
+        ``min_object_target_separation`` from the goal disc, so clutter never
+        spawns on the goal.
+    min_object_separation : float
+        Minimum spawn separation between the carried object and the
+        distractors (meters), on top of their bounding radii.
     **kwargs
         Forwarded to EnvironmentConfig.
     """
@@ -1122,6 +1144,9 @@ class PickAndPlaceConfig(EnvironmentConfig):
         min_object_target_separation: float | None = None,
         object_static_lin_threshold: float = 0.01,
         object_static_ang_threshold: float = 0.5,
+        distractors: list[SceneObject] | SceneObject | None = None,
+        n_distractors: int = 0,
+        min_object_separation: float = 0.04,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -1154,6 +1179,7 @@ class PickAndPlaceConfig(EnvironmentConfig):
         )
         self.object_static_lin_threshold = object_static_lin_threshold
         self.object_static_ang_threshold = object_static_ang_threshold
+        self.min_object_separation = min_object_separation
 
         _validate_color_config(self.cube_colors, "cube_colors")
         _validate_color_config(self.target_colors, "target_colors")
@@ -1172,24 +1198,35 @@ class PickAndPlaceConfig(EnvironmentConfig):
             )
         if not (0.01 <= self.cube_half_size <= 0.05):
             raise ValueError(f"cube_half_size must be in [0.01, 0.05], got {self.cube_half_size}")
+        if self.cube_mass <= 0:
+            raise ValueError(f"cube_mass must be > 0, got {self.cube_mass}")
         if self.target_disc_radius <= 0:
             raise ValueError(f"target_disc_radius must be > 0, got {self.target_disc_radius}")
-        if min_cube_target_separation < 0:
-            raise ValueError(
-                f"min_cube_target_separation must be >= 0, got {min_cube_target_separation}"
-            )
-        if min_object_target_separation is not None and min_object_target_separation < 0:
-            raise ValueError(
-                f"min_object_target_separation must be >= 0, got {min_object_target_separation}"
-            )
-        if self.object_static_lin_threshold < 0:
-            raise ValueError(
-                f"object_static_lin_threshold must be >= 0, got {self.object_static_lin_threshold}"
-            )
-        if self.object_static_ang_threshold < 0:
-            raise ValueError(
-                f"object_static_ang_threshold must be >= 0, got {self.object_static_ang_threshold}"
-            )
+        _require_non_negative(min_cube_target_separation=min_cube_target_separation)
+        if min_object_target_separation is not None:
+            _require_non_negative(min_object_target_separation=min_object_target_separation)
+        _require_non_negative(
+            object_static_lin_threshold=self.object_static_lin_threshold,
+            object_static_ang_threshold=self.object_static_ang_threshold,
+            min_object_separation=self.min_object_separation,
+        )
+        # Built after the cube checks so an invalid cube_half_size/cube_mass is
+        # reported against its own field, not against the default pool's cubes.
+        self.distractors = _normalize_objects(
+            distractors,
+            _default_distractor_cubes(cube_half_size, cube_mass),
+            field_name="distractors",
+        )
+        self.n_distractors = n_distractors
+        # The instruction names the carried object by color, so only the carried
+        # pool's cube colors can make an episode ambiguous; the goal disc is
+        # named as a circle and never confusable with a cube.
+        _validate_distractor_pool(
+            self.distractors,
+            self.n_distractors,
+            {o.color for o in self.object_pool() if isinstance(o, CubeObject)},
+            target_colors_field="the carried-object pool colors",
+        )
         if self.observations is None:
             self.observations = [
                 JointPositions(),
@@ -1237,7 +1274,8 @@ class PickAndPlaceConfig(EnvironmentConfig):
     def __repr__(self) -> str:  # noqa: D105
         return (
             f"PickAndPlaceConfig(objects={self.objects!r}, "
-            f"target_colors={self.target_colors!r}, cube_half_size={self.cube_half_size})"
+            f"target_colors={self.target_colors!r}, cube_half_size={self.cube_half_size}, "
+            f"n_distractors={self.n_distractors})"
         )
 
     @property
@@ -1360,7 +1398,7 @@ class StackCubeConfig(EnvironmentConfig):
         # reported against its own field, not against the default pool's cubes.
         self.distractors = _normalize_objects(
             distractors,
-            _default_stack_distractors(cube_half_size, cube_mass),
+            _default_distractor_cubes(cube_half_size, cube_mass),
             field_name="distractors",
         )
         self.n_distractors = n_distractors

--- a/src/so101_nexus/mujoco/pick_and_place.py
+++ b/src/so101_nexus/mujoco/pick_and_place.py
@@ -4,6 +4,14 @@ The carried object is chosen per episode from a compiled object pool (shared wit
 the unified pick env via ``so101_nexus.object_slots``); the goal is a visible,
 non-colliding disc whose colour is randomized per episode. Supported carried
 objects: ``CubeObject``, ``YCBObject``, ``MeshObject``.
+
+When ``PickAndPlaceConfig.n_distractors > 0``, one freejoint slot per entry in
+``PickAndPlaceConfig.distractors`` is compiled after the carried pool; each reset
+activates ``n_distractors`` of them and parks the remainder off-world with
+collisions disabled, matching ``StackCubeEnv``'s slot machinery. As in stack-cube
+the distractor pool is separate from the task objects, so unlike ``PickEnv`` (whose
+distractors are drawn from the same pool as its target) a distractor here can never
+become the carried object.
 """
 
 from __future__ import annotations
@@ -26,9 +34,13 @@ from so101_nexus.config import (
 )
 from so101_nexus.constants import COLOR_MAP, sample_color_name
 from so101_nexus.mujoco.base_env import SO101NexusMuJoCoBaseEnv
-from so101_nexus.mujoco.spawn_utils import hide_freejoint_slot, place_freejoint_slot
+from so101_nexus.mujoco.spawn_utils import (
+    activate_distractor_slots,
+    hide_freejoint_slot,
+    place_freejoint_slot,
+)
 from so101_nexus.object_slots import ObjectSlot, build_object_scene_xml, extract_object_slots
-from so101_nexus.objects import CubeObject, YCBObject
+from so101_nexus.objects import CubeObject, SceneObject, YCBObject
 from so101_nexus.rewards import (
     object_static_ok,
     place_grasp_potential,
@@ -78,11 +90,18 @@ class PickAndPlaceEnv(SO101NexusMuJoCoBaseEnv):
             robot_init_qpos_noise=robot_init_qpos_noise,
         )
 
-        scene_objects = config.object_pool()
+        scene_objects: list[SceneObject] = config.object_pool()
+        n_carried = len(scene_objects)
+        # Distractor slots are only compiled when requested, so the default
+        # single-object scene stays identical.
+        distractor_pool = list(config.distractors) if config.n_distractors else []
+        scene_objects += distractor_pool
         for obj in scene_objects:
             if isinstance(obj, YCBObject):
                 ensure_ycb_assets(obj.model_id)
-        slot_names = [f"pick_slot_{i}" for i in range(len(scene_objects))]
+        slot_names = [f"pick_slot_{i}" for i in range(n_carried)] + [
+            f"distractor_slot_{i}" for i in range(len(distractor_pool))
+        ]
 
         self.cube_half_size = config.cube_half_size
         self.target_disc_radius = config.target_disc_radius
@@ -118,7 +137,12 @@ class PickAndPlaceEnv(SO101NexusMuJoCoBaseEnv):
             self.model = mujoco.MjModel.from_xml_path(f.name)
         self.data = mujoco.MjData(self.model)
 
-        self._slots: list[ObjectSlot] = extract_object_slots(self.model, slot_names, scene_objects)
+        slots = extract_object_slots(self.model, slot_names, scene_objects)
+        # ``_slots`` stays the carried pool alone, so pool indices (and
+        # ``info["target_index"]``) are unaffected by the distractor slots.
+        self._slots: list[ObjectSlot] = slots[:n_carried]
+        self._distractor_slots: list[ObjectSlot] = slots[n_carried:]
+        self._n_distractors = config.n_distractors
         self._target_geom_id = mujoco.mj_name2id(
             self.model, mujoco.mjtObj.mjOBJ_GEOM, "target_disc"
         )
@@ -363,19 +387,56 @@ class PickAndPlaceEnv(SO101NexusMuJoCoBaseEnv):
         target_y = cy + r_t * np.sin(theta_t)
         self.model.body_pos[self._target_body_id] = [target_x, target_y, _TARGET_Z]
 
-        sep = self.config.min_object_target_separation + target_slot.bounding_radius
-        obj_x, obj_y = target_x, target_y
-        for _ in range(100):
-            r_c = rng.uniform(min_r, max_r)
-            theta_c = rng.uniform(-angle_half, angle_half)
-            obj_x = cx + r_c * np.cos(theta_c)
-            obj_y = cy + r_c * np.sin(theta_c)
-            if np.hypot(obj_x - target_x, obj_y - target_y) >= sep:
-                break
-
-        place_freejoint_slot(self.model, self.data, target_slot, rng, (obj_x, obj_y))
+        distractors = activate_distractor_slots(
+            self.model, self.data, self._distractor_slots, self._n_distractors, rng
+        )
+        active_slots = [target_slot, *distractors]
+        positions = self._sample_object_positions(rng, active_slots, (target_x, target_y))
+        for slot, xy in zip(active_slots, positions, strict=True):
+            place_freejoint_slot(self.model, self.data, slot, rng, xy)
         for idx, slot in enumerate(self._slots):
             if idx != target_idx:
                 hide_freejoint_slot(self.model, self.data, slot)
 
         self._initial_obj_z = target_slot.spawn_z
+
+    def _sample_object_positions(
+        self,
+        rng: np.random.Generator,
+        slots: list[ObjectSlot],
+        disc_xy: tuple[float, float],
+    ) -> list[tuple[float, float]]:
+        """Sample one XY per active slot, clear of the goal disc and of each other.
+
+        Two clearances apply: every object stays ``min_object_target_separation``
+        plus its bounding radius from the disc center, and any two objects stay
+        ``min_object_separation`` plus their bounding radii apart. The disc
+        clearance is measured to the disc center, not its rim, so with a
+        ``target_disc_radius`` wider than that margin an object footprint may
+        still overlap the disc's outer annulus. Falls back to the last candidate
+        once the attempt budget runs out, matching
+        ``spawn_utils.sample_separated_positions``.
+        """
+        cfg = self.config
+        min_r, max_r = cfg.spawn_min_radius, cfg.spawn_max_radius
+        angle_half = float(np.radians(cfg.spawn_angle_half_range_deg))
+        cx, cy = cfg.spawn_center
+        disc_x, disc_y = disc_xy
+        placed: list[tuple[float, float, float]] = []  # x, y, bounding radius
+        for slot in slots:
+            radius = slot.bounding_radius
+            disc_sep = cfg.min_object_target_separation + radius
+            for _ in range(100):
+                r = rng.uniform(min_r, max_r)
+                theta = rng.uniform(-angle_half, angle_half)
+                x = cx + r * np.cos(theta)
+                y = cy + r * np.sin(theta)
+                if np.hypot(x - disc_x, y - disc_y) < disc_sep:
+                    continue
+                if all(
+                    np.hypot(x - px, y - py) >= radius + pr + cfg.min_object_separation
+                    for px, py, pr in placed
+                ):
+                    break
+            placed.append((x, y, radius))
+        return [(x, y) for x, y, _ in placed]

--- a/src/so101_nexus/mujoco/spawn_utils.py
+++ b/src/so101_nexus/mujoco/spawn_utils.py
@@ -6,7 +6,12 @@ and for sampling random object orientations.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
+
+if TYPE_CHECKING:
+    from so101_nexus.object_slots import ObjectSlot
 
 MESH_FLOOR_MARGIN = 0.002
 """Small floor clearance for mesh object spawns, in metres."""
@@ -171,3 +176,38 @@ def hide_freejoint_slot(model, data, slot) -> None:
     model.geom_conaffinity[slot.geom_id] = 0
     data.qpos[slot.qpos_addr : slot.qpos_addr + 3] = [0.0, 0.0, -10.0]
     data.qpos[slot.qpos_addr + 3 : slot.qpos_addr + 7] = [1.0, 0.0, 0.0, 0.0]
+
+
+def activate_distractor_slots(
+    model, data, slots: list[ObjectSlot], count: int, rng: np.random.Generator
+) -> list[ObjectSlot]:
+    """Activate ``count`` of ``slots`` and park the rest off-world.
+
+    Restores collisions on the whole distractor pool first, so a slot that was
+    hidden by an earlier episode collides again once it is chosen. Returns the
+    chosen slots in pool order; the caller places them.
+
+    Parameters
+    ----------
+    model : mujoco.MjModel
+        Compiled model whose per-geom contact flags are toggled.
+    data : mujoco.MjData
+        State buffer whose freejoint qpos is parked for inactive slots.
+    slots : list
+        Compiled distractor pool (``so101_nexus.object_slots.ObjectSlot``).
+    count : int
+        Number of slots to activate, drawn without replacement.
+    rng : numpy.random.Generator
+        Seeded generator (``self.np_random``) backing the draw, so activation is
+        reproducible under ``reset(seed=...)``.
+    """
+    if not slots:
+        return []
+    for slot in slots:
+        model.geom_contype[slot.geom_id] = 1
+        model.geom_conaffinity[slot.geom_id] = 1
+    chosen = {int(i) for i in rng.choice(len(slots), size=count, replace=False)}
+    for idx, slot in enumerate(slots):
+        if idx not in chosen:
+            hide_freejoint_slot(model, data, slot)
+    return [slots[idx] for idx in sorted(chosen)]

--- a/src/so101_nexus/mujoco/stack_cube.py
+++ b/src/so101_nexus/mujoco/stack_cube.py
@@ -29,7 +29,7 @@ from so101_nexus.config import ControlMode, StackCubeConfig, describe_stack_targ
 from so101_nexus.constants import COLOR_MAP, ColorName, sample_color_name
 from so101_nexus.mujoco.base_env import SO101NexusMuJoCoBaseEnv
 from so101_nexus.mujoco.spawn_utils import (
-    hide_freejoint_slot,
+    activate_distractor_slots,
     place_freejoint_slot,
     sample_separated_positions,
 )
@@ -326,24 +326,6 @@ class StackCubeEnv(SO101NexusMuJoCoBaseEnv):
         self._prev_reach_progress = place_reach_potential(tcp_to_obj_dist, is_stacked, scale=scale)
         self._prev_grasp_progress = place_grasp_potential(is_grasped, is_stacked)
 
-    def _sample_distractor_slots(self, rng: np.random.Generator) -> list[ObjectSlot]:
-        """Activate ``config.n_distractors`` pool slots and park the rest off-world."""
-        if not self._distractor_slots:
-            return []
-        for slot in self._distractor_slots:
-            self.model.geom_contype[slot.geom_id] = 1
-            self.model.geom_conaffinity[slot.geom_id] = 1
-        chosen = {
-            int(i)
-            for i in rng.choice(
-                len(self._distractor_slots), size=self._n_distractors, replace=False
-            )
-        }
-        for idx, slot in enumerate(self._distractor_slots):
-            if idx not in chosen:
-                hide_freejoint_slot(self.model, self.data, slot)
-        return [self._distractor_slots[idx] for idx in sorted(chosen)]
-
     def _task_reset(self) -> None:
         rng = self.np_random
         min_r = self.config.spawn_min_radius
@@ -355,7 +337,10 @@ class StackCubeEnv(SO101NexusMuJoCoBaseEnv):
         self.model.geom_rgba[self._slot_a.geom_id] = COLOR_MAP[self.cube_a_color_name]
         self.model.geom_rgba[self._slot_b.geom_id] = COLOR_MAP[self.cube_b_color_name]
 
-        active_slots = [self._slot_a, self._slot_b, *self._sample_distractor_slots(rng)]
+        distractors = activate_distractor_slots(
+            self.model, self.data, self._distractor_slots, self._n_distractors, rng
+        )
+        active_slots = [self._slot_a, self._slot_b, *distractors]
         positions = sample_separated_positions(
             rng,
             len(active_slots),

--- a/src/so101_nexus/teleop/app.py
+++ b/src/so101_nexus/teleop/app.py
@@ -25,6 +25,7 @@ from so101_nexus.teleop.config_customization import (
     default_color_choices,
     default_cube_color_choices,
     default_object_choices,
+    has_pick_object_pool,
     load_config_factory,
     overrides_to_mapping,
 )
@@ -208,7 +209,7 @@ def _customization_ui_state_from_config(config: object | None) -> CustomizationU
         "reset_settle_frames",
     }
     common_visible = bool(common_keys & set(attrs))
-    pick_visible = "objects" in attrs and "n_distractors" in attrs
+    pick_visible = has_pick_object_pool(attrs)
     distractors_visible = "n_distractors" in attrs
     pick_and_place_visible = "cube_colors" in attrs or "target_colors" in attrs
     stack_visible = "cube_a_colors" in attrs or "cube_b_colors" in attrs

--- a/src/so101_nexus/teleop/config_customization.py
+++ b/src/so101_nexus/teleop/config_customization.py
@@ -132,13 +132,26 @@ def object_from_mapping(raw: Mapping[str, Any]) -> SceneObject:
     raise ValueError(f"unsupported object mapping type: {kind!r}")
 
 
+def has_pick_object_pool(attrs: Mapping[str, object]) -> bool:
+    """Return whether a config exposes the free-form ``objects`` pool control.
+
+    ``cube_colors`` marks the pick-and-place carried-cube sugar: that family also
+    exposes ``n_distractors``, but its ``objects`` pool is derived from the cube
+    colors and cannot be combined with a color override, so the pool control stays
+    off for it. Keyed on attribute names because the teleop layer is handed a
+    config instance, not a task identifier.
+    """
+    keys = set(attrs)
+    return {"objects", "n_distractors"} <= keys and "cube_colors" not in keys
+
+
 def apply_config_overrides[ConfigT](
     config: ConfigT,
     overrides: TeleopConfigOverrides,
 ) -> ConfigT:
     """Return a cloned config with applicable teleop overrides applied."""
     attrs = vars(config).copy()
-    is_pick_like = "objects" in attrs and "n_distractors" in attrs
+    is_pick_like = has_pick_object_pool(attrs)
 
     for name in ("ground_colors", "robot_colors"):
         value = _as_color_config(getattr(overrides, name))

--- a/src/so101_nexus/warp/pick_and_place.py
+++ b/src/so101_nexus/warp/pick_and_place.py
@@ -5,6 +5,11 @@ The carried object is chosen per episode from the shared compiled object-slot po
 per-world position lives in ``data.mocap_pos``. The disc colour is fixed at
 model-build time to the first configured target colour (``geom_rgba`` is global), a
 documented divergence from the MuJoCo backend, which randomizes it per episode.
+
+``PickAndPlaceConfig.n_distractors > 0`` additionally compiles one slot per entry
+in ``PickAndPlaceConfig.distractors`` after the carried pool; each world activates
+``n_distractors`` of them per reset and the remainder stay parked in the hidden
+band. Target selection stays inside the carried pool.
 """
 
 from __future__ import annotations
@@ -27,7 +32,7 @@ from so101_nexus.rewards import (
     place_task_potential,
     potential_shaping,
 )
-from so101_nexus.warp.object_slots import sample_polar
+from so101_nexus.warp.object_slots import sample_polar, sample_separated_polar
 from so101_nexus.warp.pick_env import WarpPickLiftVectorEnv
 
 _TARGET_Z = 0.001
@@ -72,6 +77,14 @@ class WarpPickAndPlaceVectorEnv(WarpPickLiftVectorEnv):
         if config is None:
             config = PickAndPlaceConfig()
         scene_objects = config.object_pool()
+        n_carried = len(scene_objects)
+        # Distractor slots are only compiled when requested, so the default
+        # single-object scene (and its contact budget) stays unchanged.
+        self._n_distractors = config.n_distractors
+        distractor_pool = list(config.distractors) if self._n_distractors else []
+        self._d_pool = len(distractor_pool)
+        self._d_offset = n_carried
+        scene_objects = scene_objects + distractor_pool
         self.target_color_name = (
             config.target_colors
             if isinstance(config.target_colors, str)
@@ -92,6 +105,9 @@ class WarpPickAndPlaceVectorEnv(WarpPickLiftVectorEnv):
             model_name="pick_and_place_scene",
             extra_bodies=disc_xml,
             render_mode=render_mode,
+            n_target_pool=n_carried,
+            slot_names=[f"pick_slot_{i}" for i in range(n_carried)]
+            + [f"distractor_slot_{i}" for i in range(self._d_pool)],
         )
         target_bid = mujoco.mj_name2id(self._mjm, mujoco.mjtObj.mjOBJ_BODY, "target")
         self._target_mocap_id = int(self._mjm.body_mocapid[target_bid])
@@ -185,38 +201,57 @@ class WarpPickAndPlaceVectorEnv(WarpPickLiftVectorEnv):
         if n == 0:
             return
         sel, target = self._select_active_slots(idx)  # (n, 1), (n,)
+        gen, dev = self._generator, self.device
+        if self._n_distractors:
+            # Distinct distractor slots per world, as in WarpStackCubeVectorEnv.
+            d_rank = torch.rand(n, self._d_pool, generator=gen, device=dev).argsort(dim=1)
+            sel = torch.cat([sel, self._d_offset + d_rank[:, : self._n_distractors]], dim=1)
         self._hide_all_slots(idx)
 
         cfg = self.config
         angle = float(np.radians(cfg.spawn_angle_half_range_deg))
         disc_xy = sample_polar(
-            self._generator,
-            self.device,
+            gen,
+            dev,
             n,
             cfg.spawn_min_radius,
             cfg.spawn_max_radius,
             angle,
             cfg.spawn_center,
         )
-        obj_xy = sample_polar(
-            self._generator,
-            self.device,
-            n,
+        radii = self._slot_bradius[sel]  # (n, n_placed)
+        obj_xy = sample_separated_polar(
+            gen,
+            dev,
+            radii,
+            cfg.min_object_separation,
             cfg.spawn_min_radius,
             cfg.spawn_max_radius,
             angle,
             cfg.spawn_center,
-        )
-        # Bounding-radius-aware object/disc separation (disc fixed, object resampled).
-        sep = cfg.min_object_target_separation + self._slot_bradius[sel[:, 0]]
+        )  # (n, n_placed, 2)
+        # Bounding-radius-aware object/disc separation (disc fixed, objects
+        # resampled), applied to the carried object and every distractor so no
+        # object spawns on the goal. Resampling would undo the object/object
+        # clearance the separated sampler established, so with distractors
+        # present that check gates the loop too.
+        disc_sep = cfg.min_object_target_separation + radii  # (n, n_placed)
+        # Carried object plus its distractors; distinct from ``self._n_active``,
+        # which stays 1 for this env (one carried slot drawn from the pool).
+        n_placed = sel.shape[1]
+        pair_sep = cfg.min_object_separation + radii[:, :, None] + radii[:, None, :]
+        off_diag = ~torch.eye(n_placed, dtype=torch.bool, device=dev)
         for _ in range(100):
-            bad = torch.linalg.norm(obj_xy - disc_xy, dim=1) < sep
+            bad = torch.linalg.norm(obj_xy - disc_xy[:, None, :], dim=2) < disc_sep
+            if n_placed > 1:
+                pair_dist = torch.linalg.norm(obj_xy[:, :, None, :] - obj_xy[:, None, :, :], dim=3)
+                bad |= ((pair_dist < pair_sep) & off_diag).any(dim=2)
             k = int(bad.sum())
             if k == 0:
                 break
             obj_xy[bad] = sample_polar(
-                self._generator,
-                self.device,
+                gen,
+                dev,
                 k,
                 cfg.spawn_min_radius,
                 cfg.spawn_max_radius,
@@ -227,7 +262,7 @@ class WarpPickAndPlaceVectorEnv(WarpPickLiftVectorEnv):
         self._mocap_pos[idx, self._target_mocap_id, 0] = disc_xy[:, 0]
         self._mocap_pos[idx, self._target_mocap_id, 1] = disc_xy[:, 1]
         self._mocap_pos[idx, self._target_mocap_id, 2] = _TARGET_Z
-        self._place_active_slots(idx, sel, obj_xy[:, None, :])
+        self._place_active_slots(idx, sel, obj_xy)
         self._set_target_tracking(idx, target)
 
     def _get_component_data(self, component: object) -> torch.Tensor:

--- a/src/so101_nexus/warp/pick_env.py
+++ b/src/so101_nexus/warp/pick_env.py
@@ -49,14 +49,15 @@ _SO101_DIR = get_so101_mujoco_model_dir()
 _SO101_XML = get_so101_mujoco_model_path()
 
 # Contact budget per world. The single-cube scene needs a generous floor for
-# active grasping; pools add resting contacts for hidden/distractor slots, so the
-# budget scales with the pool size. naconmax = nconmax * num_envs.
+# active grasping; every compiled slot (carried pool and distractor alike) adds
+# resting contacts, so the budget scales with the total slot count, not with the
+# carried pool. naconmax = nconmax * num_envs.
 _PICK_NCONMAX_BASE = 192
 _PICK_NCONMAX_PER_SLOT = 16
 
 
-def _contact_budget(n_pool: int) -> tuple[int, int]:
-    nconmax = _PICK_NCONMAX_BASE + _PICK_NCONMAX_PER_SLOT * n_pool
+def _contact_budget(n_slots: int) -> tuple[int, int]:
+    nconmax = _PICK_NCONMAX_BASE + _PICK_NCONMAX_PER_SLOT * n_slots
     return nconmax, nconmax * 2
 
 
@@ -116,18 +117,46 @@ class WarpPickLiftVectorEnv(SO101NexusWarpVectorEnv):
         model_name: str,
         extra_bodies: str = "",
         render_mode: str | None = None,
+        n_target_pool: int | None = None,
+        slot_names: list[str] | None = None,
     ) -> None:
         """Compile the shared object-slot model and build per-slot tensors.
 
         Shared by the pick/touch and pick-and-place backends; the latter passes
-        ``extra_bodies`` for the mocap goal disc and ``n_active=1``.
+        ``extra_bodies`` for the mocap goal disc, ``n_active=1``, and a
+        ``n_target_pool`` that excludes its trailing distractor slots.
+
+        Parameters
+        ----------
+        n_target_pool : int, optional
+            Number of leading slots a target may be drawn from, which is also
+            what ``reset(options={"target_index": k})`` is validated against.
+            ``None`` (default) allows every compiled slot.
+        slot_names : list[str], optional
+            Body-name stems for the compiled slots. ``None`` (default) names
+            them ``pick_slot_{i}``.
         """
         for obj in scene_objects:
             if isinstance(obj, YCBObject):
                 ensure_ycb_assets(obj.model_id)
-        self._n_pool = len(scene_objects)
+        self._n_total_slots = len(scene_objects)
+        # ``_n_pool`` is the carried/distractor boundary: ``_select_active_slots``
+        # draws from ``[0, _n_pool)`` and ``_parse_target_index`` range-checks a
+        # pin against it, so a value past the compiled slots would make a
+        # distractor pinnable and index past the per-slot tensors.
+        if n_target_pool is not None and not 0 < n_target_pool <= self._n_total_slots:
+            raise ValueError(
+                f"n_target_pool must be in [1, {self._n_total_slots}], got {n_target_pool}"
+            )
+        self._n_pool = self._n_total_slots if n_target_pool is None else n_target_pool
         self._n_active = n_active
-        slot_names = [f"pick_slot_{i}" for i in range(self._n_pool)]
+        if slot_names is None:
+            slot_names = [f"pick_slot_{i}" for i in range(self._n_total_slots)]
+        elif len(slot_names) != self._n_total_slots:
+            raise ValueError(
+                f"slot_names must have one entry per compiled slot "
+                f"({self._n_total_slots}), got {len(slot_names)}"
+            )
 
         xml_string = build_object_scene_xml(
             scene_objects,
@@ -144,7 +173,7 @@ class WarpPickLiftVectorEnv(SO101NexusWarpVectorEnv):
             f.flush()
             mjm = mujoco.MjModel.from_xml_path(f.name)
         slots = extract_object_slots(mjm, slot_names, scene_objects)
-        default_nconmax, default_njmax = _contact_budget(self._n_pool)
+        default_nconmax, default_njmax = _contact_budget(self._n_total_slots)
         super().__init__(
             num_envs=num_envs,
             config=config,
@@ -176,7 +205,7 @@ class WarpPickLiftVectorEnv(SO101NexusWarpVectorEnv):
         )
         self._hide_xy = hidden_slot_band_xy(
             self.device,
-            self._n_pool,
+            self._n_total_slots,
             float(self._slot_bradius.max()),
             config.spawn_max_radius,
             config.spawn_center,
@@ -227,7 +256,7 @@ class WarpPickLiftVectorEnv(SO101NexusWarpVectorEnv):
         return self._slot_bradius[self._target_slot]
 
     def _select_active_slots(self, idx: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        """Return ``(n, n_active)`` distinct pool indices and the ``(n,)`` target.
+        """Return ``(n, n_active)`` distinct target-pool indices and the ``(n,)`` target.
 
         The active set is one seeded draw, unchanged by
         ``reset(options={"target_index": k})``. Worlds whose pin is already in
@@ -260,7 +289,7 @@ class WarpPickLiftVectorEnv(SO101NexusWarpVectorEnv):
         Slot qpos columns are shared across worlds, so hiding uses fixed slices;
         active slots are overwritten afterward by ``_place_active_slots``.
         """
-        for j in range(self._n_pool):
+        for j in range(self._n_total_slots):
             qa = int(self._slot_qadr[j])
             self.qpos[idx, qa] = self._hide_xy[j, 0]
             self.qpos[idx, qa + 1] = self._hide_xy[j, 1]

--- a/tests/core/test_teleop_app_helpers.py
+++ b/tests/core/test_teleop_app_helpers.py
@@ -657,13 +657,20 @@ def test_customization_ui_state_for_pick_and_place_hides_pick_controls() -> None
             target_colors="blue",
             ground_colors="gray",
             robot_colors=["yellow", "orange"],
+            distractors=[CubeObject(color="purple")],
+            n_distractors=1,
         )
     )
 
     assert state.customize_visible is True
     assert state.customize_value is True
     assert state.common_visible is True
+    # The carried pool is driven by cube_colors, so the object-pool control stays
+    # hidden even though pick-and-place now exposes a distractor count.
     assert state.pick_visible is False
+    assert state.distractors_visible is True
+    assert state.pick_group_visible is True
+    assert state.n_distractors == 1
     assert state.pick_and_place_visible is True
     assert state.cube_colors == ["red", "green"]
     assert state.target_colors == ["blue"]

--- a/tests/core/test_teleop_config_customization.py
+++ b/tests/core/test_teleop_config_customization.py
@@ -88,6 +88,22 @@ def test_apply_config_overrides_updates_stack_cube_distractors() -> None:
     assert cfg.n_distractors == 2
 
 
+def test_apply_config_overrides_updates_pick_and_place_distractors() -> None:
+    # The pick object-pool control is hidden for pick-and-place, so an object
+    # override must not fight the cube sugar its carried pool is derived from.
+    cfg = apply_config_overrides(
+        PickAndPlaceConfig(),
+        TeleopConfigOverrides(
+            object_specs=("cube:orange",), n_distractors=2, cube_colors=("orange",)
+        ),
+    )
+
+    assert isinstance(cfg, PickAndPlaceConfig)
+    assert cfg.n_distractors == 2
+    assert cfg.objects is None
+    assert cfg.cube_colors == ["orange"]
+
+
 def test_apply_config_overrides_accepts_parsed_mesh_objects() -> None:
     mesh = MeshObject(
         collision_mesh_path="/tmp/collision.stl",

--- a/tests/mujoco/test_envs.py
+++ b/tests/mujoco/test_envs.py
@@ -679,6 +679,125 @@ def test_pick_and_place_min_cube_target_separation():
         env.close()
 
 
+def test_pick_and_place_default_scene_compiles_no_distractor_slots():
+    """n_distractors=0 keeps the single-object scene: no extra freejoint bodies."""
+    env = gym.make("MuJoCoPickAndPlace-v1")
+    baseline = gym.make(
+        "MuJoCoPickAndPlace-v1",
+        config=PickAndPlaceConfig(distractors=[CubeObject(color="green")], n_distractors=0),
+    )
+    try:
+        env.reset(seed=0)
+        baseline.reset(seed=0)
+        assert env.unwrapped._distractor_slots == []  # type: ignore[attr-defined]
+        # A configured-but-unused pool must not reach the compiled model either.
+        assert env.unwrapped.model.nbody == baseline.unwrapped.model.nbody
+        assert env.unwrapped.model.nq == baseline.unwrapped.model.nq
+    finally:
+        env.close()
+        baseline.close()
+
+
+def test_pick_and_place_custom_distractor_pool_reaches_the_scene():
+    """A non-default ``distractors`` entry is what gets compiled, not the default pool."""
+    cfg = PickAndPlaceConfig(
+        distractors=[CubeObject(color="green", half_size=0.03)], n_distractors=1
+    )
+    env = gym.make("MuJoCoPickAndPlace-v1", config=cfg)
+    try:
+        env.reset(seed=0)
+        pool = env.unwrapped._distractor_slots  # type: ignore[attr-defined]
+        assert len(pool) == 1
+        assert pool[0].bounding_radius == pytest.approx(0.03 * np.sqrt(2), rel=1e-6)
+        rgba = env.unwrapped.model.geom_rgba[pool[0].geom_id]
+        assert list(rgba) == CUBE_COLOR_MAP["green"]
+    finally:
+        env.close()
+
+
+def test_pick_and_place_distractors_active_on_table_and_separated():
+    """``n_distractors`` pool slots rest in the spawn annulus, clear of the goal
+    disc and the carried object; unchosen slots are parked with collisions off."""
+    cfg = PickAndPlaceConfig(n_distractors=2)
+    env = gym.make("MuJoCoPickAndPlace-v1", config=cfg)
+    try:
+        cx, cy = cfg.spawn_center
+        for seed in range(5):
+            env.reset(seed=seed)
+            inner = env.unwrapped
+            pool = inner._distractor_slots  # type: ignore[attr-defined]
+            assert len(pool) == len(cfg.distractors)
+            active = [s for s in pool if inner.data.qpos[s.qpos_addr + 2] > 0.0]
+            hidden = [s for s in pool if inner.data.qpos[s.qpos_addr + 2] <= 0.0]
+            assert len(active) == cfg.n_distractors
+            for slot in hidden:
+                assert inner.model.geom_contype[slot.geom_id] == 0
+                assert inner.model.geom_conaffinity[slot.geom_id] == 0
+
+            disc_xy = inner._get_target_pos()[:2]  # type: ignore[attr-defined]
+            target_slot = inner._slots[inner._target_slot_idx]  # type: ignore[attr-defined]
+            placed = [(inner._get_object_pose()[:2], target_slot.bounding_radius)]  # type: ignore[attr-defined]
+            for slot in active:
+                # A slot parked on an earlier reset must regain collisions when
+                # it becomes active again.
+                assert inner.model.geom_contype[slot.geom_id] == 1
+                assert inner.model.geom_conaffinity[slot.geom_id] == 1
+                xy = inner.data.qpos[slot.qpos_addr : slot.qpos_addr + 2]
+                r = float(np.hypot(xy[0] - cx, xy[1] - cy))
+                assert cfg.spawn_min_radius - 1e-6 <= r <= cfg.spawn_max_radius + 1e-6
+                placed.append((xy, slot.bounding_radius))
+            for xy_i, r_i in placed:
+                disc_dist = float(np.linalg.norm(np.asarray(xy_i) - disc_xy))
+                assert disc_dist >= cfg.min_object_target_separation + r_i - 1e-6
+            for i, (xy_i, r_i) in enumerate(placed):
+                for xy_j, r_j in placed[i + 1 :]:
+                    dist = float(np.linalg.norm(np.asarray(xy_i) - np.asarray(xy_j)))
+                    assert dist >= cfg.min_object_separation + r_i + r_j - 1e-6
+    finally:
+        env.close()
+
+
+def test_pick_and_place_min_object_separation_widens_distractor_spacing():
+    """``min_object_separation`` is a live knob, not a documented default."""
+    wide = PickAndPlaceConfig(n_distractors=1, min_object_separation=0.15)
+    env = gym.make("MuJoCoPickAndPlace-v1", config=wide)
+    try:
+        for seed in range(5):
+            env.reset(seed=seed)
+            inner = env.unwrapped
+            slot = next(
+                s
+                for s in inner._distractor_slots  # type: ignore[attr-defined]
+                if inner.data.qpos[s.qpos_addr + 2] > 0.0
+            )
+            xy = inner.data.qpos[slot.qpos_addr : slot.qpos_addr + 2]
+            obj_xy = inner._get_object_pose()[:2]  # type: ignore[attr-defined]
+            obj_r = inner._slots[inner._target_slot_idx].bounding_radius  # type: ignore[attr-defined]
+            floor = wide.min_object_separation + slot.bounding_radius + obj_r
+            assert float(np.linalg.norm(xy - obj_xy)) >= floor - 1e-6
+    finally:
+        env.close()
+
+
+def test_pick_and_place_distractors_do_not_change_obs_or_task():
+    """Distractors are scene clutter only: obs width, task string, and the
+    reported target stay those of the carried pool."""
+    env = gym.make("MuJoCoPickAndPlace-v1", config=PickAndPlaceConfig(n_distractors=3))
+    try:
+        obs, info = env.reset(seed=1)
+        assert obs.shape == (43,)
+        assert info["target_index"] == 0
+        assert info["target_object"] == "red cube"
+        assert env.unwrapped.task_description == (  # type: ignore[attr-defined]
+            "Pick up the red cube and place it on the blue circle."
+        )
+        for _ in range(5):
+            _, reward, _, _, _ = env.step(env.action_space.sample())
+            assert np.isfinite(reward)
+    finally:
+        env.close()
+
+
 def test_pick_and_place_success_false_at_reset():
     env = gym.make("MuJoCoPickAndPlace-v1")
     try:

--- a/tests/mujoco/test_pick_and_place_config.py
+++ b/tests/mujoco/test_pick_and_place_config.py
@@ -17,6 +17,7 @@ os.environ.setdefault("MUJOCO_GL", "egl")
 import so101_nexus.mujoco  # noqa: F401
 from so101_nexus.config import PickAndPlaceConfig
 from so101_nexus.mujoco.pick_and_place import PickAndPlaceEnv
+from so101_nexus.objects import CubeObject, YCBObject
 
 _CFG = PickAndPlaceConfig()
 
@@ -45,6 +46,68 @@ class TestConstructionValidation:
     def test_negative_object_static_ang_threshold(self):
         with pytest.raises(ValueError, match="object_static_ang_threshold"):
             PickAndPlaceConfig(object_static_ang_threshold=-0.5)
+
+    def test_negative_min_object_separation(self):
+        with pytest.raises(ValueError, match="min_object_separation"):
+            PickAndPlaceConfig(min_object_separation=-0.01)
+
+
+class TestDistractorDefaults:
+    def test_default_has_no_distractors(self):
+        assert _CFG.n_distractors == 0
+
+    def test_default_distractor_pool_avoids_carried_and_target_colors(self):
+        colors = {obj.color for obj in _CFG.distractors}
+        assert colors.isdisjoint({_CFG.cube_colors, _CFG.target_colors})
+
+    def test_default_distractor_pool_matches_configured_cube_geometry(self):
+        cfg = PickAndPlaceConfig(cube_half_size=0.02, cube_mass=0.05)
+        assert [(o.half_size, o.mass) for o in cfg.distractors] == [(0.02, 0.05)] * 3
+
+
+class TestDistractorValidation:
+    def test_negative_distractors_raises(self):
+        with pytest.raises(ValueError, match="n_distractors must be >= 0"):
+            PickAndPlaceConfig(n_distractors=-1)
+
+    def test_more_distractors_than_pool_raises(self):
+        with pytest.raises(ValueError, match="distractors pool must have at least"):
+            PickAndPlaceConfig(distractors=[CubeObject(color="green")], n_distractors=2)
+
+    def test_empty_distractor_pool_raises(self):
+        with pytest.raises(ValueError, match="distractors must not be empty"):
+            PickAndPlaceConfig(distractors=[])
+
+    def test_single_distractor_wrapped_in_list(self):
+        cfg = PickAndPlaceConfig(distractors=CubeObject(color="green"), n_distractors=1)
+        assert len(cfg.distractors) == 1
+        assert cfg.distractors[0].color == "green"
+
+    def test_distractor_color_matching_carried_cube_warns(self):
+        with pytest.warns(UserWarning, match="ambiguous"):
+            PickAndPlaceConfig(distractors=[CubeObject(color="red")], n_distractors=1)
+
+    def test_distractor_color_matching_explicit_pool_warns(self):
+        with pytest.warns(UserWarning, match="ambiguous"):
+            PickAndPlaceConfig(
+                objects=[CubeObject(color="green")],
+                distractors=[CubeObject(color="green")],
+                n_distractors=1,
+            )
+
+    def test_distractor_color_matching_disc_does_not_warn(self, recwarn):
+        # The instruction names the goal as a circle, so a blue distractor cube
+        # beside the blue disc is unambiguous.
+        PickAndPlaceConfig(distractors=[CubeObject(color="blue")], n_distractors=1)
+        assert len(recwarn) == 0
+
+    def test_unused_distractor_pool_does_not_warn(self, recwarn):
+        PickAndPlaceConfig(distractors=[CubeObject(color="red")], n_distractors=0)
+        assert len(recwarn) == 0
+
+    def test_non_cube_distractors_never_warn(self, recwarn):
+        PickAndPlaceConfig(distractors=[YCBObject("011_banana")], n_distractors=1)
+        assert len(recwarn) == 0
 
 
 class TestSharedConstants:

--- a/tests/warp/test_warp_envs.py
+++ b/tests/warp/test_warp_envs.py
@@ -379,6 +379,93 @@ def test_pnp_target_varies_per_world_and_respects_separation():
     assert not info["success"].any()
 
 
+def test_pnp_distractors_active_per_world_and_clear_of_the_disc():
+    """Each world activates exactly ``n_distractors`` pool slots inside the spawn
+    annulus, clear of the goal disc and the carried object, and target selection
+    stays inside the carried pool."""
+    import torch
+
+    from so101_nexus.config import PickAndPlaceConfig
+    from so101_nexus.warp.pick_and_place import WarpPickAndPlaceVectorEnv
+
+    cfg = PickAndPlaceConfig(n_distractors=2)
+    env = WarpPickAndPlaceVectorEnv(num_envs=8, config=cfg, device="cpu", seed=0)
+    env.reset(seed=0)
+    assert env._n_pool == 1  # carried pool only; distractors are never the target
+    assert env._d_pool == len(cfg.distractors)
+    assert bool((env._target_slot == 0).all())
+
+    disc_xy = env._target_disc_pos()[:, :2]
+    obj_xy = env._target_pos()[:, :2]
+    center = torch.tensor(cfg.spawn_center)
+    active = torch.zeros(8, env._d_pool, dtype=torch.bool)
+    for j in range(env._d_pool):
+        qa = int(env._slot_qadr[env._d_offset + j])
+        xy = env.qpos[:, qa : qa + 2]
+        radius = float(env._slot_bradius[env._d_offset + j])
+        on_table = torch.linalg.norm(xy - center, dim=1) <= cfg.spawn_max_radius + 1e-5
+        active[:, j] = on_table
+        # Hidden slots sit in the off-world band, so only active ones are checked.
+        disc_gap = torch.linalg.norm(xy - disc_xy, dim=1)[on_table]
+        assert bool((disc_gap >= cfg.min_object_target_separation + radius - 1e-5).all())
+        obj_gap = torch.linalg.norm(xy - obj_xy, dim=1)[on_table]
+        floor = cfg.min_object_separation + radius + float(env._slot_bradius[0])
+        assert bool((obj_gap >= floor - 1e-5).all())
+    assert bool((active.sum(dim=1) == cfg.n_distractors).all())
+    # Selection is per world, not one shared subset broadcast to every world.
+    assert not bool((active == active[0]).all())
+
+
+def test_pnp_target_index_pin_rejects_distractor_slots():
+    """``target_index`` is validated against the carried pool, so the trailing
+    distractor slots stay unpinnable."""
+    from so101_nexus.config import PickAndPlaceConfig
+    from so101_nexus.warp.pick_and_place import WarpPickAndPlaceVectorEnv
+
+    env = WarpPickAndPlaceVectorEnv(
+        num_envs=2, config=PickAndPlaceConfig(n_distractors=2), device="cpu", seed=0
+    )
+    with pytest.raises(ValueError, match="target_index"):
+        env.reset(seed=0, options={"target_index": 1})
+
+
+def test_pnp_default_scene_compiles_no_distractor_slots():
+    """n_distractors=0 compiles the carried pool alone, so the default contact
+    budget is unchanged even when a distractors pool is configured."""
+    from so101_nexus.config import PickAndPlaceConfig
+    from so101_nexus.warp.pick_and_place import WarpPickAndPlaceVectorEnv
+
+    cfg = PickAndPlaceConfig()
+    env = WarpPickAndPlaceVectorEnv(num_envs=2, config=cfg, device="cpu", seed=0)
+    assert env._d_pool == 0
+    assert env._n_total_slots == len(cfg.object_pool())
+    assert env._n_total_slots == env._n_pool
+
+
+def test_pnp_min_object_separation_is_a_live_knob():
+    """An exaggerated ``min_object_separation`` widens the enforced spacing across
+    every active slot, carried object included."""
+    import torch
+
+    from so101_nexus.config import PickAndPlaceConfig
+    from so101_nexus.warp.pick_and_place import WarpPickAndPlaceVectorEnv
+
+    cfg = PickAndPlaceConfig(n_distractors=1, min_object_separation=0.15)
+    env = WarpPickAndPlaceVectorEnv(num_envs=8, config=cfg, device="cpu", seed=0)
+    env.reset(seed=0)
+
+    center = torch.tensor(cfg.spawn_center)
+    qa = int(env._slot_qadr[env._d_offset])
+    xy = env.qpos[:, qa : qa + 2]
+    radius = float(env._slot_bradius[env._d_offset])
+    on_table = torch.linalg.norm(xy - center, dim=1) <= cfg.spawn_max_radius + 1e-5
+    assert bool(on_table.any())
+
+    gap = torch.linalg.norm(xy - env._target_pos()[:, :2], dim=1)[on_table]
+    floor = cfg.min_object_separation + radius + float(env._slot_bradius[0])
+    assert bool((gap >= floor - 1e-5).all())
+
+
 def test_primitive_supports_central_end_effector_pose():
     import torch
 

--- a/uv.lock
+++ b/uv.lock
@@ -3504,7 +3504,7 @@ wheels = [
 
 [[package]]
 name = "so101-nexus"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "gymnasium" },


### PR DESCRIPTION
## What changed

Adds `n_distractors`, `distractors`, and `min_object_separation` to `PickAndPlaceConfig`, placing non-target clutter alongside the carried object on both the MuJoCo and Warp backends. Bumps the package to `0.5.1`.

Distractors are drawn without replacement each episode from a pool that is **separate from the carried objects**, so unlike `PickEnv` (whose distractors share the target pool) a distractor here can never become the carried object. This mirrors `StackCubeEnv`. The MuJoCo slot-activation logic moved out of `stack_cube.py` into a shared `spawn_utils.activate_distractor_slots`.

## Why

Clutter is the cheapest available source of visual and contact realism for pick-and-place, and the pool machinery already existed for pick and stack-cube. Extending it keeps the three tasks consistent instead of leaving pick-and-place as the odd one out.

## Validation

- `make format && make lint && make typecheck` clean.
- `make test`: 1528 passed, 2 skipped, coverage 92.81% (gate 84%).
- `make test-warp`: 230 passed.
- `make docs-check` clean; `tests/test_docs_consistency.py` passes.
- Determinism goldens for `MuJoCoPickAndPlace-v1` and `MuJoCoStackCube-v1` pass **unchanged**, which is the real proof that the `stack_cube.py` refactor preserves the RNG draw order and that the `n_distractors == 0` scene is byte-identical.

## Review

Four parallel reviewers covered core config, the MuJoCo backend, the Warp backend, and teleop/docs. All returned approve-with-comments with no blockers and no majors. Findings fixed in this PR:

- `PickAndPlaceConfig` did not validate `cube_mass`, so an invalid value surfaced indirectly as `mass must be positive` raised by the default distractor pool's cubes. Now raises `cube_mass must be > 0`, matching `StackCubeConfig`. Repeated non-negative checks were factored into `_require_non_negative` to stay under the branch limit.
- `_build_slot_model` trusted `n_target_pool` and `slot_names` rather than asserting them. An out-of-range `n_target_pool` would have made a distractor pinnable via `target_index` and indexed past the per-slot tensors. Both are now validated.
- Added the missing no-dead-knob coverage: a runtime test that a custom `distractors` pool reaches the compiled scene, a Warp default-scene test, and a Warp `min_object_separation` live-knob test at an exaggerated value.
- Strengthened a separation assertion that dropped the bounding radii, and compared `model.nbody` / `model.nq` against a baseline so the "no extra freejoint bodies" claim is actually measured.
- Docstring corrections: the mechanism mirrors `StackCubeEnv`, not `PickEnv`; the goal-disc clearance is measured to the disc center, so it does not guarantee zero overlap with the disc's outer annulus.
- Naming: `_contact_budget(n_pool)` -> `n_slots` (it receives the total slot count, and passing `_n_pool` there would silently under-size the contact budget); local `n_active` -> `n_placed` to stop it shadowing the meaning of `self._n_active`.
- Shared the duplicated teleop pick-pool discriminator as `has_pick_object_pool`.

Deliberately **not** done here: folding `_sample_object_positions` into `spawn_utils.sample_separated_positions`. It is a genuine DRY win but touches the sampler `StackCubeEnv` shares, risking an RNG draw-order change right before a release. Worth doing separately.
