### PR TITLE
perf: cut per-step Python overhead and per-reset device syncs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,27 @@ for the public-API and deprecation policy.
 
 ### Changed
 
+- Performance only, no behavior change. Observations, rewards, info dicts and the RNG draw
+  sequence are bit-identical before and after on both backends.
+  - MuJoCo envs step 2 to 11 percent faster, most on the object-manipulation tasks that read
+    the most per step (`MuJoCoStackCube-v1` 126 to 112 us/step, `MuJoCoPickLift-v1` 92 to 86;
+    zero action, interleaved A/B, median of four rounds).
+    `reset` and `step` now build the observation and the info dict inside one window that
+    memoizes the TCP pose and the grasp predicate, instead of recomputing each two or three
+    times per step; the observation component list dispatches through a per-type cache rather
+    than an `isinstance` ladder over abstract base classes; and the grasp and gripper contact
+    force scans select the contacts they care about from MuJoCo's contact arrays instead of
+    building a wrapper object per contact.
+  - Warp `_task_reset` is 73 to 83 percent faster at 512 worlds (`WarpPickLift-v1` 11.9 to
+    2.1 ms, `WarpStackCube-v1` 25.7 to 6.8 ms, `WarpPickAndPlace-v1` 17.7 to 3.9 ms), which is
+    paid on every same-step autoreset during a rollout. Slot addresses and per-world target and
+    color indices are read from the device once per reset instead of once per slot and once per
+    world, removing two device synchronizations per slot plus two (pick-lift, pick-and-place)
+    or three (stack-cube) per resetting world.
+  - `import so101_nexus` no longer imports `importlib.metadata`, which pulled in the `email`,
+    `zipfile`, `csv`, `socket` and `tempfile` trees: 205 modules instead of 264.
+    `so101_nexus.__version__` now resolves on first access and is unchanged.
+
 ### Fixed
 
 ### Removed

--- a/src/so101_nexus/__init__.py
+++ b/src/so101_nexus/__init__.py
@@ -2,14 +2,8 @@
 
 from __future__ import annotations
 
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as _package_version
 from pathlib import Path
