### PR TITLE
feat(ycb): multi-hull convex collision geometry for YCB objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,50 @@ for the public-API and deprecation policy.
 
 ### Added
 
+- `decomp` extra (`coacd`, `threadpoolctl`) building multi-hull convex collision geometry for
+  YCB objects. `get_ycb_collision_parts(model_id)` returns the convex parts as
+  `YCBCollisionPart(path, mass_fraction)`, `get_ycb_collision_meshes(model_id)` returns just
+  their paths, and `ObjectSlot.geom_ids` lists every collision geom of a slot
+  (`ObjectSlot.geom_id` stays the first one).
+
 ### Changed
 
+- **YCB collision geometry is now a convex decomposition of the scan, not a single convex
+  hull.** Physics saw a fork as a solid wedge and a spatula as a filled slab, burying the
+  feature a policy has to grasp; measured as visual volume over collision volume, the ten
+  shipped models go 0.19 to 0.66 (spatula), 0.31 to 0.74 (spoon), 0.36 to 0.74 (scissors),
+  0.45 to 0.76 (fork), 0.55 to 0.74 (knife), 0.65 to 0.94 (banana), 0.68 to 0.89
+  (screwdriver), 0.84 to 0.89 (large marker), with the gelatin box (0.97) and golf ball
+  (1.00) already convex and left as one hull. Parts are computed once with CoACD, pinned to
+  one OpenMP thread so the split is reproducible, and cached under
+  `~/.cache/so101_nexus/ycb/{model_id}/collision_v2/`; the versioned directory means an
+  existing single-hull cache is rebuilt rather than silently reused, and the manifest records
+  which decomposer wrote the parts, so installing the `decomp` extra later or upgrading CoACD
+  rebuilds them too. Without the extra the collision geometry falls back to the previous
+  single hull. Cube scenes are byte-identical. Each part carries a volume-weighted share of
+  the object's mass, so total body mass is unchanged.
+- `get_ycb_collision_mesh(model_id)` now returns the first convex part
+  (`collision_v2/collision_000.obj`, was `collision.obj`) and reads the decomposition
+  manifest, so it raises `FileNotFoundError` when the model has not been prepared; it was
+  previously a pure path computation that never touched disk. Call `ensure_ycb_assets` first.
+  `ensure_ycb_assets` also deletes the superseded `collision.obj` from an older cache.
+- Grasp detection aggregates contact normals over every collision geom of the target before
+  the opposing-normal test, so fingers landing on different parts of one object still read as
+  a pinch. The MuJoCo env attribute `_obj_geom_id` is now `_obj_geom_ids` (NumPy array) plus
+  an `ngeom`-sized `_obj_geom_mask`, and subclasses must call
+  `_set_target_geoms(slot.geom_ids)` rather than assigning either directly; the Warp
+  `_obj_geom` tensor is now the `(num_envs, ngeom)` boolean `_obj_geom_mask`.
+- `mesh_xml_body()` takes `mass_fractions`, `primary_geom_name()` is now
+  `collision_geom_name(slot_name, obj, part=0)`, mesh collision geoms are named
+  `{slot}_collision_{k}` (was `{slot}_collision`), and their mesh assets `pick_coll_{i}_{k}`
+  (was `pick_coll_{i}`). `align_freejoint_geom_to_floor()` takes `geom_ids` instead of
+  `geom_id`, `so101_nexus.mujoco.spawn_utils.slot_world_min_z()` returns a slot's floor
+  clearance across all of its parts, and `set_slot_contacts()` toggles a slot's contact bits.
+- Warp default `nconmax`/`njmax` now add a small per-collision-geom term on top of the
+  per-slot one, so a decomposed pool reserves proportionally more contact memory (measured
+  peaks per world: 6.5 contacts for one cube, 6.2 for a 16-part spatula, 34.7 for a
+  seven-slot 61-geom YCB pool, against budgets of 208, 238 and 412). Cube-only scenes get
+  exactly the previous budget. Pass explicit `nconmax`/`njmax` to override.
 - Performance only, no behavior change. Observations, rewards, info dicts and the RNG draw
   sequence are bit-identical before and after on both backends.
   - MuJoCo envs step 2 to 11 percent faster, most on the object-manipulation tasks that read
@@ -35,6 +77,22 @@ for the public-API and deprecation policy.
     `so101_nexus.__version__` now resolves on first access and is unchanged.
 
 ### Fixed
+
+- Mesh-slot rest pose, spawn height, and bounding radius are measured in the body frame.
+  `extract_object_slots` read raw `mesh_vert`, which the MuJoCo compiler stores recentered on
+  each mesh's center of mass and rotated onto its principal axes, so the numbers described a
+  frame the body never sits in. Every mesh-backed slot changes even when its collision
+  geometry does not: `058_golf_ball` spawn_z 0.02322 to 0.00223, `009_gelatin_box` spawn_z
+  0.01741 to 0.00252 and bounding radius 0.05771 to 0.06748, `011_banana` bounding radius
+  0.01101 to 0.10510 (a flat-lying banana is 0.19 m long, so the old footprint was ten times
+  too small and the spawn samplers packed objects far too close). The Warp backend places
+  from `slot.spawn_z` without realignment, so its mesh objects previously started floating
+  above or sunk into the floor; the MuJoCo backend was masked by
+  `align_freejoint_geom_to_floor`.
+- `get_mujoco_ycb_rest_pose` measured the thin-X case against the inverse of the rotation it
+  returned. The two agree only for vertices centered on the origin, which is what the old
+  recentered `mesh_vert` input happened to be; with body-frame vertices the error is twice
+  the offset and could bury an object below the floor.
 
 ### Removed
 

--- a/docs/content/docs/api/core-overview.mdx
+++ b/docs/content/docs/api/core-overview.mdx
@@ -185,7 +185,9 @@ See [Scene Objects and Assets](/docs/api/objects) for full reference.
 |----------|-------------|
 | `ensure_ycb_assets(model_id)` | Download and cache YCB assets, return cache path |
 | `get_ycb_mesh_dir(model_id)` | Path to mesh directory for a YCB model |
-| `get_ycb_collision_mesh(model_id)` | Path to `collision.obj` |
+| `get_ycb_collision_parts(model_id)` | Convex collision parts with their mass fractions |
+| `get_ycb_collision_meshes(model_id)` | Paths of the convex collision parts |
+| `get_ycb_collision_mesh(model_id)` | Path of the first convex collision part |
 | `get_ycb_visual_mesh(model_id)` | Path to `visual.obj` |
 | `get_ycb_texture_file(model_id)` | Expected path to the optional `texture.png` |
 | `get_mujoco_ycb_rest_pose(verts)` | Rest orientation and spawn height for MuJoCo |

--- a/docs/content/docs/api/objects.mdx
+++ b/docs/content/docs/api/objects.mdx
@@ -113,7 +113,9 @@ YCB mesh assets are downloaded from the Hugging Face Hub on first use and cached
 ~/.cache/so101_nexus/ycb/{model_id}/
 ```
 
-Each model directory holds `collision.obj` and `visual.obj`, and, when extraction succeeds, `texture.png`.
+Each model directory holds `visual.obj`, the convex collision parts under
+`collision_v2/` (`collision_000.obj` ... plus a `parts.json` manifest), and, when
+extraction succeeds, `texture.png`.
 
 Creating a `YCBObject` and stepping an environment downloads whatever is missing. You can also trigger the download explicitly:
 
@@ -131,29 +133,44 @@ def ensure_ycb_assets(model_id: str) -> Path
 
 Downloads the mesh assets for `model_id` if they are not already cached, then returns the cache directory.
 
-`collision.obj` and `visual.obj` are the required geometry cache. The function additionally attempts to extract `texture.png` from `meshes/{model_id}/google_16k/textured.glb`. Texture extraction is best effort: if a model or the locally installed `trimesh` does not expose a texture image, the environment still runs with the untextured visual mesh.
+`visual.obj` and the `collision_v2/` parts are the required geometry cache. The collision
+geometry is a convex decomposition of the visual scan, computed once with
+[CoACD](https://github.com/SarahWeiii/CoACD) and cached, so physics sees the concavities a
+single hull would fill in. It needs the `decomp` extra; see
+[Installation](/docs/getting-started/installation) for the extras matrix. Nearly convex
+models (the golf ball, the gelatin box) keep a single hull either way. The manifest records
+which decomposer produced the parts, so installing the extra later, or upgrading CoACD,
+rebuilds the cache instead of reusing coarser geometry. The function additionally attempts
+to extract `texture.png` from `meshes/{model_id}/google_16k/textured.glb`. Texture
+extraction is best effort: if a model or the locally installed `trimesh` does not expose a
+texture image, the environment still runs with the untextured visual mesh.
 
 ### Path helpers
 
-These four functions resolve cache paths and never trigger a download. Call `ensure_ycb_assets` first if the assets may not be present yet.
+These helpers resolve cache paths and never trigger a download. Call `ensure_ycb_assets` first if the assets may not be present yet; the three collision helpers read the decomposition manifest and raise `FileNotFoundError` when it is missing.
 
 | Function | Returns |
 |----------|---------|
 | `get_ycb_mesh_dir(model_id)` | The model's cache directory |
-| `get_ycb_collision_mesh(model_id)` | Path to `collision.obj` |
+| `get_ycb_collision_parts(model_id)` | `YCBCollisionPart(path, mass_fraction)` per convex part |
+| `get_ycb_collision_meshes(model_id)` | Paths of the convex collision parts |
+| `get_ycb_collision_mesh(model_id)` | Path of the first convex collision part |
 | `get_ycb_visual_mesh(model_id)` | Path to `visual.obj` |
 | `get_ycb_texture_file(model_id)` | Expected path to the optional `texture.png` |
 
+`mass_fraction` is the part's volume-weighted share of the object's mass; the fractions sum
+to 1, so total body mass does not depend on how many parts the decomposition produced.
+
 ```python
 from so101_nexus import (
-    get_ycb_collision_mesh,
+    get_ycb_collision_meshes,
     get_ycb_mesh_dir,
     get_ycb_texture_file,
     get_ycb_visual_mesh,
 )
 
 mesh_dir = get_ycb_mesh_dir("011_banana")