-
-try:
-    __version__ = _package_version("so101-nexus")
-except PackageNotFoundError:  # pragma: no cover - running from a source tree
-    __version__ = "0.0.0+unknown"
+from typing import TYPE_CHECKING
 
 from so101_nexus.config import (
     ABSOLUTE_CONTROL_MODES,
@@ -112,6 +106,39 @@ from so101_nexus.ycb_geometry import get_mujoco_ycb_rest_pose
 
 ASSETS_DIR = Path(__file__).resolve().parent / "assets"
 SO101_DIR = ASSETS_DIR / "SO101"
+
+
+if TYPE_CHECKING:
+    # Declared for type checkers so ``so101_nexus.__version__`` keeps its type
+    # and, more importantly, so the runtime ``__getattr__`` below does not make
+    # every misspelled ``so101_nexus.X`` resolve instead of erroring.
+    __version__: str
+else:
+
+    def __getattr__(name: str) -> str:
+        """Resolve ``__version__`` on first access.
+
+        Reading installed distribution metadata pulls in 59 modules (the
+        ``email``, ``zipfile``, ``csv``, ``socket`` and ``tempfile`` trees)
+        that nothing else in the eager import needs, and every backend, CLI
+        and test import pays for them. Resolving it here keeps the eager
+        import light while ``so101_nexus.__version__`` stays a plain module
+        attribute afterwards.
+        """
+        if name != "__version__":
+            raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+        from importlib.metadata import PackageNotFoundError, version
+
+        try:
+            resolved = version("so101-nexus")
+        except PackageNotFoundError:  # pragma: no cover - running from a source tree
+            resolved = "0.0.0+unknown"
+        globals()["__version__"] = resolved
+        return resolved
+
+    def __dir__() -> list[str]:
+        """Include the lazily resolved ``__version__`` before it is first read."""
+        return sorted({*globals(), *__all__})
 
 
 def get_so101_simulation_dir() -> Path:

--- a/src/so101_nexus/mujoco/base_env.py
+++ b/src/so101_nexus/mujoco/base_env.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from enum import Enum
+from functools import cache, wraps
+from typing import TYPE_CHECKING, Any, Protocol
 
 import gymnasium
 import mujoco
@@ -49,6 +51,9 @@ from so101_nexus.observations import (
 )
 from so101_nexus.rewards import lift_progress, potential_shaping, reach_progress
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
 logger = logging.getLogger(__name__)
 
 # Internal per-joint physical scale applied to a normalized delta action.
@@ -70,6 +75,66 @@ _DELTA_ACTION_SCALE = np.array([0.05, 0.05, 0.05, 0.05, 0.05, 0.2], dtype=np.flo
 # set gives a maximum TCP reach of 0.5457 m, so 0.55 m spans the workspace
 # without admitting targets the solver could only clamp toward.
 _EE_WORKSPACE_RADIUS = 0.55
+
+
+class _Dispatch(Enum):
+    """The two observation branches that are not a base reader method.
+
+    ``TASK`` routes the component through ``_get_component_data``; ``SKIP``
+    marks a camera component, rendered in ``_get_obs`` rather than placed in
+    the flat state vector. An enum rather than string constants so a mis-typed
+    reader name can never be mistaken for a branch, which would silently
+    reshape the observation vector instead of raising.
+    """
+
+    TASK = "task"
+    SKIP = "camera"
+
+
+_CACHE_MISS = object()
+
+
+class _Reader[ReadT](Protocol):
+    """An unbound zero-argument physics reader, as ``_observation_scoped`` sees it.
+
+    Narrower than ``Callable`` because the decorator keys its memo on the
+    method's ``__name__``.
+    """
+
+    __name__: str
+
+    def __call__(self, env: Any, /) -> ReadT:
+        """Read the quantity off the environment's live MuJoCo state."""
+        ...
+
+
+def _observation_scoped[ReadT](method: _Reader[ReadT]) -> Callable[[Any], ReadT]:
+    """Memoize a zero-argument physics reader for the duration of one ``_observe``.
+
+    The decorated readers are pure functions of the current ``self.data``, and
+    ``_get_obs`` and ``_get_info`` each ask for several of the same ones while
+    describing a single physics state. Outside the ``_observe`` window
+    ``_read_cache`` is ``None`` and every call recomputes from live MuJoCo
+    state, so no caller can be handed a value belonging to an earlier state.
+    An instance attribute assigned over the reader (how the tests pin a grasp)
+    shadows this wrapper entirely and is never cached.
+
+    A memoized reader hands the same array to every caller inside the window,
+    so a decorated reader must not return anything a caller mutates in place.
+    """
+    key = method.__name__
+
+    @wraps(method)
+    def reader(self: Any) -> ReadT:
+        memo = self._read_cache
+        if memo is None:
+            return method(self)
+        value = memo.get(key, _CACHE_MISS)
+        if value is _CACHE_MISS:
+            value = memo[key] = method(self)
+        return value
+
+    return reader
 
 
 def _configure_free_camera(cam: mujoco.MjvCamera, params: dict[str, Any]) -> None:
@@ -110,6 +175,10 @@ class SO101NexusMuJoCoBaseEnv(gymnasium.Env):
     # Menagerie physics uses timestep=0.005; keep control_dt = timestep *
     # _N_SUBSTEPS = 0.02 s (unchanged from the old 0.002 * 10).
     _N_SUBSTEPS = 4
+    # Memo for the @_observation_scoped readers, non-None only inside _observe.
+    # A plain class-level None is safe here (unlike a mutable default): _observe
+    # rebinds it per instance for the window and clears it back to None.
+    _read_cache: dict[str, Any] | None = None
 
     def _init_common(
         self,
@@ -168,6 +237,11 @@ class SO101NexusMuJoCoBaseEnv(gymnasium.Env):
         # filter in _get_finger_geoms.
         self._gripper_geom_ids = self._get_finger_geoms(self._gripper_body_id)
         self._jaw_geom_ids = self._get_finger_geoms(self._jaw_body_id)
+        # Same two sets as a per-geom boolean lookup, so the contact scan can
+        # classify every contact with one fancy-index instead of a Python
+        # membership test per contact.
+        self._finger_geom_mask = np.zeros(self.model.ngeom, dtype=bool)
+        self._finger_geom_mask[list(self._gripper_geom_ids | self._jaw_geom_ids)] = True
 
         # Per-joint qpos/qvel addresses for the six controlled joints; the arm
         # slices (gripper excluded) back the static-robot check and IK.
@@ -436,6 +510,7 @@ class SO101NexusMuJoCoBaseEnv(gymnasium.Env):
         # Legacy default for pick envs that haven't migrated yet
         return 18
 
+    @_observation_scoped
     def _get_tcp_pose(self) -> np.ndarray:
         """Return the tool-centre-point pose as a 7-vector [x, y, z, qw, qx, qy, qz]."""
         pos = self.data.site_xpos[self._tcp_site_id].copy()
@@ -506,6 +581,7 @@ class SO101NexusMuJoCoBaseEnv(gymnasium.Env):
         gripper = np.clip(gripper_target, self._target_low[-1], self._target_high[-1])
         return np.concatenate([q, [gripper]])
 
+    @_observation_scoped
     def _is_grasping(self) -> float:
         """Return 1.0 when the two finger sets pinch the target object.
 
@@ -523,19 +599,28 @@ class SO101NexusMuJoCoBaseEnv(gymnasium.Env):
         float
             1.0 when a pinching two-sided grasp is detected, 0.0 otherwise.
         """
+        # Building a per-contact wrapper (data.contact[i]) costs more than the
+        # force solve itself, so the object's contacts are selected from the
+        # struct-of-arrays view first; ascending order matches the old scan, so
+        # the accumulation is unchanged. _obj_geom_id is read only once there is
+        # a contact to classify, matching the old scan for the primitive envs
+        # that never define it.
+        contacts = self.data.contact
+        geoms = contacts.geom[: self.data.ncon]
+        if geoms.shape[0] == 0:
+            return 0.0
+        obj_geom_id = self._obj_geom_id
+        rows = np.flatnonzero((geoms == obj_geom_id).any(axis=1))
+        if rows.size == 0:
+            return 0.0
+
         gripper_normal = np.zeros(3)
         jaw_normal = np.zeros(3)
-
+        frames = contacts.frame
         force_buf = np.zeros(6)
-        for i in range(self.data.ncon):
-            contact = self.data.contact[i]
-            g1, g2 = contact.geom1, contact.geom2
-
-            obj_involved = self._obj_geom_id in (g1, g2)
-            if not obj_involved:
-                continue
-
-            other = g2 if g1 == self._obj_geom_id else g1
+        for i in rows:
+            g1, g2 = geoms[i]
+            other = int(g2 if g1 == obj_geom_id else g1)
             if other in self._gripper_geom_ids:
                 accum = gripper_normal
             elif other in self._jaw_geom_ids:
@@ -548,10 +633,10 @@ class SO101NexusMuJoCoBaseEnv(gymnasium.Env):
             if normal_force < self.config.robot.grasp_force_threshold:
                 continue
 
-            # contact.frame's first row is the normal pointing from geom1 to
+            # The contact frame's first row is the normal pointing from geom1 to
             # geom2; flip it when the object is geom1 so it points into the
             # object for both orderings.
-            normal = contact.frame[:3] if g2 == self._obj_geom_id else -contact.frame[:3]
+            normal = frames[i, :3] if g2 == obj_geom_id else -frames[i, :3]
             accum += normal_force * normal
 
         if not (gripper_normal.any() and jaw_normal.any()):
@@ -641,20 +726,24 @@ class SO101NexusMuJoCoBaseEnv(gymnasium.Env):
         ``_is_grasping`` this needs no target object, so primitive envs can use
         it too.
         """
+        # Same struct-of-arrays prefilter as _is_grasping: build the per-contact
+        # wrapper only for the contacts that turn out to involve a finger.
+        contacts = self.data.contact
+        geoms = contacts.geom[: self.data.ncon]
+        fingers = self._finger_geom_mask[geoms]
+        rows = np.flatnonzero(fingers[:, 0] != fingers[:, 1])
         total = np.zeros(3)
+        if rows.size == 0:
+            return total
+
+        frames = contacts.frame
         force_buf = np.zeros(6)
-        for i in range(self.data.ncon):
-            contact = self.data.contact[i]
-            g1, g2 = contact.geom1, contact.geom2
-            g1_finger = g1 in self._gripper_geom_ids or g1 in self._jaw_geom_ids
-            g2_finger = g2 in self._gripper_geom_ids or g2 in self._jaw_geom_ids
-            if g1_finger == g2_finger:
-                continue  # neither side is a finger, or a finger touching itself
+        for i in rows:
             mujoco.mj_contactForce(self.model, self.data, i, force_buf)
             # mj_contactForce reports the force on geom2 in the contact frame,
             # whose rows are the normal and the two tangents.
-            world = contact.frame.reshape(3, 3).T @ force_buf[:3]
-            total += world if g2_finger else -world
+            world = frames[i].reshape(3, 3).T @ force_buf[:3]
+            total += world if fingers[i, 1] else -world
         return total
 
     #: Components the base reads directly, by reader method name. Resolved
@@ -673,35 +762,70 @@ class SO101NexusMuJoCoBaseEnv(gymnasium.Env):
         GazeDirection: "_gaze_direction",
     }
 
+    #: Task components routed to ``_get_component_data``; a component outside
+    #: both this tuple and ``_BASE_COMPONENT_READERS`` is rejected.
+    _TASK_COMPONENTS: tuple[type, ...] = (
+        TargetOffset,
+        ObjectPose,
+        ObjectVelocity,
+        ObjectOffset,
+        TargetPosition,
+    )
+
+    def _grasp_state_obs(self) -> np.ndarray:
+        """GraspState as a 1-vector."""
+        return np.array([self._is_grasping()])
+
+    def _gaze_state_obs(self) -> np.ndarray:
+        """GazeState as a 1-vector."""
+        return np.array([self._is_looking_at()])
+
     def _compute_obs_components(self) -> np.ndarray:
         """Build the flat state vector from the observation component list."""
         parts: list[np.ndarray] = []
         if self.config.observations is None:
             raise RuntimeError("config.observations must be set")
         for comp in self.config.observations:
-            reader = self._base_component_reader(type(comp))
-            if reader is not None:
-                parts.append(getattr(self, reader)())
-            elif isinstance(comp, GraspState):
-                parts.append(np.array([self._is_grasping()]))
-            elif isinstance(comp, GazeState):
-                parts.append(np.array([self._is_looking_at()]))
-            elif isinstance(
-                comp,
-                (TargetOffset, ObjectPose, ObjectVelocity, ObjectOffset, TargetPosition),
-            ):
-                parts.append(self._get_component_data(comp))
-            elif isinstance(comp, CameraObservation):
+            reader = self._component_reader(type(comp))
+            if reader is _Dispatch.SKIP:
                 continue  # camera images handled separately in _get_obs
-            else:
+            if reader is _Dispatch.TASK:
+                parts.append(self._get_component_data(comp))
+            elif reader is None:
                 raise ValueError(f"Unsupported observation component: {comp!r}")
+            else:
+                parts.append(getattr(self, reader)())
         return np.concatenate(parts).astype(np.float32, copy=False)
 
     @classmethod
-    def _base_component_reader(cls, component_type: type) -> str | None:
-        """Return the base reader method for a component type, or ``None``."""
+    @cache
+    def _component_reader(cls, component_type: type) -> str | _Dispatch | None:
+        """Resolve a component type to its dispatch branch, once per (class, type).
+
+        Returns a base reader method name, ``_Dispatch.TASK`` for components
+        ``_get_component_data`` owns, ``_Dispatch.SKIP`` for camera components,
+        or ``None`` when the component is unsupported. Resolution is MRO-based,
+        so a user subclass of a component dispatches like its base, matching the
+        ``isinstance`` chain this replaces. Caching it keeps the per-step
+        observation build off ``ABCMeta.__instancecheck__``, which dominated the
+        dispatch cost for a ten-component observation list. The cache is keyed on
+        the class, so a subclass may rebind ``_BASE_COMPONENT_READERS`` or
+        ``_TASK_COMPONENTS``, but must never mutate either in place: the first
+        lookup for a component type is the one that sticks.
+        """
         readers = cls._BASE_COMPONENT_READERS
-        return next((readers[k] for k in component_type.__mro__ if k in readers), None)
+        for klass in component_type.__mro__:
+            if klass in readers:
+                return readers[klass]
+        if issubclass(component_type, GraspState):
+            return "_grasp_state_obs"
+        if issubclass(component_type, GazeState):
+            return "_gaze_state_obs"
+        if issubclass(component_type, cls._TASK_COMPONENTS):
+            return _Dispatch.TASK
+        if issubclass(component_type, CameraObservation):
+            return _Dispatch.SKIP
+        return None
 
     def _resolve_target_index(self, n_pool: int) -> int | None:
         """Return this reset's ``options['target_index']`` override, or ``None``.
@@ -774,9 +898,23 @@ class SO101NexusMuJoCoBaseEnv(gymnasium.Env):
         self._settle_after_reset()
         self._refresh_reset_reference_state()
 
-        obs = self._get_obs()
-        info = self._get_info()
-        return obs, info
+        return self._observe()
+
+    def _observe(self) -> tuple[np.ndarray | dict[str, np.ndarray], dict]:
+        """Return ``(obs, info)`` describing the current physics state.
+
+        The two halves are separate methods but describe one state, and they
+        ask the ``@_observation_scoped`` readers for several of the same
+        quantities (a ten-component observation list plus a task info dict
+        reads the TCP pose three times and the grasp predicate twice). This
+        opens the memo window around both, and closes it on the way out so
+        every read taken outside ``reset``/``step`` still hits live MuJoCo.
+        """
+        self._read_cache = {}
+        try:
+            return self._get_obs(), self._get_info()
+        finally:
+            self._read_cache = None
 
     def _settle_after_reset(self) -> None:
         """Advance configured no-op frames after reset before returning observations."""
@@ -853,8 +991,7 @@ class SO101NexusMuJoCoBaseEnv(gymnasium.Env):
         for _ in range(self._N_SUBSTEPS):
             mujoco.mj_step(self.model, self.data)
 
-        obs = self._get_obs()
-        info = self._get_info()
+        obs, info = self._observe()
         info["energy_norm"] = float(np.linalg.norm(public_action))
         if self._prev_action is None:
             info["action_delta_norm"] = 0.0

--- a/src/so101_nexus/warp/pick_env.py
+++ b/src/so101_nexus/warp/pick_env.py
@@ -191,6 +191,14 @@ class WarpPickLiftVectorEnv(SO101NexusWarpVectorEnv):
         self._slot_objs = scene_objects
         self._slot_qadr = torch.tensor([s.qpos_addr for s in slots], device=self.device)
         self._slot_dadr = torch.tensor([s.dof_addr for s in slots], device=self.device)
+        # Host-side copies of the same addresses. ``_hide_all_slots`` indexes one
+        # slot at a time, and reading each address back off the device there is a
+        # synchronization per slot per autoreset, i.e. on most steps of a rollout.
+        self._slot_qadr_host = [s.qpos_addr for s in slots]
+        self._slot_dadr_host = [s.dof_addr for s in slots]
+        # Free-joint position offsets, reused by every slot write below so the
+        # reset path does not rebuild them per active slot.
+        self._qpos_offsets = torch.arange(7, device=self.device)
         self._slot_geom = torch.tensor(
             [s.geom_id for s in slots], dtype=torch.long, device=self.device
         )
@@ -289,13 +297,12 @@ class WarpPickLiftVectorEnv(SO101NexusWarpVectorEnv):
         Slot qpos columns are shared across worlds, so hiding uses fixed slices;
         active slots are overwritten afterward by ``_place_active_slots``.
         """
-        for j in range(self._n_total_slots):
-            qa = int(self._slot_qadr[j])
+        for j, qa in enumerate(self._slot_qadr_host):
             self.qpos[idx, qa] = self._hide_xy[j, 0]
             self.qpos[idx, qa + 1] = self._hide_xy[j, 1]
             self.qpos[idx, qa + 2] = self._slot_spawn_z[j]
             self.qpos[idx, qa + 3 : qa + 7] = self._slot_rest_quat[j]
-            da = int(self._slot_dadr[j])
+            da = self._slot_dadr_host[j]
             self.qvel[idx, da : da + 6] = 0.0
 
     def _place_active_slots(
@@ -309,10 +316,10 @@ class WarpPickLiftVectorEnv(SO101NexusWarpVectorEnv):
             base = self._slot_qadr[sel_k]
             yaw = random_yaw_quat_batch(self._generator, self.device, n)
             quat = quat_mul_wxyz(yaw, self._slot_rest_quat[sel_k])
-            self.qpos[rows, base[:, None] + torch.arange(3, device=self.device)] = torch.cat(
+            self.qpos[rows, base[:, None] + self._qpos_offsets[:3]] = torch.cat(
                 [positions[:, k], self._slot_spawn_z[sel_k][:, None]], dim=1
             )
-            self.qpos[rows, base[:, None] + 3 + torch.arange(4, device=self.device)] = quat
+            self.qpos[rows, base[:, None] + self._qpos_offsets[3:]] = quat
 
     def _set_target_tracking(self, idx: torch.Tensor, target: torch.Tensor) -> None:
         """Record the per-world target slot and refresh its task description."""
@@ -323,10 +330,10 @@ class WarpPickLiftVectorEnv(SO101NexusWarpVectorEnv):
         self._target_qadr[idx] = self._slot_qadr[target]
         self._target_dadr[idx] = self._slot_dadr[target]
         self._initial_obj_z[idx] = self._slot_spawn_z[target]
-        for i in range(int(idx.numel())):
-            self.task_descriptions[int(idx[i])] = self._describe_target(
-                self._slot_objs[int(target[i])]
-            )
+        # One device read per tensor instead of one per world: indexing a CUDA
+        # tensor element by element synchronizes on every element.
+        for world, slot in zip(idx.tolist(), target.tolist(), strict=True):
+            self.task_descriptions[world] = self._describe_target(self._slot_objs[slot])
 
     def _task_reset(self, mask: torch.Tensor) -> None:
         idx = mask.nonzero(as_tuple=True)[0]

--- a/src/so101_nexus/warp/stack_cube.py
+++ b/src/so101_nexus/warp/stack_cube.py
@@ -175,6 +175,13 @@ class WarpStackCubeVectorEnv(SO101NexusWarpVectorEnv):
         n_slots = len(slots)
         self._slot_qadr = torch.tensor([s.qpos_addr for s in slots], device=self.device)
         self._slot_dadr = torch.tensor([s.dof_addr for s in slots], device=self.device)
+        # Host-side copies of the same addresses, so parking the slots at reset
+        # does not synchronize once per slot (see WarpPickLiftVectorEnv).
+        self._slot_qadr_host = [s.qpos_addr for s in slots]
+        self._slot_dadr_host = [s.dof_addr for s in slots]
+        # Free-joint component offsets, reused by every slot write at reset.
+        self._qpos_offsets = torch.arange(7, device=self.device)
+        self._dof_offsets = torch.arange(6, device=self.device)
         self._slot_geom = torch.tensor(
             [s.geom_id for s in slots], dtype=torch.long, device=self.device
         )
@@ -341,13 +348,12 @@ class WarpStackCubeVectorEnv(SO101NexusWarpVectorEnv):
         # Park every slot off-world with zeroed velocity (Warp contact bits are
         # model-global, so inactive cubes cannot have collisions disabled);
         # the two selected slots per world are overwritten below.
-        for j in range(len(self._slot_qadr)):
-            qa = int(self._slot_qadr[j])
+        for j, qa in enumerate(self._slot_qadr_host):
             self.qpos[idx, qa] = self._hide_xy[j, 0]
             self.qpos[idx, qa + 1] = self._hide_xy[j, 1]
             self.qpos[idx, qa + 2] = self._slot_spawn_z[j]
             self.qpos[idx, qa + 3 : qa + 7] = self._slot_rest_quat[j]
-            da = int(self._slot_dadr[j])
+            da = self._slot_dadr_host[j]
             self.qvel[idx, da : da + 6] = 0.0
 
         angle = float(np.radians(cfg.spawn_angle_half_range_deg))
@@ -374,12 +380,12 @@ class WarpStackCubeVectorEnv(SO101NexusWarpVectorEnv):
             base = self._slot_qadr[sel_k]  # (n,) qpos address per reset world
             yaw = random_yaw_quat_batch(gen, dev, n)
             quat = quat_mul_wxyz(yaw, self._slot_rest_quat[sel_k])
-            self.qpos[rows, base[:, None] + torch.arange(3, device=dev)] = torch.cat(
+            self.qpos[rows, base[:, None] + self._qpos_offsets[:3]] = torch.cat(
                 [positions[:, k], self._slot_spawn_z[sel_k][:, None]], dim=1
             )
-            self.qpos[rows, base[:, None] + 3 + torch.arange(4, device=dev)] = quat
+            self.qpos[rows, base[:, None] + self._qpos_offsets[3:]] = quat
             dadr = self._slot_dadr[sel_k]
-            self.qvel[rows, dadr[:, None] + torch.arange(6, device=dev)] = 0.0
+            self.qvel[rows, dadr[:, None] + self._dof_offsets] = 0.0
 
         self._a_qadr[idx] = self._slot_qadr[a_sel]
         self._a_dadr[idx] = self._slot_dadr[a_sel]
@@ -388,10 +394,11 @@ class WarpStackCubeVectorEnv(SO101NexusWarpVectorEnv):
         obj_geom = self._obj_geom
         assert obj_geom is not None  # set to a tensor in __init__
         obj_geom[idx] = self._slot_geom[a_sel]
-        for i in range(n):
-            w = int(idx[i])
-            a_color = self._a_colors[int(a_sel[i])]
-            b_color = self._b_colors[int(b_sel_local[i])]
+        # One device read per tensor instead of three per world: indexing a CUDA
+        # tensor element by element synchronizes on every element.
+        for w, a_i, b_i in zip(idx.tolist(), a_sel.tolist(), b_sel_local.tolist(), strict=True):
+            a_color = self._a_colors[a_i]
+            b_color = self._b_colors[b_i]
             self.cube_a_color_names[w] = a_color
             self.cube_b_color_names[w] = b_color
             self.task_descriptions[w] = self._describe_pair(a_color, b_color)


### PR DESCRIPTION
## What changed

Behavior-preserving performance work on the two per-step hot paths and on package import. No public API, config field, CLI flag, dataset schema or documented behavior changes.

**`so101_nexus/mujoco/base_env.py`** - Python overhead was about half of a `step()` (physics is roughly 65 of 126 us on `MuJoCoStackCube-v1`).

- `reset` and `step` now go through `_observe()`, which opens a memo window around the `_get_obs()` / `_get_info()` pair. Those two describe one physics state but were re-reading the same quantities: a ten-component observation list plus a task info dict read the TCP pose three times and ran the grasp predicate twice per step. `_get_tcp_pose` and `_is_grasping` are decorated with `@_observation_scoped`. Outside the window `_read_cache` is `None`, so every read taken from anywhere else recomputes from live MuJoCo state.
- `_compute_obs_components` resolved each component through an `isinstance` ladder over an ABC hierarchy, spending 31 calls per step inside `ABCMeta.__instancecheck__`. `_component_reader` now resolves a component type to its branch once per `(class, type)`. Branch precedence, exception types and exception messages are unchanged.
- `_is_grasping` and `_get_gripper_contact_force` built a wrapper object per contact via `data.contact[i]`, which costs more than the force solve itself. Both now select the contacts they care about from the contact arrays.

**`so101_nexus/warp/pick_env.py`, `so101_nexus/warp/stack_cube.py`** - `_task_reset` read slot addresses and per-world target and color indices one element at a time off CUDA tensors. Each of those forces a device synchronization, so a 512-world reset paid over a thousand of them, on every same-step autoreset rather than only on an explicit `reset()`. Slot addresses are now kept as plain Python lists alongside the device tensors, the per-world loops take one `.tolist()` per tensor, and the free-joint offsets are built once per env. `WarpPickAndPlace` inherits the slot machinery from `WarpPickLift`, so it benefits without a change of its own.

**`so101_nexus/__init__.py`** - `__version__` resolves on first access, so the eager import no longer pulls `importlib.metadata` and the `email`, `zipfile`, `csv`, `socket` and `tempfile` trees behind it. The lazy path is guarded behind `TYPE_CHECKING`, because an unguarded module `__getattr__` tells a type checker that every unresolved attribute on the module is valid.

## Why

Profiling `MuJoCoStackCube-v1` showed `mj_step` at 33 percent of a profiled step and the rest in Python, dominated by duplicated state reads, ABC `isinstance` dispatch and per-contact wrapper construction. On the Warp side, `_task_reset` at 512 worlds was spending most of its time stalled on host-device synchronization rather than on work.

Results, all measured on this machine:

| MuJoCo, us/step, zero action, interleaved A/B, median of four rounds | before | after |
| --- | --- | --- |
| `MuJoCoStackCube-v1` | 125.8 | 112.0 (-10.9%) |
| `MuJoCoMove-v1` | 58.5 | 54.5 (-6.9%) |
| `MuJoCoPickAndPlace-v1` | 106.1 | 99.0 (-6.7%) |
| `MuJoCoPickLift-v1` | 92.2 | 86.2 (-6.6%) |
| `MuJoCoTouch-v1` | 85.4 | 82.7 (-3.2%) |
| `MuJoCoLookAt-v1` | 68.9 | 67.6 (-1.9%) |

| Warp `_task_reset`, 512 worlds | before | after |
| --- | --- | --- |
| `WarpPickLift-v1` | 11.9 ms | 2.1 ms (-83%) |
| `WarpStackCube-v1` | 25.7 ms | 6.8 ms (-73%) |
| `WarpPickAndPlace-v1` | 17.7 ms | 3.9 ms (-78%) |

`import so101_nexus` loads 205 modules instead of 264. The wall-clock effect of that one is within run-to-run noise on a warm cache, so the changelog claims only the module count.

## Validation

Correctness here is a claim about equivalence, not about a new feature, so the primary evidence is bit-exact rollout fingerprints (hashing obs, reward, terminated, truncated and every info value) rather than new tests:

- 6 MuJoCo env ids, default config, 3 seeds x 120 steps: identical.
- 42-entry matrix, every MuJoCo env id crossed with all 5 control modes, plus the largest observation set each env supports including `WristCamera`, `GripperContactForce` and the gaze and object components: identical.
- 6 Warp env ids on the Warp CPU device with `max_episode_steps=5` so autoreset fires constantly: identical. CUDA is nondeterministic run to run independently of this change, which is why CPU is the reference.

Commands:

- `make test` - 1528 passed, 2 skipped, coverage 92.80 percent.
- `make test-warp` - 230 passed.
- `make format lint typecheck` - clean.
- Each of the three commits was checked out in a worktree and smoke tested independently, so `git bisect` stays usable.

Two reviewers went over the diff. One independently instrumented the memo window across all six envs (3 seeds x 40 steps, largest observation sets, wrist and overhead cameras, `visual` obs mode) and confirmed no memoized value ever diverges from a fresh live recompute, with a negative control proving the probe detects an injected mutation; it also diffed the rewritten contact scans against verbatim reimplementations of the old loops over 200 real physics states including 122 with a loaded grasp. Their findings are folded in, including two static-typing regressions the fingerprints could not see: the memo decorator had erased the return types of `_get_tcp_pose` and `_is_grasping`, and the unguarded module `__getattr__` had disabled unresolved-attribute checking across the whole public API. Both are fixed and verified with `reveal_type`.

## Notes for the reviewer

- The memo window is the one change with a real, if closed, failure mode: a future reader decorated with `@_observation_scoped` that is not a pure function of `self.data`, or one whose return value a caller mutates in place, would be wrong inside the window. The decorator docstring says so. Worth an eye.
- Deliberately not done: replacing `np.linalg.norm` with `math.sqrt(v @ v)` on the small vectors in the reward and info paths. It measured about 2.4 percent and is bit-identical over 200k random vectors, but it hand-rolls a formula across 15 sites and silently computes something else on 2-D input, where `norm` gives the Frobenius norm. Not a good trade in reward code.
- Also declined: bounding the `@cache` on `_component_reader` to `lru_cache(maxsize=256)`. `functools.cache` uses a dict-only fast path and this is hit about ten times per step; the unbounded growth only applies to dynamically defined classes, of which the library has none. The docstring now records that subclasses must rebind `_BASE_COMPONENT_READERS` and `_TASK_COMPONENTS` rather than mutate them.
- Pre-existing issue found while testing, not addressed here: `LookAtEnv` and `MoveEnv` raise `AttributeError: '_obj_geom_id'` if configured with a `GraspState` observation and a contact occurs. The new contact scan preserves that behavior exactly rather than papering over it. Happy to open a separate issue.

## Checklist

- [x] Tests added or updated (regression test for a fix; happy path plus an edge case for new behavior).
- [x] `make format lint typecheck` and the relevant tests pass locally.
- [x] Documentation updated if the public API or behavior changed.
- [x] `CHANGELOG.md` `## [Unreleased]` entry added for any user-facing change.
- [x] No em dashes or emoji in prose, docs, or comments.

On the first box: no tests were added. This is a refactor, so per the repo testing policy the bar is "no behavior change, existing tests stay green", which the 1758 existing tests plus the 54 bit-exact rollout fingerprints above cover more tightly than a new test could. On the third: no public API or behavior changed, so no docs edit was needed.