-collision = get_ycb_collision_mesh("011_banana")
+collision_parts = get_ycb_collision_meshes("011_banana")
 visual = get_ycb_visual_mesh("011_banana")
 texture = get_ycb_texture_file("011_banana")
 ```

--- a/docs/content/docs/getting-started/installation.mdx
+++ b/docs/content/docs/getting-started/installation.mdx
@@ -42,6 +42,7 @@ The base install ships the MuJoCo backend and the environment API. Everything el
 | Extra | Adds | Install |
 | --- | --- | --- |
 | `teleop` | Gradio demonstration recorder: `lerobot[feetech]`, `gradio`, `plotly`, `opencv-python` | `pip install "so101-nexus[teleop]"` |
+| `decomp` | Convex decomposition of YCB collision meshes (`coacd`, `threadpoolctl`). Without it YCB collision geometry falls back to a single convex hull. `coacd` ships wheels for Linux x86_64/aarch64, macOS arm64 and Windows x86_64 | `pip install "so101-nexus[decomp]"` |
 | `train` | Torch training dependencies for the PPO and BC examples | `pip install "so101-nexus[train]"` |
 | `warp` | GPU-parallel MuJoCo Warp backend. Needs an NVIDIA GPU and CUDA >= 12.4 | `pip install "so101-nexus[warp]"` |
 | `rocm` | PyTorch from AMD's ROCm 7.2 wheel index. See below | `uv sync --extra train --extra rocm --no-default-groups` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
+decomp = ["coacd>=1.0.5,<2", "threadpoolctl>=3.1,<4"]
 viz = ["Pillow"]
 teleop = [
     "lerobot[feetech]>=0.5.0,<0.6",

--- a/src/so101_nexus/__init__.py
+++ b/src/so101_nexus/__init__.py
@@ -96,8 +96,11 @@ from so101_nexus.rewards import (
     simple_reward,
 )
 from so101_nexus.ycb_assets import (
+    YCBCollisionPart,
     ensure_ycb_assets,
     get_ycb_collision_mesh,
+    get_ycb_collision_meshes,
+    get_ycb_collision_parts,
     get_ycb_mesh_dir,
     get_ycb_texture_file,
     get_ycb_visual_mesh,
@@ -231,6 +234,7 @@ __all__ = [
     "TargetPosition",
     "TouchConfig",
     "WristCamera",
+    "YCBCollisionPart",
     "YCBObject",
     "YcbModelId",
     "__version__",
@@ -247,6 +251,8 @@ __all__ = [
     "get_so101_simulation_dir",
     "get_so101_urdf_path",
     "get_ycb_collision_mesh",
+    "get_ycb_collision_meshes",
+    "get_ycb_collision_parts",
     "get_ycb_mesh_dir",
     "get_ycb_texture_file",
     "get_ycb_visual_mesh",

--- a/src/so101_nexus/config.py
+++ b/src/so101_nexus/config.py
@@ -1015,9 +1015,10 @@ class PickConfig(EnvironmentConfig):
         Pool of scene objects to sample from. Accepts a single ``SceneObject``,
         a list of ``SceneObject``, or ``None`` (defaults to ``[CubeObject()]``).
         A single object is automatically wrapped in a list.
-        ``YCBObject`` entries collide as a single convex hull of the scan, which
-        makes several YCB models ungraspable regardless of the policy; read
-        ``YCBObject``'s docstring before putting one in a grasping task's pool.
+        ``YCBObject`` entries collide as a convex decomposition of the scan, which
+        needs the ``decomp`` extra; without it they fall back to a single convex
+        hull that makes several YCB models ungraspable regardless of the policy.
+        Read ``YCBObject``'s docstring before putting one in a grasping task's pool.
     n_distractors : int
         Number of distractor objects to place. 0 means single-object scene.
     lift_threshold : float

--- a/src/so101_nexus/mujoco/base_env.py
+++ b/src/so101_nexus/mujoco/base_env.py
@@ -52,9 +52,12 @@ from so101_nexus.observations import (
 from so101_nexus.rewards import lift_progress, potential_shaping, reach_progress
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
 
 logger = logging.getLogger(__name__)
+
+_NO_TARGET_GEOMS = np.zeros(0, dtype=bool)
+"""Empty grasp-target mask shared by envs that have not selected a target yet."""
 
 # Internal per-joint physical scale applied to a normalized delta action.
 # The public delta action space is normalized to [-1, 1] (the cross-backend
@@ -151,7 +154,7 @@ class SO101NexusMuJoCoBaseEnv(gymnasium.Env):
 
     Notes
     -----
-    ``_is_grasping()`` requires ``_obj_geom_id`` to be set by the subclass.
+    ``_is_grasping()`` requires ``_obj_geom_ids`` to be set by the subclass.
     Primitive envs without a graspable object (``LookAtEnv``, ``MoveEnv``)
     must **never** call ``_is_grasping()``.
     """
@@ -160,7 +163,8 @@ class SO101NexusMuJoCoBaseEnv(gymnasium.Env):
     model: mujoco.MjModel
     data: mujoco.MjData
     config: EnvironmentConfig
-    _obj_geom_id: int
+    _obj_geom_ids: np.ndarray
+    _obj_geom_mask: np.ndarray
     # Options dict of the current episode's reset(), for _task_reset to read.
     # Declared, never assigned at class level: a mutable class default would be
     # shared by every instance the moment someone mutates it in place.
@@ -197,6 +201,10 @@ class SO101NexusMuJoCoBaseEnv(gymnasium.Env):
         self.render_mode = render_mode
         self.robot_init_qpos_noise = robot_init_qpos_noise
         self._privileged_state: np.ndarray | None = None
+        # Grasp-detection target, sized to the model by _set_target_geoms. Left
+        # empty for primitive envs, which must never call _is_grasping(); it
+        # raises IndexError there rather than reporting a grasp of geom 0.
+        self._obj_geom_mask: np.ndarray = _NO_TARGET_GEOMS
         self._init_qpos_clamp_warned = False
 
     def _finish_model_setup(self) -> None:
@@ -581,6 +589,21 @@ class SO101NexusMuJoCoBaseEnv(gymnasium.Env):
         gripper = np.clip(gripper_target, self._target_low[-1], self._target_high[-1])
         return np.concatenate([q, [gripper]])
 
+    def _set_target_geoms(self, geom_ids: Sequence[int]) -> None:
+        """Point grasp detection at one object slot's collision geoms.
+
+        Keeps ``_obj_geom_ids`` and the per-geom boolean lookup the contact scan
+        indexes in step, so the two can never disagree. The mask is what makes
+        the scan cost independent of the part count of a decomposed mesh.
+        """
+        self._obj_geom_ids = np.asarray(geom_ids, dtype=np.int32)
+        mask = self._obj_geom_mask
+        if mask.size != self.model.ngeom:  # first target of this model
+            mask = self._obj_geom_mask = np.zeros(self.model.ngeom, dtype=bool)
+        else:
+            mask[:] = False
+        mask[self._obj_geom_ids] = True
+
     @_observation_scoped
     def _is_grasping(self) -> float:
         """Return 1.0 when the two finger sets pinch the target object.
@@ -594,6 +617,11 @@ class SO101NexusMuJoCoBaseEnv(gymnasium.Env):
         touched by both finger sets from the same side while it rests on the
         table, which satisfies bilateral contact but bears no load.
 
+        Contacts are aggregated over every collision geom of the target
+        (``_obj_geom_mask``, set by ``_set_target_geoms``), so a decomposed mesh
+        whose fingers land on different convex parts still yields one normal per
+        finger set.
+
         Returns
         -------
         float
@@ -602,15 +630,15 @@ class SO101NexusMuJoCoBaseEnv(gymnasium.Env):
         # Building a per-contact wrapper (data.contact[i]) costs more than the
         # force solve itself, so the object's contacts are selected from the
         # struct-of-arrays view first; ascending order matches the old scan, so
-        # the accumulation is unchanged. _obj_geom_id is read only once there is
-        # a contact to classify, matching the old scan for the primitive envs
-        # that never define it.
+        # the accumulation is unchanged. The target mask is read only once there
+        # is a contact to classify, matching the old scan for the primitive
+        # envs that never define one.
         contacts = self.data.contact
         geoms = contacts.geom[: self.data.ncon]
         if geoms.shape[0] == 0:
             return 0.0
-        obj_geom_id = self._obj_geom_id
-        rows = np.flatnonzero((geoms == obj_geom_id).any(axis=1))
+        is_obj = self._obj_geom_mask[geoms]
+        rows = np.flatnonzero(is_obj.any(axis=1))
         if rows.size == 0:
             return 0.0
 
@@ -620,7 +648,8 @@ class SO101NexusMuJoCoBaseEnv(gymnasium.Env):
         force_buf = np.zeros(6)
         for i in rows:
             g1, g2 = geoms[i]
-            other = int(g2 if g1 == obj_geom_id else g1)
+            obj_is_first = bool(is_obj[i, 0])
+            other = int(g2 if obj_is_first else g1)
             if other in self._gripper_geom_ids:
                 accum = gripper_normal
             elif other in self._jaw_geom_ids:
@@ -636,7 +665,7 @@ class SO101NexusMuJoCoBaseEnv(gymnasium.Env):
             # The contact frame's first row is the normal pointing from geom1 to
             # geom2; flip it when the object is geom1 so it points into the
             # object for both orderings.
-            normal = frames[i, :3] if g2 == obj_geom_id else -frames[i, :3]
+            normal = -frames[i, :3] if obj_is_first else frames[i, :3]
             accum += normal_force * normal
 
         if not (gripper_normal.any() and jaw_normal.any()):

--- a/src/so101_nexus/mujoco/pick_and_place.py
+++ b/src/so101_nexus/mujoco/pick_and_place.py
@@ -38,6 +38,7 @@ from so101_nexus.mujoco.spawn_utils import (
     activate_distractor_slots,
     hide_freejoint_slot,
     place_freejoint_slot,
+    set_slot_contacts,
 )
 from so101_nexus.object_slots import ObjectSlot, build_object_scene_xml, extract_object_slots
 from so101_nexus.objects import CubeObject, SceneObject, YCBObject
@@ -153,7 +154,7 @@ class PickAndPlaceEnv(SO101NexusMuJoCoBaseEnv):
         self._prev_task_potential: float = 0.0
         self._prev_reach_progress: float = 0.0
         self._prev_grasp_progress: float = 0.0
-        self._obj_geom_id: int = self._slots[0].geom_id
+        self._set_target_geoms(self._slots[0].geom_ids)
         self.task_description = config.task_description
 
         self._finish_model_setup()
@@ -361,14 +362,13 @@ class PickAndPlaceEnv(SO101NexusMuJoCoBaseEnv):
         # Restore collisions on every slot; the chosen target collides, the rest
         # are hidden below the floor with their contact bits zeroed.
         for slot in self._slots:
-            self.model.geom_contype[slot.geom_id] = 1
-            self.model.geom_conaffinity[slot.geom_id] = 1
+            set_slot_contacts(self.model, slot, True)
 
         target_idx = self._choose_target_index(rng, n_pool)
         target_slot = self._slots[target_idx]
         target_obj = target_slot.obj
         self._target_slot_idx = target_idx
-        self._obj_geom_id = target_slot.geom_id
+        self._set_target_geoms(target_slot.geom_ids)
         self.cube_color_name = target_obj.color if isinstance(target_obj, CubeObject) else ""
 
         # The disc colour is sampled per episode (reproducible under reset(seed=...)).

--- a/src/so101_nexus/mujoco/pick_env.py
+++ b/src/so101_nexus/mujoco/pick_env.py
@@ -33,6 +33,7 @@ from so101_nexus.mujoco.spawn_utils import (
     hide_freejoint_slot,
     place_freejoint_slot,
     sample_separated_positions,
+    set_slot_contacts,
 )
 from so101_nexus.object_slots import (
     ObjectSlot,
@@ -119,8 +120,8 @@ class PickEnv(SO101NexusMuJoCoBaseEnv):
         self._prev_task_potential: float = 0.0
         self._prev_reach_progress: float = 0.0
         self._prev_grasp_progress: float = 0.0
-        # _obj_geom_id required by base _is_grasping(); will be set at reset
-        self._obj_geom_id: int = self._slots[0].geom_id
+        # Grasp detection needs a target before the first reset picks one.
+        self._set_target_geoms(self._slots[0].geom_ids)
 
         self._finish_model_setup()
 
@@ -239,8 +240,7 @@ class PickEnv(SO101NexusMuJoCoBaseEnv):
         # that remain unchosen below are re-zeroed; slots that become active
         # need contype/conaffinity = 1 so they collide with the floor and gripper.
         for slot in self._slots:
-            self.model.geom_contype[slot.geom_id] = 1
-            self.model.geom_conaffinity[slot.geom_id] = 1
+            set_slot_contacts(self.model, slot, True)
 
         # Sample n_slots distinct slot indices from the pool without replacement.
         chosen_indices, target_pool_idx = self._choose_slots(rng, n_pool, n_slots)
@@ -248,7 +248,7 @@ class PickEnv(SO101NexusMuJoCoBaseEnv):
 
         # One chosen slot is the target; the rest are distractors.
         self._target_slot_idx = target_pool_idx
-        self._obj_geom_id = self._slots[target_pool_idx].geom_id
+        self._set_target_geoms(self._slots[target_pool_idx].geom_ids)
 
         # Gather bounding radii only for active slots (for position sampling).
         active_bounding_radii = [self._slots[int(i)].bounding_radius for i in chosen_indices]

--- a/src/so101_nexus/mujoco/spawn_utils.py
+++ b/src/so101_nexus/mujoco/spawn_utils.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from so101_nexus.object_slots import ObjectSlot
 
 MESH_FLOOR_MARGIN = 0.002
@@ -100,9 +102,9 @@ def random_yaw_quat(rng: np.random.Generator) -> np.ndarray:
 def mesh_geom_world_min_z(model, data, geom_id: int) -> float:
     """Return the minimum world Z of one compiled mesh collision geom.
 
-    This helper is scoped to the current pick-scene structure, where each mesh
-    object body has one collision mesh geom. Future compound mesh bodies should
-    compute the minimum across all collision geoms attached to the body.
+    A mesh object body carries one collision geom per convex part of its
+    decomposition, so the body's clearance is the minimum over ``slot.geom_ids``
+    (see :func:`slot_world_min_z`), not over a single part.
     """
     import mujoco
 
@@ -118,23 +120,28 @@ def mesh_geom_world_min_z(model, data, geom_id: int) -> float:
     return float(world[:, 2].min())
 
 
+def slot_world_min_z(model, data, geom_ids: Sequence[int]) -> float:
+    """Return the minimum world Z over every collision geom of a slot."""
+    return min(mesh_geom_world_min_z(model, data, geom_id) for geom_id in geom_ids)
+
+
 def align_freejoint_geom_to_floor(
     model,
     data,
     *,
     qpos_addr: int,
-    geom_id: int,
+    geom_ids: Sequence[int],
     xy: tuple[float, float],
     quat: np.ndarray,
     margin: float = MESH_FLOOR_MARGIN,
 ) -> float:
-    """Set a freejoint mesh pose so its compiled collision geom clears the floor."""
+    """Set a freejoint mesh pose so its compiled collision geoms clear the floor."""
     import mujoco
 
     data.qpos[qpos_addr : qpos_addr + 3] = [xy[0], xy[1], 0.0]
     data.qpos[qpos_addr + 3 : qpos_addr + 7] = quat
     mujoco.mj_forward(model, data)
-    min_z = mesh_geom_world_min_z(model, data, geom_id)
+    min_z = slot_world_min_z(model, data, geom_ids)
     spawn_z = -min_z + margin
     data.qpos[qpos_addr + 2] = spawn_z
     mujoco.mj_forward(model, data)
@@ -162,8 +169,19 @@ def place_freejoint_slot(
     obj_quat = np.zeros(4)
     mujoco.mju_mulQuat(obj_quat, random_yaw_quat(rng), slot.rest_quat)
     align_freejoint_geom_to_floor(
-        model, data, qpos_addr=slot.qpos_addr, geom_id=slot.geom_id, xy=(x, y), quat=obj_quat
+        model, data, qpos_addr=slot.qpos_addr, geom_ids=slot.geom_ids, xy=(x, y), quat=obj_quat
     )
+
+
+def set_slot_contacts(model, slot, enabled: bool) -> None:
+    """Enable or disable collisions on every collision geom of a slot.
+
+    ``geom_ids`` is listed rather than passed as-is because NumPy reads a tuple
+    index as a multi-dimensional index.
+    """
+    geom_ids = list(slot.geom_ids)
+    model.geom_contype[geom_ids] = int(enabled)
+    model.geom_conaffinity[geom_ids] = int(enabled)
 
 
 def hide_freejoint_slot(model, data, slot) -> None:
@@ -172,8 +190,7 @@ def hide_freejoint_slot(model, data, slot) -> None:
     Zeroing the contact bits keeps the constraint solver from exploding stacked
     hidden bodies during the post-reset settle.
     """
-    model.geom_contype[slot.geom_id] = 0
-    model.geom_conaffinity[slot.geom_id] = 0
+    set_slot_contacts(model, slot, False)
     data.qpos[slot.qpos_addr : slot.qpos_addr + 3] = [0.0, 0.0, -10.0]
     data.qpos[slot.qpos_addr + 3 : slot.qpos_addr + 7] = [1.0, 0.0, 0.0, 0.0]
 
@@ -204,8 +221,7 @@ def activate_distractor_slots(
     if not slots:
         return []
     for slot in slots:
-        model.geom_contype[slot.geom_id] = 1
-        model.geom_conaffinity[slot.geom_id] = 1
+        set_slot_contacts(model, slot, True)
     chosen = {int(i) for i in rng.choice(len(slots), size=count, replace=False)}
     for idx, slot in enumerate(slots):
         if idx not in chosen:

--- a/src/so101_nexus/mujoco/stack_cube.py
+++ b/src/so101_nexus/mujoco/stack_cube.py
@@ -138,7 +138,7 @@ class StackCubeEnv(SO101NexusMuJoCoBaseEnv):
         self._distractor_slots = slots[2:]
         self._n_distractors = config.n_distractors
         # Grasp detection always targets cube A; cube B is never picked up.
-        self._obj_geom_id = self._slot_a.geom_id
+        self._set_target_geoms(self._slot_a.geom_ids)
 
         self._prev_task_potential: float = 0.0
         self._prev_reach_progress: float = 0.0

--- a/src/so101_nexus/object_slots.py
+++ b/src/so101_nexus/object_slots.py
@@ -18,6 +18,8 @@ import this module without triggering MuJoCo env registration. No torch import.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import mujoco
 import numpy as np
 
@@ -25,11 +27,14 @@ from so101_nexus.constants import COLOR_MAP
 from so101_nexus.objects import CubeObject, MeshObject, SceneObject, YCBObject
 from so101_nexus.scene import SCENE_LIGHTS_XML, SCENE_VISUAL_XML
 from so101_nexus.ycb_assets import (
-    get_ycb_collision_mesh,
+    get_ycb_collision_parts,
     get_ycb_texture_file,
     get_ycb_visual_mesh,
 )
 from so101_nexus.ycb_geometry import get_mujoco_ycb_rest_pose
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 # Default bounding radius used when an object exposes no geometry to measure.
 DEFAULT_BOUNDING_RADIUS = 0.025
@@ -43,12 +48,19 @@ def cube_bounding_radius(obj: CubeObject) -> float:
     return float(obj.half_size * np.sqrt(2))
 
 
-def primary_geom_name(slot_name: str, obj: SceneObject) -> str:
-    """Return the name of the collision/contact geom for an object slot."""
+def collision_geom_name(slot_name: str, obj: SceneObject, part: int = 0) -> str:
+    """Return the name of a slot's collision/contact geom.
+
+    Mesh-backed slots (YCB, custom) carry one geom per convex part of their
+    collision decomposition, numbered from zero; cubes carry a single box geom.
+    """
     if isinstance(obj, CubeObject):
         return f"{slot_name}_geom"
-    # YCBObject and MeshObject both use the _collision suffix.
-    return f"{slot_name}_collision"
+    return _mesh_collision_geom_name(slot_name, part)
+
+
+def _mesh_collision_geom_name(slot_name: str, part: int) -> str:
+    return f"{slot_name}_collision_{part}"
 
 
 def cube_xml_body(slot_name: str, obj: CubeObject) -> str:
@@ -71,22 +83,32 @@ def mesh_xml_body(
     asset_index: int,
     mass: float,
     material_name: str | None = None,
+    mass_fractions: Sequence[float] = (1.0,),
 ) -> str:
     """Return the MJCF ``<body>`` fragment for one freejoint mesh slot.
 
-    Mesh slots carry a hidden collision geom (group 3) and a non-colliding visual
+    Mesh slots carry hidden collision geoms (group 3) and a non-colliding visual
     geom (group 2); the latter is mostly for MuJoCo rendering parity (Warp
     training reads state tensors, not rendered images).
+
+    The collision hull is a convex decomposition, so there is one collision geom
+    per part. Each part declares ``mass * mass_fractions[k]`` rather than the
+    full mass: MuJoCo sums geom masses into the body, so declaring ``mass`` on
+    every part would multiply the object's weight by the part count.
     """
     material_attr = f' material="{material_name}"' if material_name else ""
+    collision_geoms = "".join(
+        f'      <geom name="{_mesh_collision_geom_name(slot_name, part)}" type="mesh" '
+        f'mesh="pick_coll_{asset_index}_{part}"\n'
+        f'            mass="{float(mass) * float(fraction)!r}" contype="1" conaffinity="1"\n'
+        f'            group="3" condim="4" friction="1 0.05 0.001" solref="0.01 1"\n'
+        f'            solimp="0.95 0.99 0.001"/>\n'
+        for part, fraction in enumerate(mass_fractions)
+    )
     return (
         f'    <body name="{slot_name}" pos="0.15 0 0.01">\n'
         f'      <freejoint name="{slot_name}_joint"/>\n'
-        f'      <geom name="{slot_name}_collision" type="mesh" '
-        f'mesh="pick_coll_{asset_index}"\n'
-        f'            mass="{mass}" contype="1" conaffinity="1"\n'
-        f'            group="3" condim="4" friction="1 0.05 0.001" solref="0.01 1"\n'
-        f'            solimp="0.95 0.99 0.001"/>\n'
+        f"{collision_geoms}"
         f'      <geom name="{slot_name}_visual" type="mesh" '
         f'mesh="pick_vis_{asset_index}"\n'
         f'            group="2" contype="0" conaffinity="0" mass="0"{material_attr}/>\n'
@@ -134,9 +156,12 @@ def build_object_scene_xml(
 
     for i, (obj, slot) in enumerate(zip(objects, slot_names, strict=True)):
         if isinstance(obj, YCBObject):
-            collision_path = get_ycb_collision_mesh(obj.model_id).as_posix()
+            parts = get_ycb_collision_parts(obj.model_id)
+            for k, part in enumerate(parts):
+                asset_entries += (
+                    f'    <mesh name="pick_coll_{i}_{k}" file="{part.path.as_posix()}"/>\n'
+                )
             visual_path = get_ycb_visual_mesh(obj.model_id).as_posix()
-            asset_entries += f'    <mesh name="pick_coll_{i}" file="{collision_path}"/>\n'
             asset_entries += f'    <mesh name="pick_vis_{i}" file="{visual_path}"/>\n'
             material_name = None
             texture_path = get_ycb_texture_file(obj.model_id)
@@ -152,10 +177,16 @@ def build_object_scene_xml(
                     'texuniform="false"/>\n'
                 )
             mass = obj.mass_override if obj.mass_override is not None else _DEFAULT_YCB_MASS
-            body_entries += mesh_xml_body(slot, i, mass, material_name=material_name)
+            body_entries += mesh_xml_body(
+                slot,
+                i,
+                mass,
+                material_name=material_name,
+                mass_fractions=[part.mass_fraction for part in parts],
+            )
         elif isinstance(obj, MeshObject):
             asset_entries += (
-                f'    <mesh name="pick_coll_{i}" file="{obj.collision_mesh_path}"'
+                f'    <mesh name="pick_coll_{i}_0" file="{obj.collision_mesh_path}"'
                 f' scale="{obj.scale} {obj.scale} {obj.scale}"/>\n'
             )
             asset_entries += (
@@ -195,13 +226,15 @@ class ObjectSlot:
     Backend-neutral: ``qpos_addr``/``dof_addr`` index the shared ``MjModel``
     layout and apply to a scalar ``MjData`` (MuJoCo) and a batched
     ``mjw.Data`` column (Warp) alike. ``rest_quat`` is a NumPy ``wxyz`` vector;
-    backends convert to tensors as needed.
+    backends convert to tensors as needed. ``geom_ids`` holds every collision
+    geom of the slot (one per convex part of a decomposed mesh, one for a cube),
+    which is what contact scans must aggregate over.
     """
 
     __slots__ = (
         "bounding_radius",
         "dof_addr",
-        "geom_id",
+        "geom_ids",
         "obj",
         "qpos_addr",
         "rest_quat",
@@ -212,7 +245,7 @@ class ObjectSlot:
         self,
         qpos_addr: int,
         dof_addr: int,
-        geom_id: int,
+        geom_ids: tuple[int, ...],
         rest_quat: np.ndarray,
         spawn_z: float,
         bounding_radius: float,
@@ -220,11 +253,57 @@ class ObjectSlot:
     ) -> None:
         self.qpos_addr = qpos_addr
         self.dof_addr = dof_addr
-        self.geom_id = geom_id
+        self.geom_ids = geom_ids
         self.rest_quat = rest_quat
         self.spawn_z = spawn_z
         self.bounding_radius = bounding_radius
         self.obj = obj
+
+    @property
+    def geom_id(self) -> int:
+        """First collision geom of the slot; the whole object is ``geom_ids``."""
+        return self.geom_ids[0]
+
+
+def _slot_collision_geom_ids(
+    mjm: mujoco.MjModel, slot_name: str, obj: SceneObject
+) -> tuple[int, ...]:
+    """Return every collision geom id of a slot body, in XML order."""
+    geom_ids: list[int] = []
+    if isinstance(obj, CubeObject):
+        geom_id = int(mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_GEOM, f"{slot_name}_geom"))
+        geom_ids = [geom_id] if geom_id >= 0 else []
+    else:
+        while True:
+            name = _mesh_collision_geom_name(slot_name, len(geom_ids))
+            geom_id = int(mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_GEOM, name))
+            if geom_id < 0:
+                break
+            geom_ids.append(geom_id)
+    if not geom_ids:
+        # mj_name2id's -1 sentinel would silently address the model's last geom.
+        raise ValueError(f"slot {slot_name!r} has no collision geom in the compiled model")
+    return tuple(geom_ids)
+
+
+def _body_frame_collision_verts(mjm: mujoco.MjModel, geom_ids: tuple[int, ...]) -> np.ndarray:
+    """Return the union of a slot's compiled collision vertices, in body frame.
+
+    The compiler recenters every mesh on its own center of mass and folds the
+    offset into the geom frame, so raw ``mesh_vert`` blocks of a multi-part
+    decomposition do not share an origin. Rest pose and footprint must see the
+    whole object, not one part.
+    """
+    chunks = []
+    rot = np.zeros(9)
+    for geom_id in geom_ids:
+        mesh_id = int(mjm.geom_dataid[geom_id])
+        vert_start = int(mjm.mesh_vertadr[mesh_id])
+        vert_count = int(mjm.mesh_vertnum[mesh_id])
+        verts = mjm.mesh_vert[vert_start : vert_start + vert_count]
+        mujoco.mju_quat2Mat(rot, mjm.geom_quat[geom_id])
+        chunks.append(verts @ rot.reshape(3, 3).T + mjm.geom_pos[geom_id])
+    return np.concatenate(chunks)
 
 
 def extract_object_slots(
@@ -236,21 +315,17 @@ def extract_object_slots(
 
     For cubes the rest pose is identity and the spawn height is the half-size;
     for mesh-backed objects (YCB, custom) the stable rest orientation and floor
-    clearance come from the compiled mesh vertices.
+    clearance come from the union of the compiled collision-part vertices.
     """
     slots: list[ObjectSlot] = []
     for slot_name, obj in zip(slot_names, objects, strict=True):
-        geom_name = primary_geom_name(slot_name, obj)
-        geom_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_GEOM, geom_name)
+        geom_ids = _slot_collision_geom_ids(mjm, slot_name, obj)
         joint_id = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_JOINT, f"{slot_name}_joint")
         qpos_addr = int(mjm.jnt_qposadr[joint_id])
         dof_addr = int(mjm.jnt_dofadr[joint_id])
 
         if isinstance(obj, (YCBObject, MeshObject)):
-            mesh_id = mjm.geom_dataid[geom_id]
-            vert_start = mjm.mesh_vertadr[mesh_id]
-            vert_count = mjm.mesh_vertnum[mesh_id]
-            verts = mjm.mesh_vert[vert_start : vert_start + vert_count]
+            verts = _body_frame_collision_verts(mjm, geom_ids)
             rest_quat, spawn_z = get_mujoco_ycb_rest_pose(verts)
             # Footprint is measured in the resting orientation: the stable rest
             # pose can rotate a thin X/Y axis up, changing the horizontal extent
@@ -271,7 +346,7 @@ def extract_object_slots(
             ObjectSlot(
                 qpos_addr=qpos_addr,
                 dof_addr=dof_addr,
-                geom_id=geom_id,
+                geom_ids=geom_ids,
                 rest_quat=rest_quat,
                 spawn_z=float(spawn_z),
                 bounding_radius=bounding_radius,

--- a/src/so101_nexus/objects.py
+++ b/src/so101_nexus/objects.py
@@ -67,19 +67,23 @@ class CubeObject(SceneObject):
 class YCBObject(SceneObject):
     """YCB dataset object identified by model_id (e.g. '003_cracker_box').
 
-    The visual mesh is the original YCB scan, but the **collision geometry is a
-    single convex hull** of it (see ``ensure_ycb_assets``). Physics therefore
-    sees the hull, not the shape you see rendered, and the two differ a lot for
-    concave or elongated models: a fork is a wedge, a banana is a solid crescent
-    hull. Two consequences for manipulation tasks:
+    The visual mesh is the original YCB scan; the collision geometry is a
+    **convex decomposition** of it (see ``ensure_ycb_assets``), so physics sees
+    the concavities that make an object graspable (a fork's handle, a spatula's
+    neck) instead of one solid wedge. The decomposition needs the optional
+    ``decomp`` extra (``pip install so101-nexus[decomp]``); without it the
+    collision geometry falls back to a single convex hull, and then:
 
-    - The feature that makes an object graspable in reality (a fork's handle, a
-      banana's taper) is buried inside the hull, so the fingers never touch it.
+    - The feature that makes an object graspable in reality is buried inside the
+      hull, so the fingers never touch it.
     - A model whose hull is wider than the gripper can close on cannot be
-      grasped at all, no matter how good the policy is. Measure a candidate
-      before building a task around it: ``ensure_ycb_assets(model_id)`` then
-      ``get_ycb_collision_mesh(model_id)`` gives the path to the collision OBJ
-      physics uses; load it to measure the hull.
+      grasped at all, no matter how good the policy is.
+
+    Installing the extra after the assets were prepared rebuilds the cache on the
+    next ``ensure_ycb_assets`` call: the manifest records which decomposer wrote
+    the parts. Measure a candidate before building a task around it:
+    ``ensure_ycb_assets(model_id)`` then ``get_ycb_collision_meshes(model_id)``
+    gives the OBJ parts physics uses.
 
     Parameters
     ----------

--- a/src/so101_nexus/warp/base_env.py
+++ b/src/so101_nexus/warp/base_env.py
@@ -181,7 +181,7 @@ def _grasp_from_contacts(
     contact_frame: torch.Tensor,
     normal_force: torch.Tensor,
     nacon: int,
-    obj_geom: torch.Tensor,
+    obj_mask: torch.Tensor,
     gripper_mask: torch.Tensor,
     jaw_mask: torch.Tensor,
     threshold: float,
@@ -190,25 +190,33 @@ def _grasp_from_contacts(
 ) -> torch.Tensor:
     """Reduce flat contacts to a ``(num_envs,)`` two-sided grasp signal in {0, 1}.
 
-    A world grasps when its target geom (``obj_geom[world]``) contacts both a
-    gripper finger geom and a moving-jaw finger geom with normal force at or
-    above ``threshold``, *and* the two sides' force-weighted mean contact
-    normals oppose each other by at least ``opposing_threshold`` (see
-    ``so101_nexus.grasp.opposing_normals_ok``). Without the opposition term an
-    object too wide for the jaw to close on registers as grasped while both
-    fingers merely press the same face of it. Pure tensor reduction over the
-    packed ``[0, nacon)`` contact slots, so it is unit-testable with synthetic
-    arrays. Mirrors the MuJoCo base's ``_is_grasping``.
+    A world grasps when its target object (every collision geom flagged in
+    ``obj_mask[world]``) contacts both a gripper finger geom and a moving-jaw
+    finger geom with normal force at or above ``threshold``, *and* the two
+    sides' force-weighted mean contact normals oppose each other by at least
+    ``opposing_threshold`` (see ``so101_nexus.grasp.opposing_normals_ok``).
+    Without the opposition term an object too wide for the jaw to close on
+    registers as grasped while both fingers merely press the same face of it.
+    Pure tensor reduction over the packed ``[0, nacon)`` contact slots, so it is
+    unit-testable with synthetic arrays. Mirrors the MuJoCo base's
+    ``_is_grasping``.
+
+    Parameters
+    ----------
+    obj_mask:
+        ``(num_envs, ngeom)`` boolean lookup of the target's collision geoms per
+        world. Flagging every convex part of a decomposed mesh is what keeps the
+        opposition test per-object rather than per-part, and the lookup keeps the
+        reduction contact-sized rather than contacts-times-parts.
     """
-    device = obj_geom.device
+    device = obj_mask.device
     if nacon == 0:
         return torch.zeros(num_envs, device=device)
     geom = contact_geom[:nacon].long()
     world = contact_world[:nacon].long().clamp(0, num_envs - 1)
     g1, g2 = geom[:, 0], geom[:, 1]
-    obj = obj_geom[world]
-    obj_is_g1 = g1 == obj
-    involved = obj_is_g1 | (g2 == obj)
+    obj_is_g1 = obj_mask[world, g1.clamp(min=0)]
+    involved = obj_is_g1 | obj_mask[world, g2.clamp(min=0)]
     other = torch.where(obj_is_g1, g2, g1).clamp(min=0)
     force = normal_force[:nacon]
     strong = involved & (force >= threshold)
@@ -390,9 +398,10 @@ class SO101NexusWarpVectorEnv(VectorEnv):
         jaw_bid = mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_BODY, "moving_jaw_so101_v1")
         self._gripper_mask = self._finger_geom_mask(mjm, gripper_bid, ngeom)
         self._jaw_mask = self._finger_geom_mask(mjm, jaw_bid, ngeom)
-        # Per-world target geom for grasp detection; manipulation tasks set this to
-        # a (num_envs,) long tensor. None means no graspable object (primitives).
-        self._obj_geom: torch.Tensor | None = None
+        # Per-world target collision geoms for grasp detection; manipulation tasks
+        # set this to a (num_envs, ngeom) boolean mask (one row per world, every
+        # convex part of the target flagged). None means no graspable object.
+        self._obj_geom_mask: torch.Tensor | None = None
         # Zero-copy contact views; the force buffer is allocated lazily on the
         # first contact-force query (grasp state or gripper contact force), so a
         # task that reads neither pays nothing.
@@ -1174,12 +1183,12 @@ class SO101NexusWarpVectorEnv(VectorEnv):
         return force_view, int(self._nacon_view[0])
 
     def _is_grasping(self) -> torch.Tensor:
-        """Return ``(N,)`` float in {0, 1}: two-sided pinching grasp of the target geom.
+        """Return ``(N,)`` float in {0, 1}: two-sided pinching grasp of the target object.
 
-        Zero everywhere when no graspable object is registered (``_obj_geom``
-        unset), so primitive tasks never trigger grasp logic.
+        Zero everywhere when no graspable object is registered
+        (``_obj_geom_mask`` unset), so primitive tasks never trigger grasp logic.
         """
-        if self._obj_geom is None:
+        if self._obj_geom_mask is None:
             return torch.zeros(self.num_envs, device=self.device)
         force_view, nacon = self._contact_forces()
         return _grasp_from_contacts(
@@ -1188,7 +1197,7 @@ class SO101NexusWarpVectorEnv(VectorEnv):
             contact_frame=self._contact_frame_view,
             normal_force=force_view[:, 0].abs(),
             nacon=nacon,
-            obj_geom=self._obj_geom,
+            obj_mask=self._obj_geom_mask,
             gripper_mask=self._gripper_mask,
             jaw_mask=self._jaw_mask,
             threshold=self.config.robot.grasp_force_threshold,

--- a/src/so101_nexus/warp/object_slots.py
+++ b/src/so101_nexus/warp/object_slots.py
@@ -8,10 +8,31 @@ helpers operate on zero-copy ``qpos`` tensor views.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import torch
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from so101_nexus.object_slots import ObjectSlot
 
 HIDE_CLEARANCE = 0.1
 """Clearance (m) between the off-world parking band and the reachable spawn annulus."""
+
+
+def slot_geom_masks(slots: Sequence[ObjectSlot], ngeom: int, device: torch.device) -> torch.Tensor:
+    """Return an ``(n_slots, ngeom)`` boolean lookup of each slot's collision geoms.
+
+    A per-geom mask rather than a padded id matrix: the batched grasp reduction
+    then costs two contact-sized gathers instead of a comparison against every
+    convex part, so its cost does not grow with the decomposition. Mirrors the
+    MuJoCo base env's ``_obj_geom_mask``.
+    """
+    masks = torch.zeros((len(slots), ngeom), dtype=torch.bool, device=device)
+    for row, slot in enumerate(slots):
+        masks[row, list(slot.geom_ids)] = True
+    return masks
 
 
 def hidden_slot_band_xy(

--- a/src/so101_nexus/warp/pick_env.py
+++ b/src/so101_nexus/warp/pick_env.py
@@ -43,21 +43,31 @@ from so101_nexus.warp.object_slots import (
     quat_mul_wxyz,
     random_yaw_quat_batch,
     sample_separated_polar,
+    slot_geom_masks,
 )
 
 _SO101_DIR = get_so101_mujoco_model_dir()
 _SO101_XML = get_so101_mujoco_model_path()
 
 # Contact budget per world. The single-cube scene needs a generous floor for
-# active grasping; every compiled slot (carried pool and distractor alike) adds
-# resting contacts, so the budget scales with the total slot count, not with the
-# carried pool. naconmax = nconmax * num_envs.
+# active grasping, and every compiled slot (carried pool and distractor alike)
+# adds resting contacts. The convex parts of one decomposed mesh never collide
+# with each other and only two or three of them touch the floor at once, so an
+# extra part costs far less than an extra slot: measured peaks per world are 6.5
+# contacts for one cube, 6.2 for a 16-part spatula, and 34.7 for a seven-slot
+# 61-geom YCB pool, against budgets of 208, 238 and 412. naconmax = nconmax *
+# num_envs, so the per-part term stays small on purpose.
 _PICK_NCONMAX_BASE = 192
 _PICK_NCONMAX_PER_SLOT = 16
+_PICK_NCONMAX_PER_EXTRA_PART = 2
 
 
-def _contact_budget(n_slots: int) -> tuple[int, int]:
-    nconmax = _PICK_NCONMAX_BASE + _PICK_NCONMAX_PER_SLOT * n_slots
+def _contact_budget(n_slots: int, n_collision_geoms: int) -> tuple[int, int]:
+    nconmax = (
+        _PICK_NCONMAX_BASE
+        + _PICK_NCONMAX_PER_SLOT * n_slots
+        + _PICK_NCONMAX_PER_EXTRA_PART * (n_collision_geoms - n_slots)
+    )
     return nconmax, nconmax * 2
 
 
@@ -173,7 +183,9 @@ class WarpPickLiftVectorEnv(SO101NexusWarpVectorEnv):
             f.flush()
             mjm = mujoco.MjModel.from_xml_path(f.name)
         slots = extract_object_slots(mjm, slot_names, scene_objects)
-        default_nconmax, default_njmax = _contact_budget(self._n_total_slots)
+        default_nconmax, default_njmax = _contact_budget(
+            len(slots), sum(len(slot.geom_ids) for slot in slots)
+        )
         super().__init__(
             num_envs=num_envs,
             config=config,
@@ -199,9 +211,7 @@ class WarpPickLiftVectorEnv(SO101NexusWarpVectorEnv):
         # Free-joint position offsets, reused by every slot write below so the
         # reset path does not rebuild them per active slot.
         self._qpos_offsets = torch.arange(7, device=self.device)
-        self._slot_geom = torch.tensor(
-            [s.geom_id for s in slots], dtype=torch.long, device=self.device
-        )
+        self._slot_geom_masks = slot_geom_masks(slots, mjm.ngeom, self.device)
         self._slot_spawn_z = torch.tensor(
             [s.spawn_z for s in slots], dtype=torch.float32, device=self.device
         )
@@ -219,9 +229,11 @@ class WarpPickLiftVectorEnv(SO101NexusWarpVectorEnv):
             config.spawn_center,
         )
 
-        # Per-world target tracking (set at reset). ``_obj_geom`` drives grasp
+        # Per-world target tracking (set at reset). ``_obj_geom_mask`` drives grasp
         # detection in the base; ``_target_qadr`` indexes the selected slot pose.
-        self._obj_geom = torch.zeros(num_envs, dtype=torch.long, device=self.device)
+        self._obj_geom_mask = torch.zeros(
+            (num_envs, mjm.ngeom), dtype=torch.bool, device=self.device
+        )
         self._target_qadr = torch.zeros(num_envs, dtype=torch.long, device=self.device)
         self._target_dadr = torch.zeros(num_envs, dtype=torch.long, device=self.device)
         self._target_slot = torch.zeros(num_envs, dtype=torch.long, device=self.device)
@@ -324,9 +336,9 @@ class WarpPickLiftVectorEnv(SO101NexusWarpVectorEnv):
     def _set_target_tracking(self, idx: torch.Tensor, target: torch.Tensor) -> None:
         """Record the per-world target slot and refresh its task description."""
         self._target_slot[idx] = target
-        obj_geom = self._obj_geom
-        assert obj_geom is not None  # set to a tensor in _build_slot_model
-        obj_geom[idx] = self._slot_geom[target]
+        obj_mask = self._obj_geom_mask
+        assert obj_mask is not None  # set to a tensor in _build_slot_model
+        obj_mask[idx] = self._slot_geom_masks[target]
         self._target_qadr[idx] = self._slot_qadr[target]
         self._target_dadr[idx] = self._slot_dadr[target]
         self._initial_obj_z[idx] = self._slot_spawn_z[target]

--- a/src/so101_nexus/warp/stack_cube.py
+++ b/src/so101_nexus/warp/stack_cube.py
@@ -56,20 +56,28 @@ from so101_nexus.warp.object_slots import (
     quat_mul_wxyz,
     random_yaw_quat_batch,
     sample_separated_polar,
+    slot_geom_masks,
 )
 
 _SO101_DIR = get_so101_mujoco_model_dir()
 _SO101_XML = get_so101_mujoco_model_path()
 
 # Contact budget per world, mirroring so101_nexus.warp.pick_env._contact_budget:
-# a generous floor for active grasping plus a per-slot allowance for the parked
-# slots' resting contacts. naconmax = nconmax * num_envs.
+# a generous floor for active grasping, a per-slot allowance for the parked
+# slots' resting contacts, and a small per-extra-part term (the convex parts of
+# one decomposed mesh never collide with each other). naconmax = nconmax *
+# num_envs.
 _STACK_NCONMAX_BASE = 192
 _STACK_NCONMAX_PER_SLOT = 16
+_STACK_NCONMAX_PER_EXTRA_PART = 2
 
 
-def _contact_budget(n_slots: int) -> tuple[int, int]:
-    nconmax = _STACK_NCONMAX_BASE + _STACK_NCONMAX_PER_SLOT * n_slots
+def _contact_budget(n_slots: int, n_collision_geoms: int) -> tuple[int, int]:
+    nconmax = (
+        _STACK_NCONMAX_BASE
+        + _STACK_NCONMAX_PER_SLOT * n_slots
+        + _STACK_NCONMAX_PER_EXTRA_PART * (n_collision_geoms - n_slots)
+    )
     return nconmax, nconmax * 2
 
 
@@ -155,7 +163,9 @@ class WarpStackCubeVectorEnv(SO101NexusWarpVectorEnv):
             f.flush()
             mjm = mujoco.MjModel.from_xml_path(f.name)
         slots = extract_object_slots(mjm, slot_names, scene_objects)
-        default_nconmax, default_njmax = _contact_budget(len(slots))
+        default_nconmax, default_njmax = _contact_budget(
+            len(slots), sum(len(slot.geom_ids) for slot in slots)
+        )
 
         super().__init__(
             num_envs=num_envs,
@@ -182,9 +192,7 @@ class WarpStackCubeVectorEnv(SO101NexusWarpVectorEnv):
         # Free-joint component offsets, reused by every slot write at reset.
         self._qpos_offsets = torch.arange(7, device=self.device)
         self._dof_offsets = torch.arange(6, device=self.device)
-        self._slot_geom = torch.tensor(
-            [s.geom_id for s in slots], dtype=torch.long, device=self.device
-        )
+        self._slot_geom_masks = slot_geom_masks(slots, mjm.ngeom, self.device)
         self._slot_spawn_z = torch.tensor(
             [s.spawn_z for s in slots], dtype=torch.float32, device=self.device
         )
@@ -209,7 +217,7 @@ class WarpStackCubeVectorEnv(SO101NexusWarpVectorEnv):
         self._a_dadr = self._slot_dadr[0].expand(num_envs).clone()
         self._b_qadr = self._slot_qadr[self._a_pool].expand(num_envs).clone()
         self._b_dadr = self._slot_dadr[self._a_pool].expand(num_envs).clone()
-        self._obj_geom = self._slot_geom[0].expand(num_envs).clone()
+        self._obj_geom_mask = self._slot_geom_masks[0].expand(num_envs, -1).clone()
         self.cube_a_color_names = [self._a_colors[0]] * num_envs
         self.cube_b_color_names = [self._b_colors[0]] * num_envs
         self._world_rows = torch.arange(num_envs, device=self.device)
@@ -391,9 +399,9 @@ class WarpStackCubeVectorEnv(SO101NexusWarpVectorEnv):
         self._a_dadr[idx] = self._slot_dadr[a_sel]
         self._b_qadr[idx] = self._slot_qadr[b_sel]
         self._b_dadr[idx] = self._slot_dadr[b_sel]
-        obj_geom = self._obj_geom
-        assert obj_geom is not None  # set to a tensor in __init__
-        obj_geom[idx] = self._slot_geom[a_sel]
+        obj_mask = self._obj_geom_mask
+        assert obj_mask is not None  # set to a tensor in __init__
+        obj_mask[idx] = self._slot_geom_masks[a_sel]
         # One device read per tensor instead of three per world: indexing a CUDA
         # tensor element by element synchronizes on every element.
         for w, a_i, b_i in zip(idx.tolist(), a_sel.tolist(), b_sel_local.tolist(), strict=True):

--- a/src/so101_nexus/ycb_assets.py
+++ b/src/so101_nexus/ycb_assets.py
@@ -2,21 +2,59 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol, cast
+from typing import TYPE_CHECKING, Protocol, cast
 
 from so101_nexus.constants import YCB_OBJECTS
+
+if TYPE_CHECKING:
+    import numpy as np
 
 logger = logging.getLogger(__name__)
 
 _HF_REPO_ID = os.environ.get("SO101_YCB_HF_REPO", "ai-habitat/ycb")
 _CACHE_DIR = Path.home() / ".cache" / "so101_nexus" / "ycb"
 
+_COLLISION_SUBDIR = "collision_v2"
+"""Cache subdirectory holding the convex decomposition.
+
+Versioned: bump it whenever the decomposition changes, otherwise the parts
+cached by an older release keep winning the ``ensure_ycb_assets`` early return.
+"""
+
+_MANIFEST_NAME = "parts.json"
+
+_HULL_DECOMPOSER = "convex_hull"
+"""Manifest marker for parts built without CoACD (the single-hull fallback)."""
+
+# CoACD settings. The seed is fixed because scene geometry must not vary
+# between runs; preprocessing (watertight remeshing of the open YCB scans) is
+# what lifts the thin, concave models above the acceptance convexity, and the
+# hull cap keeps the per-object geom count affordable for contact budgets.
+_COACD_SEED = 0
+_COACD_THRESHOLD = 0.02
+_COACD_MAX_HULLS = 16
+_COACD_PREPROCESS_RESOLUTION = 100
+
+_SINGLE_HULL_CONVEXITY = 0.95
+"""Volume ratio above which a model keeps its single convex hull.
+
+Boxes and balls are already their own hull; decomposing them only buys geoms.
+"""
+
 
 class _ExportableMesh(Protocol):
+    vertices: np.ndarray
+    faces: np.ndarray
+
+    @property
+    def volume(self) -> float: ...
+
     def export(self, file_obj: str, file_type: str | None = None) -> object: ...
 
     @property
@@ -25,6 +63,24 @@ class _ExportableMesh(Protocol):
 
 class _TextureImage(Protocol):
     def save(self, fp: str, format: str | None = None) -> object: ...
+
+
+@dataclass(frozen=True, slots=True)
+class YCBCollisionPart:
+    """One convex part of a YCB model's collision decomposition.
+
+    Attributes
+    ----------
+    path:
+        OBJ file holding the convex part.
+    mass_fraction:
+        Share of the object's mass carried by this part, proportional to its
+        volume. A model's fractions sum to 1, so the body's total mass does not
+        depend on how many parts the decomposition produced.
+    """
+
+    path: Path
+    mass_fraction: float
 
 
 def _validate_model_id(model_id: str) -> None:
@@ -58,6 +114,122 @@ def _convert_glb_to_obj(glb_path: Path, obj_path: Path) -> None:
     """Convert a GLB mesh to OBJ format using trimesh."""
     mesh = _load_exportable_mesh(glb_path)
     mesh.export(str(obj_path), file_type="obj")
+
+
+def _collision_dir(model_id: str) -> Path:
+    """Return the versioned directory holding a model's convex collision parts."""
+    return _CACHE_DIR / model_id / _COLLISION_SUBDIR
+
+
+def _decomposer_id() -> str:
+    """Identify the decomposer that would produce the parts, for cache keying.
+
+    Includes the CoACD version, because its splits change between releases, so a
+    cache written by another version is not the geometry this install builds.
+    Both packages of the ``decomp`` extra must be present: without
+    ``threadpoolctl`` the search is not thread-pinned, and ``_convex_parts``
+    falls back to a single hull rather than write geometry it cannot reproduce.
+    """
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        version("threadpoolctl")
+        return f"coacd {version('coacd')}"
+    except (ImportError, PackageNotFoundError):
+        return _HULL_DECOMPOSER
+
+
+def _convex_parts(mesh: _ExportableMesh) -> list[_ExportableMesh]:
+    """Decompose ``mesh`` into convex collision parts.
+
+    Nearly convex models keep their single convex hull. The rest are handed to
+    CoACD, which is an optional extra (``pip install so101-nexus[decomp]``);
+    without it the single hull remains the fallback, so no existing install
+    breaks, it just keeps the coarse collision geometry.
+
+    CoACD's MCTS search is parallelized over OpenMP, and its thread scheduling
+    changes the split it converges on: the same mesh and seed yield different
+    part counts run to run. Scene geometry must not vary between runs, so the
+    search is pinned to one thread (a few seconds per model, once, then cached).
+    The limit is scoped to this call and restored afterwards.
+    """
+    hull = mesh.convex_hull
+    hull_volume = abs(hull.volume)
+    # The YCB scans are open surfaces, so this is the divergence-theorem volume
+    # rather than a true enclosed one; logged because a model whose integral
+    # overshoots would skip decomposition without any other signal.
+    convexity = abs(mesh.volume) / hull_volume if hull_volume > 0.0 else 1.0
+    logger.debug("mesh convexity (volume / hull volume): %.3f", convexity)
+    if convexity >= _SINGLE_HULL_CONVEXITY:
+        return [hull]
+    try:
+        import coacd
+        from threadpoolctl import threadpool_limits
+    except ImportError as exc:
+        logger.warning(
+            "%s is not installed: collision geometry stays a single convex hull, "
+            "which physics sees as a solid wedge for concave models. "
+            "Install so101-nexus[decomp] for a multi-hull decomposition.",
+            exc.name or "coacd",
+        )
+        return [hull]
+
+    import trimesh
+
+    coacd.set_log_level("error")
+    with threadpool_limits(limits=1, user_api="openmp"):
+        parts = coacd.run_coacd(
+            coacd.Mesh(mesh.vertices, mesh.faces),
+            threshold=_COACD_THRESHOLD,
+            max_convex_hull=_COACD_MAX_HULLS,
+            preprocess_mode="on",
+            preprocess_resolution=_COACD_PREPROCESS_RESOLUTION,
+            seed=_COACD_SEED,
+        )
+    # CoACD parts are near-convex, not exactly convex; MuJoCo collides the hull
+    # of a mesh geom anyway, so hulling here keeps the exported OBJ and the
+    # compiled collider identical. A sliver part can fail to hull at all, which
+    # is the same "drop it" case as a zero-volume one.
+    hulls = []
+    for vertices, faces in parts:
+        try:
+            hulls.append(trimesh.Trimesh(vertices, faces).convex_hull)
+        except Exception:  # qhull errors are not importable without scipy here
+            logger.debug("dropping a degenerate CoACD part")
+    return [part for part in hulls if abs(part.volume) > 0.0] or [hull]
+
+
+def _write_collision_parts(mesh: _ExportableMesh, out_dir: Path) -> None:
+    """Export the convex decomposition of ``mesh`` and its manifest into ``out_dir``.
+
+    The manifest is the cache sentinel, so it is removed before the parts are
+    rewritten and published atomically: an interrupted export leaves no manifest
+    and the next call rebuilds, instead of wedging the cache behind a truncated
+    one that ``ensure_ycb_assets`` would accept forever.
+    """
+    parts = _convex_parts(mesh)
+    volumes = [abs(part.volume) for part in parts]
+    total = sum(volumes)
+    fractions = (
+        [volume / total for volume in volumes] if total > 0.0 else [1.0 / len(parts)] * len(parts)
+    )
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = out_dir / _MANIFEST_NAME
+    manifest_path.unlink(missing_ok=True)
+    for stale in out_dir.glob("collision_*.obj"):
+        stale.unlink()
+    entries = []
+    for index, (part, fraction) in enumerate(zip(parts, fractions, strict=True)):
+        name = f"collision_{index:03d}.obj"
+        part.export(str(out_dir / name), file_type="obj")
+        entries.append({"file": name, "mass_fraction": fraction})
+    pending = manifest_path.with_suffix(".json.pending")
+    pending.write_text(
+        json.dumps({"decomposer": _decomposer_id(), "parts": entries}, indent=2),
+        encoding="utf-8",
+    )
+    os.replace(pending, manifest_path)
 
 
 def _texture_image_from_material(material: object) -> _TextureImage | None:
@@ -122,28 +294,61 @@ def _texture_glb_path(model_id: str) -> Path:
     return orig if orig.exists() else base / "textured.glb"
 
 
+def _read_manifest(collision_dir: Path) -> dict | None:
+    """Return the parsed parts manifest, or ``None`` when it is absent or unusable.
+
+    Anything unreadable reads as absent so the cache rebuilds itself: the
+    manifest is the sentinel ``ensure_ycb_assets`` early-returns on, and a
+    truncated one would otherwise wedge the model behind a parse error forever.
+    """
+    try:
+        manifest = json.loads((collision_dir / _MANIFEST_NAME).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(manifest, dict) or not isinstance(manifest.get("parts"), list):
+        return None
+    return manifest
+
+
+def _collision_parts_are_current(collision_dir: Path) -> bool:
+    """Return True when the cached parts were built by this install's decomposer.
+
+    A cache written by a different CoACD version (or by the single-hull fallback
+    before the ``decomp`` extra was installed) is rebuilt, so scene geometry
+    always matches the decomposer that is actually present. The reverse is never
+    true: an install without CoACD keeps whatever is cached rather than
+    overwriting a real decomposition with a coarse hull.
+    """
+    manifest = _read_manifest(collision_dir)
+    if manifest is None:
+        return False
+    current = _decomposer_id()
+    return manifest.get("decomposer") == current or current == _HULL_DECOMPOSER
+
+
 def ensure_ycb_assets(model_id: str) -> Path:
     """Download YCB mesh assets from HuggingFace if not already cached.
 
-    Downloads from the ai-habitat/ycb dataset and converts GLB meshes
-    to OBJ format for use with MuJoCo. The visual mesh is
-    exported directly and the collision mesh is derived from its convex hull.
-    That hull is what physics sees, so concave and elongated models lose
-    exactly the features that make them graspable; see ``YCBObject`` before
-    building a manipulation task around one.
+    Downloads from the ai-habitat/ycb dataset and converts GLB meshes to OBJ
+    format for use with MuJoCo. The visual mesh is exported directly; the
+    collision geometry is a cached convex decomposition of it (see
+    :func:`get_ycb_collision_parts`), so physics sees the concavities a single
+    hull would fill in. Decomposition needs the optional ``decomp`` extra;
+    without it the collision geometry falls back to one convex hull, which is
+    what ``YCBObject`` warns about.
 
     Returns the directory containing the model's mesh files.
     """
     _validate_model_id(model_id)
     mesh_dir = _CACHE_DIR / model_id
 
-    collision_path = mesh_dir / "collision.obj"
+    collision_dir = _collision_dir(model_id)
     visual_path = mesh_dir / "visual.obj"
     texture_path = mesh_dir / "texture.png"
     glb_path = _CACHE_DIR / "meshes" / model_id / "google_16k" / "textured.glb"
     orig_path = glb_path.with_suffix(".glb.orig")
 
-    if collision_path.exists() and visual_path.exists():
+    if _collision_parts_are_current(collision_dir) and visual_path.exists():
         if not texture_path.exists():
             if not glb_path.exists() or not orig_path.exists():
                 from huggingface_hub import snapshot_download
@@ -178,9 +383,9 @@ def ensure_ycb_assets(model_id: str) -> Path:
     mesh_dir.mkdir(parents=True, exist_ok=True)
     _convert_glb_to_obj(glb_path, visual_path)
 
-    mesh = _load_exportable_mesh(glb_path)
-    hull = mesh.convex_hull
-    hull.export(str(collision_path), file_type="obj")
+    _write_collision_parts(_load_exportable_mesh(glb_path), collision_dir)
+    # Single-hull cache from a release before the decomposition; nothing reads it.
+    (mesh_dir / "collision.obj").unlink(missing_ok=True)
     preferred_glb = _texture_glb_path(model_id)
     extracted = _extract_glb_texture(preferred_glb, texture_path)
     if not extracted:
@@ -194,10 +399,51 @@ def ensure_ycb_assets(model_id: str) -> Path:
     return mesh_dir
 
 
-def get_ycb_collision_mesh(model_id: str) -> Path:
-    """Return the path to the collision mesh for a YCB model."""
+def get_ycb_collision_parts(model_id: str) -> list[YCBCollisionPart]:
+    """Return the cached convex collision parts of a YCB model, in export order.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the model has not been prepared yet; call
+        :func:`ensure_ycb_assets` first.
+    """
     _validate_model_id(model_id)
-    return _CACHE_DIR / model_id / "collision.obj"
+    manifest = _read_manifest(_collision_dir(model_id))
+    if manifest is None:
+        raise FileNotFoundError(
+            f"No usable collision decomposition cached for {model_id!r}; "
+            f"call ensure_ycb_assets({model_id!r}) first."
+        )
+    parts_dir = _collision_dir(model_id)
+    return [
+        YCBCollisionPart(parts_dir / entry["file"], float(entry["mass_fraction"]))
+        for entry in manifest["parts"]
+    ]
+
+
+def get_ycb_collision_meshes(model_id: str) -> list[Path]:
+    """Return the OBJ paths of a YCB model's convex collision parts.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the model has not been prepared yet; call
+        :func:`ensure_ycb_assets` first.
+    """
+    return [part.path for part in get_ycb_collision_parts(model_id)]
+
+
+def get_ycb_collision_mesh(model_id: str) -> Path:
+    """Return the path to the first convex part of a YCB model's collision mesh.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the model has not been prepared yet; call
+        :func:`ensure_ycb_assets` first.
+    """
+    return get_ycb_collision_parts(model_id)[0].path
 
 
 def get_ycb_visual_mesh(model_id: str) -> Path:

--- a/src/so101_nexus/ycb_geometry.py
+++ b/src/so101_nexus/ycb_geometry.py
@@ -6,10 +6,13 @@ import numpy as np
 
 
 def get_mujoco_ycb_rest_pose(verts: np.ndarray, margin: float = 0.002) -> tuple[np.ndarray, float]:
-    """Return a stable object rest quaternion and spawn Z from raw mesh vertices.
+    """Return a stable object rest quaternion and spawn Z from mesh vertices.
 
     Objects are rotated so their thinnest axis points up (Z), producing a
     flat, stable rest pose. The quaternion uses the convention (w, x, y, z).
+    ``verts`` are read in the body frame, so ``spawn_z`` is the height the body
+    origin needs for the rotated mesh to clear the floor by ``margin``; vertices
+    that are not centered on the origin are handled.
     """
     extents = np.ptp(verts, axis=0)
     thin_axis = int(np.argmin(extents))
@@ -22,15 +25,16 @@ def get_mujoco_ycb_rest_pose(verts: np.ndarray, margin: float = 0.002) -> tuple[
         quat = np.array([1.0, 0.0, 0.0, 0.0])
         spawn_z = float(-np.min(verts[:, 2])) + margin
     elif thin_axis == 0:
-        # Thin axis is X - rotate 90° around Y to bring X → Z.
-        # Permute columns (X,Y,Z) → (Z,Y,X) then negate new-X to preserve handedness.
+        # Thin axis is X - rotate 90 degrees around Y to bring X to Z, which maps
+        # (x, y, z) to (z, y, -x). Negating any column other than the new Z would
+        # invert the measured height, which cancels only for centered vertices.
         quat = np.array([_SQRT_HALF, 0.0, _SQRT_HALF, 0.0])
         rotated = verts[:, [2, 1, 0]].copy()
-        rotated[:, 0] *= -1
+        rotated[:, 2] *= -1
         spawn_z = float(-np.min(rotated[:, 2])) + margin
     else:
-        # Thin axis is Y - rotate 90° around X to bring Y → Z.
-        # Permute columns (X,Y,Z) → (X,Z,Y) then negate new-Y to preserve handedness.
+        # Thin axis is Y - rotate 90 degrees around X to bring Y to Z, which maps
+        # (x, y, z) to (x, -z, y).
         quat = np.array([_SQRT_HALF, _SQRT_HALF, 0.0, 0.0])
         rotated = verts[:, [0, 2, 1]].copy()
         rotated[:, 1] *= -1

--- a/tests/core/test_object_slots.py
+++ b/tests/core/test_object_slots.py
@@ -15,15 +15,16 @@ import mujoco
 from so101_nexus import get_so101_mujoco_model_path
 from so101_nexus.object_slots import (
     build_object_scene_xml,
+    collision_geom_name,
     cube_bounding_radius,
     cube_xml_body,
     extract_object_slots,
     mesh_xml_body,
     object_bounding_radius,
-    primary_geom_name,
 )
 from so101_nexus.objects import CubeObject, MeshObject, YCBObject
 from so101_nexus.scene import MUJOCO_SCENE_OPTION_XML
+from so101_nexus.ycb_assets import YCBCollisionPart
 
 _ROBOT_XML = str(get_so101_mujoco_model_path())
 
@@ -52,16 +53,28 @@ class TestXmlBuilders:
 
     def test_mesh_xml_body_groups(self):
         xml = mesh_xml_body("pick_slot_0", 0, 0.01)
-        assert 'name="pick_slot_0_collision"' in xml
-        assert 'mesh="pick_coll_0"' in xml
+        assert 'name="pick_slot_0_collision_0"' in xml
+        assert 'mesh="pick_coll_0_0"' in xml
         assert 'group="3"' in xml
         assert 'name="pick_slot_0_visual"' in xml
         assert 'mesh="pick_vis_0"' in xml
         assert 'group="2"' in xml
 
-    def test_primary_geom_name(self):
-        assert primary_geom_name("pick_slot_0", CubeObject()) == "pick_slot_0_geom"
-        assert primary_geom_name("pick_slot_1", YCBObject("011_banana")) == "pick_slot_1_collision"
+    def test_mesh_xml_body_splits_mass_across_parts(self):
+        xml = mesh_xml_body("pick_slot_0", 1, 0.02, mass_fractions=(0.25, 0.75))
+        assert 'name="pick_slot_0_collision_0"' in xml
+        assert 'name="pick_slot_0_collision_1"' in xml
+        assert 'mesh="pick_coll_1_0"' in xml
+        assert 'mesh="pick_coll_1_1"' in xml
+        assert 'mass="0.005"' in xml
+        assert 'mass="0.015"' in xml
+        assert xml.count('type="mesh"') == 3  # two collision parts plus the visual
+
+    def test_collision_geom_name(self):
+        assert collision_geom_name("pick_slot_0", CubeObject()) == "pick_slot_0_geom"
+        banana = YCBObject("011_banana")
+        assert collision_geom_name("pick_slot_1", banana) == "pick_slot_1_collision_0"
+        assert collision_geom_name("pick_slot_1", banana, part=2) == "pick_slot_1_collision_2"
 
     def test_cube_bounding_radius(self):
         assert cube_bounding_radius(CubeObject(half_size=0.0125)) == pytest.approx(
@@ -103,7 +116,11 @@ class TestXmlBuilders:
         visual_path = tmp_path / "visual.obj"
         texture_path = tmp_path / "texture.png"
         texture_path.write_text("texture", encoding="utf-8")
-        monkeypatch.setattr(object_slots, "get_ycb_collision_mesh", lambda _m: collision_path)
+        monkeypatch.setattr(
+            object_slots,
+            "get_ycb_collision_parts",
+            lambda _m: [YCBCollisionPart(collision_path, 1.0)],
+        )
         monkeypatch.setattr(object_slots, "get_ycb_visual_mesh", lambda _m: visual_path)
         monkeypatch.setattr(object_slots, "get_ycb_texture_file", lambda _m: texture_path)
 
@@ -138,7 +155,11 @@ class TestXmlBuilders:
         collision_path = _FakePath("C:/cache/ycb/collision.obj", r"C:\cache\ycb\collision.obj")
         visual_path = _FakePath("C:/cache/ycb/visual.obj", r"C:\cache\ycb\visual.obj")
         texture_path = _FakePath("C:/cache/ycb/texture.png", r"C:\cache\ycb\texture.png")
-        monkeypatch.setattr(object_slots, "get_ycb_collision_mesh", lambda _m: collision_path)
+        monkeypatch.setattr(
+            object_slots,
+            "get_ycb_collision_parts",
+            lambda _m: [YCBCollisionPart(collision_path, 1.0)],
+        )
         monkeypatch.setattr(object_slots, "get_ycb_visual_mesh", lambda _m: visual_path)
         monkeypatch.setattr(object_slots, "get_ycb_texture_file", lambda _m: texture_path)
 
@@ -223,3 +244,115 @@ class TestSlotExtraction:
         naive_radius = float(np.linalg.norm([2 * hx, 2 * hy]) / 2)
         assert slot.bounding_radius == pytest.approx(rotated_radius, abs=1e-6)
         assert slot.bounding_radius != pytest.approx(naive_radius, abs=1e-6)
+
+
+def _write_box_obj(path, lo, hi):
+    """Write an axis-aligned box OBJ spanning ``lo`` to ``hi``."""
+    corners = [(x, y, z) for x in (lo[0], hi[0]) for y in (lo[1], hi[1]) for z in (lo[2], hi[2])]
+    faces = [
+        (1, 2, 4),
+        (1, 4, 3),
+        (5, 6, 8),
+        (5, 8, 7),
+        (1, 2, 6),
+        (1, 6, 5),
+        (3, 4, 8),
+        (3, 8, 7),
+        (1, 3, 7),
+        (1, 7, 5),
+        (2, 4, 8),
+        (2, 8, 6),
+    ]
+    lines = [f"v {x} {y} {z}" for x, y, z in corners]
+    lines += [f"f {a} {b} {c}" for a, b, c in faces]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+class TestMultiPartCollision:
+    """A decomposed YCB collision hull must behave as one object, not N objects.
+
+    The fixture is a thin slab offset from the body origin and split across its
+    thin axis, so reading one part (or reading raw compiled vertices instead of
+    body-frame ones) gives a measurably different rest pose.
+    """
+
+    X0, X1 = 0.10, 0.11  # thin axis, offset from the body origin
+    XSPLIT = 0.1025
+    HY, HZ = 0.03, 0.02
+    MARGIN = 0.002
+    MASS = 0.05
+
+    def _compile(self, monkeypatch, tmp_path, parts):
+        from so101_nexus import object_slots
+
+        visual = _write_box_obj(
+            tmp_path / "visual.obj",
+            (self.X0, -self.HY, -self.HZ),
+            (self.X1, self.HY, self.HZ),
+        )
+        monkeypatch.setattr(object_slots, "get_ycb_collision_parts", lambda _m: parts)
+        monkeypatch.setattr(object_slots, "get_ycb_visual_mesh", lambda _m: visual)
+        monkeypatch.setattr(object_slots, "get_ycb_texture_file", lambda _m: tmp_path / "none.png")
+
+        obj = YCBObject(model_id="011_banana", mass_override=self.MASS)
+        xml, slot_names = _cube_scene([obj])
+        so_dir = get_so101_mujoco_model_path().parent
+        with tempfile.NamedTemporaryFile("w", suffix=".xml", dir=so_dir, delete=True) as f:
+            f.write(xml)
+            f.flush()
+            mjm = mujoco.MjModel.from_xml_path(f.name)
+        return mjm, extract_object_slots(mjm, slot_names, [obj])[0]
+
+    def _single_hull(self, tmp_path):
+        path = _write_box_obj(
+            tmp_path / "whole.obj",
+            (self.X0, -self.HY, -self.HZ),
+            (self.X1, self.HY, self.HZ),
+        )
+        return [YCBCollisionPart(path, 1.0)]
+
+    def _two_slabs(self, tmp_path):
+        """Split across the thin axis, unequally, so part 0 alone is measurably shorter."""
+        near = _write_box_obj(
+            tmp_path / "near.obj",
+            (self.X0, -self.HY, -self.HZ),
+            (self.XSPLIT, self.HY, self.HZ),
+        )
+        far = _write_box_obj(
+            tmp_path / "far.obj",
+            (self.XSPLIT, -self.HY, -self.HZ),
+            (self.X1, self.HY, self.HZ),
+        )
+        return [YCBCollisionPart(near, 0.25), YCBCollisionPart(far, 0.75)]
+
+    def test_every_part_becomes_a_collision_geom(self, monkeypatch, tmp_path):
+        _, slot = self._compile(monkeypatch, tmp_path, self._two_slabs(tmp_path))
+        assert len(slot.geom_ids) == 2
+        assert slot.geom_id == slot.geom_ids[0]
+        assert slot.geom_ids[1] == slot.geom_ids[0] + 1
+
+    def test_body_mass_is_independent_of_part_count(self, monkeypatch, tmp_path):
+        single_mjm, single_slot = self._compile(monkeypatch, tmp_path, self._single_hull(tmp_path))
+        multi_mjm, multi_slot = self._compile(monkeypatch, tmp_path, self._two_slabs(tmp_path))
+        single_body = int(single_mjm.geom_bodyid[single_slot.geom_id])
+        multi_body = int(multi_mjm.geom_bodyid[multi_slot.geom_id])
+        assert float(multi_mjm.body_mass[multi_body]) == pytest.approx(
+            float(single_mjm.body_mass[single_body]), rel=1e-9
+        )
+        assert float(multi_mjm.body_mass[multi_body]) == pytest.approx(self.MASS, rel=1e-9)
+
+    def test_rest_pose_uses_the_union_of_the_parts(self, monkeypatch, tmp_path):
+        _, single = self._compile(monkeypatch, tmp_path, self._single_hull(tmp_path))
+        _, multi = self._compile(monkeypatch, tmp_path, self._two_slabs(tmp_path))
+        # The slab rests on its thin axis, so the body origin must clear the far
+        # face: reading only part 0 would spawn it 7.5 mm into the floor.
+        expected_z = self.X1 + self.MARGIN
+        part0_z = self.XSPLIT + self.MARGIN
+        assert multi.spawn_z == pytest.approx(expected_z, abs=1e-5)
+        assert multi.spawn_z == pytest.approx(single.spawn_z, abs=1e-5)
+        assert multi.spawn_z != pytest.approx(part0_z, abs=1e-5)
+        # Footprint after the rest rotation is the Y and Z extents of the union.
+        expected_radius = float(np.linalg.norm([2 * self.HY, 2 * self.HZ]) / 2)
+        assert multi.bounding_radius == pytest.approx(expected_radius, abs=1e-5)
+        np.testing.assert_allclose(multi.rest_quat, single.rest_quat)

--- a/tests/core/test_ycb.py
+++ b/tests/core/test_ycb.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import contextlib
+import json
 import sys
 import types
 from pathlib import Path
@@ -47,12 +49,17 @@ class TestYCBAssets:
 
 
 class _FakeMesh:
+    """Stands in for a trimesh mesh; convex by construction, so no decomposition."""
+
+    volume = 1.0
+
     def __init__(self):
         self.exports: list[tuple[str, str | None]] = []
         self.convex_hull = self
 
     def export(self, file_obj: str, file_type: str | None = None):
         self.exports.append((file_obj, file_type))
+        Path(file_obj).write_text("hull", encoding="utf-8")
 
 
 class _FakeScene:
@@ -161,12 +168,34 @@ def test_extract_glb_texture_returns_false_without_texture(
     assert not out.exists()
 
 
+def _write_cached_parts(
+    mesh_dir: Path,
+    files: tuple[str, ...] = ("collision_000.obj",),
+    decomposer: str | None = None,
+) -> Path:
+    """Write a v2 collision decomposition cache entry and return its directory."""
+    parts_dir = mesh_dir / "collision_v2"
+    parts_dir.mkdir(parents=True, exist_ok=True)
+    for name in files:
+        (parts_dir / name).write_text("c", encoding="utf-8")
+    (parts_dir / "parts.json").write_text(
+        json.dumps(
+            {
+                "decomposer": ycb_assets._decomposer_id() if decomposer is None else decomposer,
+                "parts": [{"file": name, "mass_fraction": 1.0 / len(files)} for name in files],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return parts_dir
+
+
 def test_ensure_ycb_assets_cache_hit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     monkeypatch.setattr(ycb_assets, "_CACHE_DIR", tmp_path)
     model_id = "009_gelatin_box"
     mesh_dir = tmp_path / model_id
     mesh_dir.mkdir(parents=True)
-    (mesh_dir / "collision.obj").write_text("c", encoding="utf-8")
+    _write_cached_parts(mesh_dir)
     (mesh_dir / "visual.obj").write_text("v", encoding="utf-8")
     (mesh_dir / "texture.png").write_text("t", encoding="utf-8")
 
@@ -190,7 +219,7 @@ def test_ensure_ycb_assets_cache_hit_extracts_missing_texture(
     model_id = "009_gelatin_box"
     mesh_dir = tmp_path / model_id
     mesh_dir.mkdir(parents=True)
-    (mesh_dir / "collision.obj").write_text("c", encoding="utf-8")
+    _write_cached_parts(mesh_dir)
     (mesh_dir / "visual.obj").write_text("v", encoding="utf-8")
     glb = tmp_path / "meshes" / model_id / "google_16k" / "textured.glb"
     glb.parent.mkdir(parents=True)
@@ -239,7 +268,7 @@ def test_ensure_ycb_assets_returns_when_texture_extract_finds_nothing(
     assert not (mesh_dir / "texture.png").exists()
 
 
-def test_ensure_ycb_assets_download_and_convex_hull(
+def test_ensure_ycb_assets_download_and_decomposition(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ):
     model_id = "009_gelatin_box"
@@ -274,7 +303,12 @@ def test_ensure_ycb_assets_download_and_convex_hull(
         tmp_path / "meshes" / model_id / "google_16k" / "textured.glb",
         tmp_path / model_id / "visual.obj",
     )
-    assert mesh.exports[-1] == (str(tmp_path / model_id / "collision.obj"), "obj")
+    parts_dir = tmp_path / model_id / "collision_v2"
+    assert mesh.exports[-1] == (str(parts_dir / "collision_000.obj"), "obj")
+    assert json.loads((parts_dir / "parts.json").read_text(encoding="utf-8")) == {
+        "decomposer": ycb_assets._decomposer_id(),
+        "parts": [{"file": "collision_000.obj", "mass_fraction": 1.0}],
+    }
 
 
 def test_ensure_ycb_assets_scene_path_for_hull(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
@@ -299,14 +333,60 @@ def test_ensure_ycb_assets_scene_path_for_hull(monkeypatch: pytest.MonkeyPatch, 
     monkeypatch.setattr(ycb_assets, "_convert_glb_to_obj", lambda _g, p: p.write_text("v"))
 
     ycb_assets.ensure_ycb_assets(model_id)
-    assert mesh.exports[-1] == (str(tmp_path / model_id / "collision.obj"), "obj")
+    assert mesh.exports[-1] == (
+        str(tmp_path / model_id / "collision_v2" / "collision_000.obj"),
+        "obj",
+    )
 
 
 def test_collision_and_visual_mesh_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     monkeypatch.setattr(ycb_assets, "_CACHE_DIR", tmp_path)
     model_id = "058_golf_ball"
-    assert ycb_assets.get_ycb_collision_mesh(model_id) == tmp_path / model_id / "collision.obj"
+    parts_dir = _write_cached_parts(tmp_path / model_id, ("collision_000.obj", "collision_001.obj"))
+    assert ycb_assets.get_ycb_collision_meshes(model_id) == [
+        parts_dir / "collision_000.obj",
+        parts_dir / "collision_001.obj",
+    ]
+    assert ycb_assets.get_ycb_collision_mesh(model_id) == parts_dir / "collision_000.obj"
     assert ycb_assets.get_ycb_visual_mesh(model_id) == tmp_path / model_id / "visual.obj"
+
+
+def test_collision_parts_require_prepared_assets(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr(ycb_assets, "_CACHE_DIR", tmp_path)
+    with pytest.raises(FileNotFoundError, match="ensure_ycb_assets"):
+        ycb_assets.get_ycb_collision_parts("058_golf_ball")
+
+
+def test_collision_parts_reject_a_truncated_manifest(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """A half-written manifest must read as absent, not wedge the cache forever."""
+    monkeypatch.setattr(ycb_assets, "_CACHE_DIR", tmp_path)
+    model_id = "058_golf_ball"
+    parts_dir = _write_cached_parts(tmp_path / model_id)
+    (parts_dir / "parts.json").write_text('{"parts": [{"file":', encoding="utf-8")
+
+    assert not ycb_assets._collision_parts_are_current(parts_dir)
+    with pytest.raises(FileNotFoundError, match="ensure_ycb_assets"):
+        ycb_assets.get_ycb_collision_parts(model_id)
+
+
+def test_cached_parts_from_another_decomposer_are_rebuilt(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """Installing the extra (or upgrading CoACD) must not keep the old geometry.
+
+    The reverse never holds: an install without CoACD keeps a real decomposition
+    rather than overwriting it with a coarse hull.
+    """
+    monkeypatch.setattr(ycb_assets, "_CACHE_DIR", tmp_path)
+    parts_dir = _write_cached_parts(tmp_path / "058_golf_ball", decomposer="coacd 0.0.1")
+
+    monkeypatch.setattr(ycb_assets, "_decomposer_id", lambda: "coacd 9.9.9")
+    assert not ycb_assets._collision_parts_are_current(parts_dir)
+
+    monkeypatch.setattr(ycb_assets, "_decomposer_id", lambda: ycb_assets._HULL_DECOMPOSER)
+    assert ycb_assets._collision_parts_are_current(parts_dir)
 
 
 def test_extract_glb_texture_accepts_orig_extension(
@@ -371,7 +451,7 @@ def test_ensure_ycb_assets_downloads_orig_when_partial_cache_lacks_it(
 
     mesh_dir = tmp_path / model_id
     mesh_dir.mkdir(parents=True)
-    (mesh_dir / "collision.obj").write_text("c", encoding="utf-8")
+    _write_cached_parts(mesh_dir)
     (mesh_dir / "visual.obj").write_text("v", encoding="utf-8")
     glb_dir = tmp_path / "meshes" / model_id / "google_16k"
     glb_dir.mkdir(parents=True)
@@ -420,7 +500,7 @@ def test_ensure_ycb_assets_logs_warning_when_extraction_fails(
 
     mesh_dir = tmp_path / model_id
     mesh_dir.mkdir(parents=True)
-    (mesh_dir / "collision.obj").write_text("c", encoding="utf-8")
+    _write_cached_parts(mesh_dir)
     (mesh_dir / "visual.obj").write_text("v", encoding="utf-8")
     glb_dir = tmp_path / "meshes" / model_id / "google_16k"
     glb_dir.mkdir(parents=True)
@@ -441,3 +521,151 @@ def test_ensure_ycb_assets_logs_warning_when_extraction_fails(
     msg = warning_records[0].getMessage()
     assert model_id in msg, f"WARNING must name the model id, got: {msg!r}"
     assert "textured.glb.orig" in msg, f"WARNING must name the GLB path tried, got: {msg!r}"
+
+
+class _ConcaveMesh:
+    """Mesh whose convex hull is twice its volume, so it must be decomposed."""
+
+    volume = 0.5
+    vertices = ((0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0))
+    faces = ((0, 1, 2), (0, 1, 3), (0, 2, 3), (1, 2, 3))
+
+    def __init__(self):
+        self.convex_hull = _FakeMesh()
+
+
+def _fake_coacd(monkeypatch: pytest.MonkeyPatch, events: list[tuple]) -> None:
+    """Install fake ``coacd`` and ``threadpoolctl`` modules recording their use.
+
+    Both live in the optional ``decomp`` extra, so faking them keeps these tests
+    running on a plain install (and in CI, which syncs no extras).
+    """
+
+    def _run_coacd(mesh, **kwargs):
+        events.append(("run_coacd", kwargs))
+        return [("v0", "f0"), ("v1", "f1")]
+
+    @contextlib.contextmanager
+    def _threadpool_limits(limits=None, user_api=None):
+        events.append(("enter_limits", limits, user_api))
+        yield
+        events.append(("exit_limits",))
+
+    _patch_module(
+        monkeypatch,
+        "coacd",
+        types.SimpleNamespace(
+            Mesh=lambda vertices, faces: (vertices, faces),
+            run_coacd=_run_coacd,
+            set_log_level=lambda _level: None,
+        ),
+    )
+    _patch_module(
+        monkeypatch, "threadpoolctl", types.SimpleNamespace(threadpool_limits=_threadpool_limits)
+    )
+
+
+def _fake_trimesh_with_hulls(monkeypatch: pytest.MonkeyPatch, volumes: list[float]) -> None:
+    hulls = []
+
+    def _trimesh(_vertices, _faces):
+        hull = _FakeMesh()
+        hull.volume = volumes[len(hulls)]
+        hulls.append(hull)
+        return types.SimpleNamespace(convex_hull=hull)
+
+    _patch_module(monkeypatch, "trimesh", types.SimpleNamespace(Scene=_FakeScene, Trimesh=_trimesh))
+
+
+def test_convex_parts_keeps_single_hull_for_convex_meshes(monkeypatch: pytest.MonkeyPatch):
+    """A box or a ball is its own hull; decomposing it only buys collision geoms."""
+    events: list[tuple] = []
+    _fake_coacd(monkeypatch, events)
+    mesh = _FakeMesh()
+
+    assert ycb_assets._convex_parts(mesh) == [mesh.convex_hull]
+    assert events == []
+
+
+@pytest.mark.parametrize("missing", ["coacd", "threadpoolctl"])
+def test_convex_parts_falls_back_to_single_hull_without_the_extra(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, missing: str
+):
+    """The decomposer is an optional extra: a plain install must still build scenes."""
+    import logging
+
+    _fake_coacd(monkeypatch, [])
+    _patch_module(monkeypatch, missing, None)
+    mesh = _ConcaveMesh()
+
+    with caplog.at_level(logging.WARNING, logger="so101_nexus.ycb_assets"):
+        parts = ycb_assets._convex_parts(mesh)
+
+    assert parts == [mesh.convex_hull]
+    # The warning must name the package that is actually missing.
+    assert missing in caplog.records[0].getMessage()
+
+
+def test_write_collision_parts_weights_mass_by_part_volume(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    events: list[tuple] = []
+    _fake_coacd(monkeypatch, events)
+    _fake_trimesh_with_hulls(monkeypatch, [1.0, 3.0])
+
+    ycb_assets._write_collision_parts(_ConcaveMesh(), tmp_path)
+
+    manifest = json.loads((tmp_path / "parts.json").read_text(encoding="utf-8"))
+    assert manifest["parts"] == [
+        {"file": "collision_000.obj", "mass_fraction": 0.25},
+        {"file": "collision_001.obj", "mass_fraction": 0.75},
+    ]
+    assert sum(part["mass_fraction"] for part in manifest["parts"]) == 1.0
+    # Scene geometry must not vary between runs: the search is seeded AND pinned
+    # to one OpenMP thread, because CoACD's thread scheduling changes the split.
+    assert events[0] == ("enter_limits", 1, "openmp")
+    assert events[1][0] == "run_coacd"
+    assert events[1][1]["seed"] == ycb_assets._COACD_SEED
+    assert events[2] == ("exit_limits",)
+
+
+def test_write_collision_parts_drops_stale_parts(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """A shorter decomposition must not leave orphan OBJs behind in the cache."""
+    (tmp_path).mkdir(parents=True, exist_ok=True)
+    (tmp_path / "collision_007.obj").write_text("stale", encoding="utf-8")
+    _patch_module(monkeypatch, "trimesh", types.SimpleNamespace(Scene=_FakeScene))
+
+    ycb_assets._write_collision_parts(_FakeMesh(), tmp_path)
+
+    assert sorted(p.name for p in tmp_path.glob("collision_*.obj")) == ["collision_000.obj"]
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "model_id,min_convexity",
+    [
+        ("033_spatula", 0.55),  # 0.19 as a single hull
+        ("031_spoon", 0.60),  # 0.31 as a single hull
+        ("030_fork", 0.55),  # 0.45 as a single hull
+    ],
+)
+def test_decomposed_collision_geometry_tracks_the_visual_mesh(model_id: str, min_convexity: float):
+    """Collision volume must stay close to the scan, not balloon into a solid wedge.
+
+    Downloads and decomposes on a cold cache; cached runs only load the OBJs.
+    """
+    pytest.importorskip("coacd")
+    trimesh = pytest.importorskip("trimesh")
+
+    ycb_assets.ensure_ycb_assets(model_id)
+    visual = trimesh.load(str(ycb_assets.get_ycb_visual_mesh(model_id)), force="mesh")
+    parts = [
+        trimesh.load(str(path), force="mesh").convex_hull
+        for path in ycb_assets.get_ycb_collision_meshes(model_id)
+    ]
+    convexity = abs(visual.volume) / sum(abs(part.volume) for part in parts)
+    assert convexity >= min_convexity, (
+        f"{model_id} collision volume is {1 / convexity:.2f}x the visual mesh "
+        f"(convexity {convexity:.2f} < {min_convexity})"
+    )
+    assert len(parts) > 1

--- a/tests/core/test_ycb_geometry_properties.py
+++ b/tests/core/test_ycb_geometry_properties.py
@@ -81,3 +81,35 @@ def test_rest_pose_deterministic(n, scale, seed):
     q2, z2 = get_mujoco_ycb_rest_pose(verts, margin=1e-3)
     np.testing.assert_array_equal(q1, q2)
     assert z1 == z2
+
+
+@pytest.mark.parametrize("thin_axis", [0, 1, 2])
+@pytest.mark.parametrize("offset", [0.0, 0.11])
+def test_spawn_z_matches_the_returned_rotation(thin_axis: int, offset: float):
+    """``spawn_z`` must be the clearance of the mesh under ``quat``, not its mirror.
+
+    Regression: the thin-X branch measured the height of the inverse rotation.
+    That is invisible for vertices centered on the origin (the two agree by
+    symmetry) and buries the object below the floor once they are offset, which
+    is what the body-frame vertices from ``extract_object_slots`` are.
+    """
+    import mujoco
+
+    half = [0.03, 0.03, 0.03]
+    half[thin_axis] = 0.005
+    corners = np.array(
+        [
+            [sx * half[0], sy * half[1], sz * half[2]]
+            for sx in (-1, 1)
+            for sy in (-1, 1)
+            for sz in (-1, 1)
+        ]
+    )
+    verts = corners + np.array([offset, offset, offset])
+
+    quat, spawn_z = get_mujoco_ycb_rest_pose(verts, margin=0.002)
+
+    rot = np.zeros(9)
+    mujoco.mju_quat2Mat(rot, quat)
+    rotated_z = (verts @ rot.reshape(3, 3).T)[:, 2]
+    assert spawn_z == pytest.approx(-rotated_z.min() + 0.002, abs=1e-6)

--- a/tests/mujoco/test_envs.py
+++ b/tests/mujoco/test_envs.py
@@ -398,7 +398,8 @@ def test_pick_mixed_pool_with_distractors():
 
 @pytest.mark.parametrize("model_id", ["011_banana", "030_fork", "031_spoon", "032_knife"])
 def test_pick_ycb_collision_geom_starts_above_floor(model_id):
-    from so101_nexus.mujoco.spawn_utils import mesh_geom_world_min_z
+    pytest.importorskip("coacd", reason="multi-hull collision needs the decomp extra")
+    from so101_nexus.mujoco.spawn_utils import slot_world_min_z
 
     config = PickConfig(objects=[YCBObject(model_id=model_id)], reset_settle_frames=0)
     env = gym.make("MuJoCoPickLift-v1", config=config)
@@ -406,7 +407,9 @@ def test_pick_ycb_collision_geom_starts_above_floor(model_id):
         env.reset(seed=0)
         inner = env.unwrapped
         slot = inner._slots[inner._target_slot_idx]  # type: ignore[attr-defined]
-        min_z = mesh_geom_world_min_z(inner.model, inner.data, slot.geom_id)  # type: ignore[attr-defined]
+        assert len(slot.geom_ids) > 1, f"{model_id} should decompose into multiple hulls"
+        # Every convex part must clear the floor, not just the first one.
+        min_z = slot_world_min_z(inner.model, inner.data, slot.geom_ids)  # type: ignore[attr-defined]
         assert min_z >= -1e-6
     finally:
         env.close()
@@ -1678,7 +1681,7 @@ def test_pick_and_place_color_description_agreement():
         assert inner.cube_color_name in desc
         assert inner.target_color_name in desc
         # Rendered geom rgba matches the named color.
-        cube_rgba = inner.model.geom_rgba[inner._obj_geom_id]
+        cube_rgba = inner.model.geom_rgba[inner._obj_geom_ids[0]]
         target_rgba = inner.model.geom_rgba[inner._target_geom_id]
         np.testing.assert_allclose(cube_rgba, COLOR_MAP[inner.cube_color_name], atol=1e-6)
         np.testing.assert_allclose(target_rgba, COLOR_MAP[inner.target_color_name], atol=1e-6)

--- a/tests/mujoco/test_grasp_and_targeting.py
+++ b/tests/mujoco/test_grasp_and_targeting.py
@@ -30,6 +30,8 @@ from so101_nexus.testing import component_slice
 _OPEN = np.array([0, 0, 0, 0, 0, 0, 1], dtype=np.float32)
 _CLOSE = np.array([0, 0, 0, 0, 0, 0, -1], dtype=np.float32)
 _LIFT = np.array([0, 0, 0.4, 0, 0, 0, -1], dtype=np.float32)
+#: 90 degree yaw, exactly normalized (MuJoCo renormalizes, but the test should not rely on it).
+_YAW_90 = np.array([1.0, 0.0, 0.0, 1.0]) / np.sqrt(2.0)
 
 
 def _pick_env(*, half_size=0.012, robot=None, objects=None, observations=None, n_distractors=0):
@@ -50,8 +52,8 @@ def _fingertip_geoms(env):
     ]
 
 
-def _pinch_the_target(env, steps=60):
-    """Close the jaws on the target held between the fingertips."""
+def _pinch_the_target(env, steps=60, quat=(1.0, 0.0, 0.0, 0.0)):
+    """Close the jaws on the target held between the fingertips at ``quat``."""
     for _ in range(60):
         env.step(_OPEN)
     tips = _fingertip_geoms(env)
@@ -59,7 +61,7 @@ def _pinch_the_target(env, steps=60):
     for _ in range(steps):
         mid = env.data.geom_xpos[tips].mean(0)
         env.data.qpos[slot.qpos_addr : slot.qpos_addr + 3] = mid
-        env.data.qpos[slot.qpos_addr + 3 : slot.qpos_addr + 7] = [1, 0, 0, 0]
+        env.data.qpos[slot.qpos_addr + 3 : slot.qpos_addr + 7] = quat
         env.data.qvel[slot.dof_addr : slot.dof_addr + 6] = 0.0
         env.step(_CLOSE)
 
@@ -91,16 +93,18 @@ def _straddle_the_target(env, penetration=0.04):
     mujoco.mj_forward(env.model, env.data)
 
 
-def _loaded_finger_sides(env):
-    """Return which finger sets currently bear force against the target geom."""
+def _loaded_contacts(env):
+    """Return the finger sets bearing force on the target and the geoms they load."""
     sides = set()
+    loaded_geoms = set()
     force = np.zeros(6)
+    target_geoms = set(env._obj_geom_ids.tolist())
     for i in range(env.data.ncon):
         contact = env.data.contact[i]
         pair = (contact.geom1, contact.geom2)
-        if env._obj_geom_id not in pair:
+        if not target_geoms & set(pair):
             continue
-        other = pair[1] if pair[0] == env._obj_geom_id else pair[0]
+        target, other = (pair[0], pair[1]) if pair[0] in target_geoms else (pair[1], pair[0])
         mujoco.mj_contactForce(env.model, env.data, i, force)
         if abs(force[0]) < env.config.robot.grasp_force_threshold:
             continue
@@ -108,7 +112,15 @@ def _loaded_finger_sides(env):
             sides.add("gripper")
         elif other in env._jaw_geom_ids:
             sides.add("jaw")
-    return sides
+        else:
+            continue
+        loaded_geoms.add(int(target))
+    return sides, loaded_geoms
+
+
+def _loaded_finger_sides(env):
+    """Return which finger sets currently bear force against the target object."""
+    return _loaded_contacts(env)[0]
 
 
 def test_straddling_an_over_wide_object_is_not_a_grasp():
@@ -155,6 +167,35 @@ def test_a_real_pinch_still_grasps_and_carries_the_object():
             env.step(_LIFT)
         assert env._is_grasping() == 1.0
         assert float(env._get_target_pose()[2]) - z0 > env.config.lift_threshold
+    finally:
+        env.close()
+
+
+@pytest.mark.slow
+def test_pinching_a_decomposed_ycb_object_grasps_across_its_parts():
+    """Grasp detection is per object, not per convex part.
+
+    A YCB collision hull is a multi-part decomposition, so the two finger sets
+    load different parts of the same body. Aggregating contact normals per geom
+    instead of per slot scores that as one-sided and returns 0.0.
+    """
+    pytest.importorskip("coacd", reason="multi-hull collision needs the decomp extra")
+    from so101_nexus.objects import YCBObject
+
+    env = _pick_env(objects=[YCBObject(model_id="043_phillips_screwdriver")])
+    try:
+        env.reset(seed=0)
+        slot = env._slots[0]
+        assert len(slot.geom_ids) > 1, "screwdriver should decompose into multiple hulls"
+        # Stand the handle upright between the fingertips so the jaws close across
+        # its shaft rather than along it.
+        _pinch_the_target(env, quat=_YAW_90)
+        sides, loaded_geoms = _loaded_contacts(env)
+        assert sides == {"gripper", "jaw"}
+        # The point of the test: without contacts on more than one part it would
+        # pass under per-geom aggregation too, and guard nothing.
+        assert len(loaded_geoms) > 1, f"fingers loaded a single part: {loaded_geoms}"
+        assert env._is_grasping() == 1.0
     finally:
         env.close()
 
@@ -225,7 +266,7 @@ def test_target_index_option_selects_the_target():
             _, info = env.reset(seed=11, options={"target_index": k})
             assert info["target_index"] == k
             assert info["target_object"] == repr(_POOL[k])
-            assert env._obj_geom_id == env._slots[k].geom_id
+            assert tuple(env._obj_geom_ids) == env._slots[k].geom_ids
     finally:
         env.close()
 

--- a/tests/mujoco/test_spawn_utils.py
+++ b/tests/mujoco/test_spawn_utils.py
@@ -190,6 +190,49 @@ def test_mesh_geom_world_min_z_rejects_non_mesh_geom():
         spawn_utils.mesh_geom_world_min_z(model, data, 0)
 
 
+class _FakeTwoPartModel:
+    """Two mesh geoms sharing one body, as a decomposed collision hull compiles to."""
+
+    def __init__(self, geom_types: tuple[int, int]):
+        self.geom_type = np.array(geom_types, dtype=np.int32)
+        self.geom_dataid = np.array([0, 1], dtype=np.int32)
+        self.mesh_vertadr = np.array([0, 2], dtype=np.int32)
+        self.mesh_vertnum = np.array([2, 2], dtype=np.int32)
+        self.mesh_vert = np.array(
+            [[0.0, 0.0, 0.05], [0.0, 0.0, 0.06], [0.0, 0.0, -0.01], [0.0, 0.0, 0.02]],
+            dtype=np.float64,
+        )
+
+
+class _FakeTwoPartData:
+    def __init__(self):
+        self.qpos = np.zeros(7, dtype=np.float64)
+        self.geom_xpos = np.array([[0.0, 0.0, 0.5], [0.0, 0.0, 0.5]], dtype=np.float64)
+        self.geom_xmat = np.tile(np.eye(3, dtype=np.float64).reshape(1, 9), (2, 1))
+
+
+def test_slot_world_min_z_takes_the_lowest_part():
+    """A slot clears the floor only when its lowest convex part does."""
+    import mujoco
+
+    mesh = mujoco.mjtGeom.mjGEOM_MESH
+    model = _FakeTwoPartModel((mesh, mesh))
+    data = _FakeTwoPartData()
+
+    assert spawn_utils.slot_world_min_z(model, data, (0, 1)) == pytest.approx(0.49)
+    assert spawn_utils.slot_world_min_z(model, data, (0,)) == pytest.approx(0.55)
+
+
+def test_slot_world_min_z_rejects_a_non_mesh_part():
+    import mujoco
+
+    model = _FakeTwoPartModel((mujoco.mjtGeom.mjGEOM_MESH, mujoco.mjtGeom.mjGEOM_BOX))
+    data = _FakeTwoPartData()
+
+    with pytest.raises(ValueError, match="mesh geom"):
+        spawn_utils.slot_world_min_z(model, data, (0, 1))
+
+
 def test_align_freejoint_geom_to_floor_sets_spawn_height(monkeypatch):
     import mujoco
 
@@ -205,7 +248,7 @@ def test_align_freejoint_geom_to_floor_sets_spawn_height(monkeypatch):
         model,
         data,
         qpos_addr=0,
-        geom_id=0,
+        geom_ids=(0,),
         xy=(0.2, -0.1),
         quat=np.array([1.0, 0.0, 0.0, 0.0]),
         margin=0.005,

--- a/tests/warp/test_warp_envs.py
+++ b/tests/warp/test_warp_envs.py
@@ -311,13 +311,19 @@ def test_pick_object_pose_obs_tracks_cube():
     assert torch.allclose(obs[:, :3], env._target_pos(), atol=1e-5)
 
 
-def test_pick_contact_budget_headroom_and_grasp_range():
+@pytest.mark.parametrize("objects", [None, "033_spatula"])
+def test_pick_contact_budget_headroom_and_grasp_range(objects):
+    """The default budget must cover a decomposed pool, not just a single cube."""
     import torch
 
     from so101_nexus.config import PickConfig
+    from so101_nexus.objects import YCBObject
     from so101_nexus.warp.pick_env import WarpPickLiftVectorEnv
 
-    env = WarpPickLiftVectorEnv(num_envs=6, config=PickConfig(), device="cpu", seed=0)
+    if objects is not None:
+        pytest.importorskip("coacd", reason="multi-hull collision needs the decomp extra")
+    config = PickConfig() if objects is None else PickConfig(objects=YCBObject(objects))
+    env = WarpPickLiftVectorEnv(num_envs=6, config=config, device="cpu", seed=0)
     env.reset(seed=0)
     max_nacon = 0
     info = {}
@@ -349,15 +355,15 @@ def test_pick_supports_heterogeneous_pool():
     assert torch.isfinite(obs).all()
     assert torch.isfinite(reward).all()
 
-    # Mixed pool with distractors: per-world target geoms are valid pool geoms.
-    pool = [CubeObject(color="red"), CubeObject(color="blue"), YCBObject("058_golf_ball")]
+    # Mixed pool with a decomposed model: every world's target mask is exactly
+    # the compiled mask of its selected slot, parts included.
+    pool = [CubeObject(color="red"), CubeObject(color="blue"), YCBObject("011_banana")]
     env2 = WarpPickLiftVectorEnv(
         num_envs=8, config=PickConfig(objects=pool, n_distractors=1), device="cpu", seed=1
     )
     obs2, _ = env2.reset(seed=1)
     assert torch.isfinite(obs2).all()
-    valid_geoms = set(env2._slot_geom.tolist())
-    assert all(int(g) in valid_geoms for g in env2._obj_geom.tolist())
+    assert torch.equal(env2._obj_geom_mask, env2._slot_geom_masks[env2._target_slot])
     # Target selection differs across worlds for a multi-object pool.
     assert env2._target_slot.unique().numel() > 1
 

--- a/tests/warp/test_warp_helpers.py
+++ b/tests/warp/test_warp_helpers.py
@@ -39,12 +39,22 @@ def _frames(normals):
     return frame
 
 
+def _mask(per_world_geoms, ngeom):
+    """Pack per-world target geom ids into the ``(num_envs, ngeom)`` boolean lookup."""
+    import torch
+
+    mask = torch.zeros((len(per_world_geoms), ngeom), dtype=torch.bool)
+    for world, geoms in enumerate(per_world_geoms):
+        mask[world, list(geoms)] = True
+    return mask
+
+
 def test_grasp_from_contacts_two_sided_and_isolation():
     import torch
 
     from so101_nexus.warp.base_env import _grasp_from_contacts
 
-    obj = torch.tensor([49, 49, 49])
+    obj = _mask([[49], [49], [49]], ngeom=60)
     gripper = torch.zeros(60, dtype=torch.bool)
     gripper[30] = True
     jaw = torch.zeros(60, dtype=torch.bool)
@@ -65,7 +75,7 @@ def test_grasp_from_contacts_two_sided_and_isolation():
         contact_frame=frames,
         normal_force=normal_force,
         nacon=5,
-        obj_geom=obj,
+        obj_mask=obj,
         gripper_mask=gripper,
         jaw_mask=jaw,
         threshold=0.5,
@@ -86,7 +96,7 @@ def test_grasp_from_contacts_rejects_same_side_straddle():
 
     from so101_nexus.warp.base_env import _grasp_from_contacts
 
-    obj = torch.tensor([49, 49])
+    obj = _mask([[49], [49]], ngeom=60)
     gripper = torch.zeros(60, dtype=torch.bool)
     gripper[30] = True
     jaw = torch.zeros(60, dtype=torch.bool)
@@ -103,7 +113,7 @@ def test_grasp_from_contacts_rejects_same_side_straddle():
         contact_frame=frames,
         normal_force=normal_force,
         nacon=4,
-        obj_geom=obj,
+        obj_mask=obj,
         gripper_mask=gripper,
         jaw_mask=jaw,
         threshold=0.5,
@@ -134,7 +144,7 @@ def test_grasp_from_contacts_one_sided_contact_is_never_a_grasp():
         contact_frame=_frames([[0.0, 0.0, 1.0]]),
         normal_force=torch.ones(1),
         nacon=1,
-        obj_geom=torch.tensor([49]),
+        obj_mask=_mask([[49]], ngeom=60),
         gripper_mask=gripper,
         jaw_mask=jaw,
         threshold=0.5,
@@ -150,7 +160,7 @@ def test_grasp_from_contacts_opposing_threshold_minus_one_is_contact_only():
 
     from so101_nexus.warp.base_env import _grasp_from_contacts
 
-    obj = torch.tensor([49])
+    obj = _mask([[49]], ngeom=60)
     gripper = torch.zeros(60, dtype=torch.bool)
     gripper[30] = True
     jaw = torch.zeros(60, dtype=torch.bool)
@@ -161,7 +171,7 @@ def test_grasp_from_contacts_opposing_threshold_minus_one_is_contact_only():
         contact_frame=_frames([[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]]),
         normal_force=torch.ones(2),
         nacon=2,
-        obj_geom=obj,
+        obj_mask=obj,
         gripper_mask=gripper,
         jaw_mask=jaw,
         threshold=0.5,
@@ -176,7 +186,7 @@ def test_grasp_from_contacts_empty_is_zero():
 
     from so101_nexus.warp.base_env import _grasp_from_contacts
 
-    obj = torch.tensor([5, 5])
+    obj = _mask([[5], [5]], ngeom=10)
     mask = torch.zeros(10, dtype=torch.bool)
     grasp = _grasp_from_contacts(
         contact_geom=torch.zeros((4, 2), dtype=torch.long),
@@ -184,7 +194,7 @@ def test_grasp_from_contacts_empty_is_zero():
         contact_frame=torch.zeros((4, 3, 3)),
         normal_force=torch.zeros(4),
         nacon=0,
-        obj_geom=obj,
+        obj_mask=obj,
         gripper_mask=mask,
         jaw_mask=mask,
         threshold=0.5,
@@ -192,3 +202,33 @@ def test_grasp_from_contacts_empty_is_zero():
         num_envs=2,
     )
     assert grasp.tolist() == [0.0, 0.0]
+
+
+def test_grasp_from_contacts_aggregates_across_object_parts():
+    """Fingers landing on different convex parts of one object still oppose.
+
+    A decomposed mesh spreads the two finger contacts over separate geoms of the
+    same body. Reducing per geom would leave each part one-sided and score 0.
+    """
+    import torch
+
+    from so101_nexus.warp.base_env import _grasp_from_contacts
+
+    gripper = torch.zeros(60, dtype=torch.bool)
+    gripper[30] = True
+    jaw = torch.zeros(60, dtype=torch.bool)
+    jaw[41] = True
+    grasp = _grasp_from_contacts(
+        contact_geom=torch.tensor([[49, 30], [52, 41]]),
+        contact_world=torch.tensor([0, 0]),
+        contact_frame=_frames([[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]]),
+        normal_force=torch.ones(2),
+        nacon=2,
+        obj_mask=_mask([[49, 52]], ngeom=60),
+        gripper_mask=gripper,
+        jaw_mask=jaw,
+        threshold=0.5,
+        opposing_threshold=0.3,
+        num_envs=1,
+    )
+    assert grasp.tolist() == [1.0]

--- a/tests/warp/test_warp_heterogeneous.py
+++ b/tests/warp/test_warp_heterogeneous.py
@@ -61,7 +61,7 @@ def test_autoreset_preserves_per_world_target_metadata():
     assert not truncated[2:].any()
     # Non-reset worlds keep their target; reset worlds keep a valid geom mapping.
     assert torch.equal(env._target_slot[2:], slot_before[2:])
-    assert torch.equal(env._obj_geom, env._slot_geom[env._target_slot])
+    assert torch.equal(env._obj_geom_mask, env._slot_geom_masks[env._target_slot])
 
 
 def test_per_world_task_descriptions_and_reducer():

--- a/uv.lock
+++ b/uv.lock
@@ -558,6 +558,20 @@ wheels = [
 ]
 
 [[package]]
+name = "coacd"
+version = "1.0.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/3b/434beab9e1754ca0ae3a619b383243dd85aa65d03a4dc7333c8296c97a92/coacd-1.0.11-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:adbc58259a721cc5ede24cc8c2671a95e75a8a52dc1ee4d953d80d236b192da9", size = 3299264, upload-time = "2026-05-04T19:23:36.183Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/a7/06f63baa29198f681ba60848e3271cc625eddd61cd4e59071f56ffce9362/coacd-1.0.11-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e376fadb22790444c7253f0cee9104a1af01ec965488c1318e84e3b2dbf1e2a3", size = 2573832, upload-time = "2026-05-04T19:23:38.008Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b4/057c78f7b16b87871cfcecc6febe70522e77a2a33f8788960377152c224d/coacd-1.0.11-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a60f700a52e5b40462e508c14bb756cd63ce7e6a95ff72ae0b1592be1dbb0106", size = 2640170, upload-time = "2026-05-04T19:23:39.322Z" },
+    { url = "https://files.pythonhosted.org/packages/00/83/c50472ce98175fddd86d4aba861fea89f30350a5487880b3a81d34915a85/coacd-1.0.11-cp39-abi3-win_amd64.whl", hash = "sha256:4de22f70d1a3fa8c44698c8006a223fe5fb0ee84b76adecf3726cf2003e9145f", size = 1465079, upload-time = "2026-05-04T19:23:41.604Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -3517,6 +3531,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+decomp = [
+    { name = "coacd" },
+    { name = "threadpoolctl" },
+]
 rocm = [
     { name = "pytorch-triton-rocm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "torch", version = "2.13.0+rocm7.2", source = { registry = "https://download.pytorch.org/whl/rocm7.2" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -3571,6 +3589,7 @@ visual = [
 
 [package.metadata]
 requires-dist = [
+    { name = "coacd", marker = "extra == 'decomp'", specifier = ">=1.0.5,<2" },
     { name = "gradio", marker = "extra == 'teleop'", specifier = ">=5.0.0" },
     { name = "gymnasium", specifier = ">=1.0.0,<2" },
     { name = "huggingface-hub", specifier = "<2" },
@@ -3585,6 +3604,7 @@ requires-dist = [
     { name = "pytorch-triton-rocm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'rocm'", index = "https://download.pytorch.org/whl/rocm7.2", conflict = { package = "so101-nexus", extra = "rocm" } },
     { name = "scipy", specifier = "<2" },
     { name = "tensorboard", marker = "extra == 'train'", specifier = ">=2.0.0" },
+    { name = "threadpoolctl", marker = "extra == 'decomp'", specifier = ">=3.1,<4" },
     { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'rocm'", index = "https://download.pytorch.org/whl/rocm7.2", conflict = { package = "so101-nexus", extra = "rocm" } },
     { name = "torch", marker = "extra == 'train'" },
     { name = "torch", marker = "extra == 'warp'" },
@@ -3593,7 +3613,7 @@ requires-dist = [
     { name = "tyro", specifier = ">=0.9.0,<2" },
     { name = "wandb", extras = ["media"], marker = "extra == 'train'", specifier = ">=0.16.0" },
 ]
-provides-extras = ["viz", "teleop", "train", "warp", "rocm"]
+provides-extras = ["decomp", "viz", "teleop", "train", "warp", "rocm"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3710,6 +3730,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

YCB collision geometry is a cached **multi-hull convex decomposition** of the scan instead of a single convex hull, and an object slot now owns every collision geom of its body.

- **`so101_nexus/ycb_assets.py`** - `ensure_ycb_assets()` caches a CoACD decomposition under `~/.cache/so101_nexus/ycb/{model_id}/collision_v2/` (`collision_000.obj` ... plus a `parts.json` manifest with a volume-weighted `mass_fraction` per part). Nearly convex models (ratio >= 0.95) keep one hull. New public API: `YCBCollisionPart`, `get_ycb_collision_parts()`, `get_ycb_collision_meshes()`; `get_ycb_collision_mesh()` returns part 0.
- **`so101_nexus/object_slots.py`** - one `<geom name="{slot}_collision_{k}" mesh="pick_coll_{i}_{k}">` per part, each declaring `mass * fraction`. `ObjectSlot.geom_ids` (with `geom_id` kept as part 0), `collision_geom_name()` replaces `primary_geom_name()`, and rest pose / spawn height / footprint come from the body-frame union of all parts.
- **Both backends** - grasp detection aggregates contact normals across a target's parts before the opposing-normal test, via an `ngeom`-sized boolean lookup (`_obj_geom_mask`, set through `_set_target_geoms()` on MuJoCo; `(num_envs, ngeom)` tensor on Warp). `spawn_utils` gained `slot_world_min_z()` and `set_slot_contacts()`; Warp's contact budget adds a small per-collision-geom term on top of the per-slot one.

Convexity (visual volume / summed part hull volume), before -> after:

| model | before | after | parts |
|---|---|---|---|
| 033_spatula | 0.19 | **0.66** | 16 |
| 031_spoon | 0.31 | **0.74** | 16 |
| 037_scissors | 0.36 | 0.74 | 16 |
| 030_fork | 0.45 | 0.76 | 12 |
| 032_knife | 0.55 | 0.74 | 9 |
| 011_banana | 0.65 | 0.94 | 13 |
| 043_phillips_screwdriver | 0.68 | 0.89 | 16 |
| 040_large_marker | 0.84 | 0.89 | 16 |
| 009_gelatin_box | 0.97 | 0.97 | 1 |
| 058_golf_ball | 1.00 | 1.00 | 1 |

## Why

Physics saw a fork as a solid wedge and a spatula as a filled slab, so the feature a policy has to grasp (a fork's handle, a spatula's neck) was buried inside the collider and unreachable no matter how good the policy. The four traps this had to clear:

- **Mass multiplication.** N parts each declaring `mass=` would give N times the intended weight. Each part carries a volume-weighted share; `test_body_mass_is_independent_of_part_count` compiles the same object as one hull and as two parts and compares `body_mass`.
- **Rest pose read one mesh.** `extract_object_slots()` measured raw `mesh_vert`, which the compiler stores recentered on each mesh's center of mass and rotated onto its principal axes. Now it unions every part after applying `geom_pos`/`geom_quat`. This also fixes pre-existing wrong values for single-mesh slots (see Fixed in the changelog).
- **Grasp detection is per object.** Contacts land on different parts of the same body, so per-geom aggregation would silently score a real pinch as one-sided. Guarded by a real-physics MuJoCo test that fails when the scan is restricted to `geom_ids[:1]`, and a synthetic Warp test.
- **Stale cache.** The versioned directory means an existing single-hull cache is rebuilt, and the manifest records which decomposer wrote the parts, so installing the `decomp` extra later or upgrading CoACD rebuilds rather than reusing coarse geometry.

CoACD's MCTS is OpenMP-parallel and returns a different split run to run even with a fixed seed (measured 11 vs 12 parts across processes), so the search is pinned to one thread with `threadpoolctl`; regenerating `030_fork` reproduces all 12 parts byte for byte.

The decomposer is the optional `decomp` extra. Without it the collision geometry falls back to the previous single hull, so no existing install breaks.

## Validation

- `uv run ruff format --check src tests`, `uv run ruff check src tests`, `uv run ty check` - clean.
- `uv run pytest tests/core tests/mujoco tests/warp tests/test_docs_consistency.py -q` - **1546 passed** (Warp on the CPU device, no GPU).
- Simulated a plain install by shadowing `coacd` and `threadpoolctl` with import-raising stubs: **729 passed, 6 skipped, 0 failed**, so CI without the extra skips the decomposition tests rather than failing.
- Cube scene MJCF and extracted slot metadata are **byte-identical to `main`** for both the MuJoCo and Warp option presets (checked against `git show HEAD:src/so101_nexus/object_slots.py`).
- Smoke: live `MuJoCoPickLift-v1` episodes with the spatula, spoon and golf ball, 120 random steps each - finite observations and rewards, body mass exact, no convex part below the floor.
- Warp contact budget sized from measurement (peaks per world: 6.5 contacts for one cube, 6.2 for a 16-part spatula, 34.7 for a seven-slot 61-geom pool, against budgets of 208, 238 and 412); cube-only scenes get exactly the previous budget.

## Checklist

- [x] Tests added or updated (regression test for a fix; happy path plus an edge case for new behavior).
- [x] `make format lint typecheck` and the relevant tests pass locally.
- [x] Documentation updated if the public API or behavior changed.
- [x] `CHANGELOG.md` `## [Unreleased]` entry added for any user-facing change.
- [x] No em dashes or emoji in prose, docs, or comments.

## Notes for the reviewer

- **Breaking:** `get_ycb_collision_mesh()` now reads the manifest and raises `FileNotFoundError` when a model has not been prepared; it was a pure path computation. The returned path moved to `collision_v2/collision_000.obj`.
- **Breaking for subclasses:** MuJoCo envs must call `_set_target_geoms(slot.geom_ids)` rather than assigning `_obj_geom_id`, which no longer exists.
- Mesh-slot `spawn_z` and `bounding_radius` change for every mesh-backed object, including the two whose collision geometry is untouched (`058_golf_ball` spawn_z 0.02322 to 0.00223, `011_banana` bounding radius 0.01101 to 0.10510). The new values are the correct ones; the old footprints were up to ten times too small, so the spawn samplers had been packing mesh objects far too close.
