### PR TITLE
feat: improve YCB collision hull fidelity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,33 +11,31 @@ for the public-API and deprecation policy.
 
 ### Added
 
-- `decomp` extra (`coacd`, `threadpoolctl`) building multi-hull convex collision geometry for
-  YCB objects. `get_ycb_collision_parts(model_id)` returns the convex parts as
-  `YCBCollisionPart(path, mass_fraction)`, `get_ycb_collision_meshes(model_id)` returns just
-  their paths, and `ObjectSlot.geom_ids` lists every collision geom of a slot
+- `decomp` extra (`coacd`, `rtree`, `threadpoolctl`) for measured multi-hull YCB
+  collision geometry. `get_ycb_collision_parts(model_id)` returns the parts as
+  `YCBCollisionPart(path, mass_fraction)`. `get_ycb_collision_meshes(model_id)` returns their
+  paths. `ObjectSlot.geom_ids` lists each collision geom of a slot
   (`ObjectSlot.geom_id` stays the first one).
 
 ### Changed
 
-- **YCB collision geometry is now a convex decomposition of the scan, not a single convex
-  hull.** Physics saw a fork as a solid wedge and a spatula as a filled slab, burying the
-  feature a policy has to grasp; measured as visual volume over collision volume, the ten
-  shipped models go 0.19 to 0.66 (spatula), 0.31 to 0.74 (spoon), 0.36 to 0.74 (scissors),
-  0.45 to 0.76 (fork), 0.55 to 0.74 (knife), 0.65 to 0.94 (banana), 0.68 to 0.89
-  (screwdriver), 0.84 to 0.89 (large marker), with the gelatin box (0.97) and golf ball
-  (1.00) already convex and left as one hull. Parts are computed once with CoACD, pinned to
-  one OpenMP thread so the split is reproducible, and cached under
-  `~/.cache/so101_nexus/ycb/{model_id}/collision_v2/`; the versioned directory means an
-  existing single-hull cache is rebuilt rather than silently reused, and the manifest records
-  which decomposer wrote the parts, so installing the `decomp` extra later or upgrading CoACD
-  rebuilds them too. Without the extra the collision geometry falls back to the previous
-  single hull. Cube scenes are byte-identical. Each part carries a volume-weighted share of
-  the object's mass, so total body mass is unchanged.
+- **YCB collision geometry now uses a measured convex decomposition of the scan.** A
+  deterministic 20,000-point surface audit keeps one hull when its p95 error is at most 3 mm
+  and its maximum error is at most 10 mm. The gelatin box, large marker, and golf ball keep
+  one hull. The other seven objects use 3 to 19 CoACD parts. Their p95 collision error is
+  2.07 mm to 3.02 mm, instead of 5.78 mm to 25.65 mm for one hull. CoACD has no object-level
+  part limit, and each decomposed part has at most 128 vertices to match MuJoCo.
+- Collision caches now use
+  `~/.cache/so101_nexus/ycb/{model_id}/collision_v3/manifest.json`. The manifest records the
+  visual scan SHA-256, CoACD version, complete configuration, quality gates, part volumes,
+  and vertex counts. A changed source or generation input rebuilds the cache. An installation
+  without the `decomp` extra keeps a valid decomposition, or falls back to one hull. Each part
+  carries a volume-weighted mass share, so the total object mass stays unchanged.
 - `get_ycb_collision_mesh(model_id)` now returns the first convex part
-  (`collision_v2/collision_000.obj`, was `collision.obj`) and reads the decomposition
-  manifest, so it raises `FileNotFoundError` when the model has not been prepared; it was
-  previously a pure path computation that never touched disk. Call `ensure_ycb_assets` first.
-  `ensure_ycb_assets` also deletes the superseded `collision.obj` from an older cache.
+  (`collision_v3/collision_000.obj`, was `collision.obj`) and reads the decomposition
+  manifest. It raises `FileNotFoundError` when the model is not prepared. Call
+  `ensure_ycb_assets` first. `ensure_ycb_assets` also deletes the old `collision.obj` file
+  when it rebuilds a cache.
 - Grasp detection aggregates contact normals over every collision geom of the target before
   the opposing-normal test, so fingers landing on different parts of one object still read as
   a pinch. The MuJoCo env attribute `_obj_geom_id` is now `_obj_geom_ids` (NumPy array) plus

--- a/docs/content/docs/api/objects.mdx
+++ b/docs/content/docs/api/objects.mdx
@@ -114,8 +114,8 @@ YCB mesh assets are downloaded from the Hugging Face Hub on first use and cached
 ```
 
 Each model directory holds `visual.obj`, the convex collision parts under
-`collision_v2/` (`collision_000.obj` ... plus a `parts.json` manifest), and, when
-extraction succeeds, `texture.png`.
+`collision_v3/` (`collision_000.obj` and more), and a `manifest.json` file. The
+directory also holds `texture.png` when the texture extraction succeeds.
 
 Creating a `YCBObject` and stepping an environment downloads whatever is missing. You can also trigger the download explicitly:
 
@@ -133,17 +133,29 @@ def ensure_ycb_assets(model_id: str) -> Path
 
 Downloads the mesh assets for `model_id` if they are not already cached, then returns the cache directory.
 
-`visual.obj` and the `collision_v2/` parts are the required geometry cache. The collision
-geometry is a convex decomposition of the visual scan, computed once with
-[CoACD](https://github.com/SarahWeiii/CoACD) and cached, so physics sees the concavities a
-single hull would fill in. It needs the `decomp` extra; see
-[Installation](/docs/getting-started/installation) for the extras matrix. Nearly convex
-models (the golf ball, the gelatin box) keep a single hull either way. The manifest records
-which decomposer produced the parts, so installing the extra later, or upgrading CoACD,
-rebuilds the cache instead of reusing coarser geometry. The function additionally attempts
-to extract `texture.png` from `meshes/{model_id}/google_16k/textured.glb`. Texture
-extraction is best effort: if a model or the locally installed `trimesh` does not expose a
-texture image, the environment still runs with the untextured visual mesh.
+`visual.obj` and the `collision_v3/` parts are the required geometry cache. The
+generator uses 20,000 deterministic surface samples to measure the convex hull
+against the visual scan. It keeps one hull when the p95 error is at most 3 mm
+and the maximum error is at most 10 mm. This gate keeps the gelatin box, large
+marker, and golf ball as one hull.
+
+The other models use the collision-aware [CoACD](https://github.com/SarahWeiii/CoACD)
+decomposition. CoACD has no object-level part limit. It limits each part to 128
+vertices, which matches the [MuJoCo mesh hull limit](https://mujoco.readthedocs.io/en/stable/XMLreference.html#asset-mesh-maxhullvert).
+The audited models use 3 to 19 parts. Their collision surfaces have 2.07 mm to
+3.02 mm of p95 error against the visual scans.
+
+The manifest records the source hash, the CoACD version, the complete
+configuration, the quality gates, and the part sizes. The cache rebuilds after
+the source or a generation input changes. An installation without the `decomp`
+extra can use an existing decomposition. Otherwise, it falls back to one convex
+hull. See [Installation](/docs/getting-started/installation) for the extras
+matrix.
+
+The function also attempts to extract `texture.png` from
+`meshes/{model_id}/google_16k/textured.glb`. Texture extraction is best effort.
+If no texture image is available, the environment uses the untextured visual
+mesh.
 
 ### Path helpers
 

--- a/docs/content/docs/getting-started/installation.mdx
+++ b/docs/content/docs/getting-started/installation.mdx
@@ -42,7 +42,7 @@ The base install ships the MuJoCo backend and the environment API. Everything el
 | Extra | Adds | Install |
 | --- | --- | --- |
 | `teleop` | Gradio demonstration recorder: `lerobot[feetech]`, `gradio`, `plotly`, `opencv-python` | `pip install "so101-nexus[teleop]"` |
-| `decomp` | Convex decomposition of YCB collision meshes (`coacd`, `threadpoolctl`). Without it YCB collision geometry falls back to a single convex hull. `coacd` ships wheels for Linux x86_64/aarch64, macOS arm64 and Windows x86_64 | `pip install "so101-nexus[decomp]"` |
+| `decomp` | Measured convex decomposition of YCB collision meshes (`coacd`, `rtree`, `threadpoolctl`). Without it YCB collision geometry falls back to a single convex hull. The packages ship wheels for the supported platforms | `pip install "so101-nexus[decomp]"` |
 | `train` | Torch training dependencies for the PPO and BC examples | `pip install "so101-nexus[train]"` |
 | `warp` | GPU-parallel MuJoCo Warp backend. Needs an NVIDIA GPU and CUDA >= 12.4 | `pip install "so101-nexus[warp]"` |
 | `rocm` | PyTorch from AMD's ROCm 7.2 wheel index. See below | `uv sync --extra train --extra rocm --no-default-groups` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-decomp = ["coacd>=1.0.5,<2", "threadpoolctl>=3.1,<4"]
+decomp = ["coacd>=1.0.13,<2", "rtree>=1.4,<2", "threadpoolctl>=3.1,<4"]
 viz = ["Pillow"]
 teleop = [
     "lerobot[feetech]>=0.5.0,<0.6",

--- a/src/so101_nexus/objects.py
+++ b/src/so101_nexus/objects.py
@@ -65,25 +65,24 @@ class CubeObject(SceneObject):
 
 
 class YCBObject(SceneObject):
-    """YCB dataset object identified by model_id (e.g. '003_cracker_box').
+    """YCB dataset object identified by ``model_id``.
 
-    The visual mesh is the original YCB scan; the collision geometry is a
-    **convex decomposition** of it (see ``ensure_ycb_assets``), so physics sees
-    the concavities that make an object graspable (a fork's handle, a spatula's
-    neck) instead of one solid wedge. The decomposition needs the optional
-    ``decomp`` extra (``pip install so101-nexus[decomp]``); without it the
-    collision geometry falls back to a single convex hull, and then:
+    The visual mesh is the original YCB scan. The collision geometry is a
+    measured convex decomposition of it (see ``ensure_ycb_assets``), so physics
+    sees concavities such as a fork handle or a spatula neck. A surface-error
+    gate keeps a single hull when that hull already matches the scan.
 
-    - The feature that makes an object graspable in reality is buried inside the
-      hull, so the fingers never touch it.
-    - A model whose hull is wider than the gripper can close on cannot be
-      grasped at all, no matter how good the policy is.
+    The decomposition needs the optional ``decomp`` extra
+    (``pip install so101-nexus[decomp]``). Without it, collision geometry falls
+    back to one convex hull:
 
-    Installing the extra after the assets were prepared rebuilds the cache on the
-    next ``ensure_ycb_assets`` call: the manifest records which decomposer wrote
-    the parts. Measure a candidate before building a task around it:
-    ``ensure_ycb_assets(model_id)`` then ``get_ycb_collision_meshes(model_id)``
-    gives the OBJ parts physics uses.
+    - The hull can bury the feature that makes an object graspable.
+    - A hull wider than the open gripper makes a grasp impossible.
+
+    Installing the extra after asset preparation rebuilds the cache on the next
+    ``ensure_ycb_assets`` call. The manifest records the scan hash, generator
+    configuration, and part properties. ``get_ycb_collision_meshes(model_id)``
+    returns the OBJ parts that physics uses.
 
     Parameters
     ----------

--- a/src/so101_nexus/ycb_assets.py
+++ b/src/so101_nexus/ycb_assets.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import hashlib
+import importlib
 import json
 import logging
+import math
 import os
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol, cast
+from typing import TYPE_CHECKING, Protocol, TypedDict, cast
 
 from so101_nexus.constants import YCB_OBJECTS
 
@@ -20,32 +23,55 @@ logger = logging.getLogger(__name__)
 _HF_REPO_ID = os.environ.get("SO101_YCB_HF_REPO", "ai-habitat/ycb")
 _CACHE_DIR = Path.home() / ".cache" / "so101_nexus" / "ycb"
 
-_COLLISION_SUBDIR = "collision_v2"
-"""Cache subdirectory holding the convex decomposition.
+_COLLISION_SUBDIR = "collision_v3"
+"""Cache subdirectory for collision parts built with a measured surface-error gate."""
 
-Versioned: bump it whenever the decomposition changes, otherwise the parts
-cached by an older release keep winning the ``ensure_ycb_assets`` early return.
-"""
+_MANIFEST_NAME = "manifest.json"
 
-_MANIFEST_NAME = "parts.json"
+_FALLBACK_DECOMPOSER = "convex_hull"
+"""Manifest marker for a hull built without the ``decomp`` extra."""
 
-_HULL_DECOMPOSER = "convex_hull"
-"""Manifest marker for parts built without CoACD (the single-hull fallback)."""
+_HULL_DECOMPOSER = "none (hull kept)"
+"""Manifest marker for a measured hull that does not need decomposition."""
 
-# CoACD settings. The seed is fixed because scene geometry must not vary
-# between runs; preprocessing (watertight remeshing of the open YCB scans) is
-# what lifts the thin, concave models above the acceptance convexity, and the
-# hull cap keeps the per-object geom count affordable for contact budgets.
-_COACD_SEED = 0
-_COACD_THRESHOLD = 0.02
-_COACD_MAX_HULLS = 16
-_COACD_PREPROCESS_RESOLUTION = 100
+_HULL_GAP_SAMPLES = 20_000
+_HULL_GAP_SEED = 0
+_HULL_GAP_GATE_M = 0.003
+_HULL_GAP_MAX_GATE_M = 0.010
 
-_SINGLE_HULL_CONVEXITY = 0.95
-"""Volume ratio above which a model keeps its single convex hull.
 
-Boxes and balls are already their own hull; decomposing them only buys geoms.
-"""
+class _CoacdSettings(TypedDict):
+    threshold: float
+    max_convex_hull: int
+    preprocess_mode: str
+    preprocess_resolution: int
+    resolution: int
+    mcts_nodes: int
+    mcts_iterations: int
+    mcts_max_depth: int
+    pca: bool
+    merge: bool
+    decimate: bool
+    max_ch_vertex: int
+    seed: int
+
+
+_COACD_SETTINGS: _CoacdSettings = {
+    "threshold": 0.03,
+    "max_convex_hull": -1,
+    "preprocess_mode": "auto",
+    "preprocess_resolution": 50,
+    "resolution": 2000,
+    "mcts_nodes": 20,
+    "mcts_iterations": 150,
+    "mcts_max_depth": 3,
+    "pca": False,
+    "merge": True,
+    "decimate": True,
+    "max_ch_vertex": 128,
+    "seed": 0,
+}
+"""Audited CoACD configuration for the ten supported YCB scans."""
 
 
 class _ExportableMesh(Protocol):
@@ -83,6 +109,18 @@ class YCBCollisionPart:
     mass_fraction: float
 
 
+@dataclass(frozen=True, slots=True)
+class _CollisionBuild:
+    """Collision parts and the inputs that produced them."""
+
+    parts: tuple[_ExportableMesh, ...]
+    decomposer: str
+    decomposed: bool
+    settings: Mapping[str, object] | None
+    hull_gap_p95_m: float | None
+    hull_gap_max_m: float | None
+
+
 def _validate_model_id(model_id: str) -> None:
     if model_id not in YCB_OBJECTS:
         raise ValueError(f"model_id must be one of {list(YCB_OBJECTS)}, got {model_id!r}")
@@ -100,11 +138,11 @@ def get_ycb_texture_file(model_id: str) -> Path:
     return _CACHE_DIR / model_id / "texture.png"
 
 
-def _load_exportable_mesh(glb_path: Path) -> _ExportableMesh:
-    """Load a GLB as a mesh object with `export` and `convex_hull`."""
+def _load_exportable_mesh(mesh_path: Path) -> _ExportableMesh:
+    """Load a mesh file as one object with ``export`` and ``convex_hull``."""
     import trimesh
 
-    scene_or_mesh = trimesh.load(str(glb_path), force="mesh")
+    scene_or_mesh = trimesh.load(str(mesh_path), force="mesh")
     if isinstance(scene_or_mesh, trimesh.Scene):
         return cast("_ExportableMesh", scene_or_mesh.dump(concatenate=True))
     return cast("_ExportableMesh", scene_or_mesh)
@@ -122,97 +160,126 @@ def _collision_dir(model_id: str) -> Path:
 
 
 def _decomposer_id() -> str:
-    """Identify the decomposer that would produce the parts, for cache keying.
-
-    Includes the CoACD version, because its splits change between releases, so a
-    cache written by another version is not the geometry this install builds.
-    Both packages of the ``decomp`` extra must be present: without
-    ``threadpoolctl`` the search is not thread-pinned, and ``_convex_parts``
-    falls back to a single hull rather than write geometry it cannot reproduce.
-    """
+    """Identify the installed generator for cache keying."""
     try:
         from importlib.metadata import PackageNotFoundError, version
 
-        version("threadpoolctl")
+        for package in ("threadpoolctl", "rtree"):
+            version(package)
         return f"coacd {version('coacd')}"
     except (ImportError, PackageNotFoundError):
-        return _HULL_DECOMPOSER
+        return _FALLBACK_DECOMPOSER
 
 
-def _convex_parts(mesh: _ExportableMesh) -> list[_ExportableMesh]:
-    """Decompose ``mesh`` into convex collision parts.
+def _hull_surface_gap(
+    hull: _ExportableMesh,
+    mesh: _ExportableMesh,
+) -> tuple[float, float]:
+    """Return the p95 and maximum distances from a hull surface to a scan."""
+    import numpy as np
+    import trimesh
 
-    Nearly convex models keep their single convex hull. The rest are handed to
-    CoACD, which is an optional extra (``pip install so101-nexus[decomp]``);
-    without it the single hull remains the fallback, so no existing install
-    breaks, it just keeps the coarse collision geometry.
+    points, _ = trimesh.sample.sample_surface(
+        hull,
+        _HULL_GAP_SAMPLES,
+        seed=_HULL_GAP_SEED,
+    )
+    scan = trimesh.Trimesh(vertices=mesh.vertices, faces=mesh.faces, process=False)
+    scan.update_faces(scan.nondegenerate_faces())
+    distances = np.asarray(trimesh.proximity.closest_point(scan, points)[1], dtype=np.float64)
+    if distances.size == 0 or not np.isfinite(distances).all():
+        raise ValueError("The hull surface distance contains no finite samples.")
+    return float(np.percentile(distances, 95)), float(distances.max())
 
-    CoACD's MCTS search is parallelized over OpenMP, and its thread scheduling
-    changes the split it converges on: the same mesh and seed yield different
-    part counts run to run. Scene geometry must not vary between runs, so the
-    search is pinned to one thread (a few seconds per model, once, then cached).
-    The limit is scoped to this call and restored afterwards.
-    """
+
+def _build_collision_geometry(mesh: _ExportableMesh) -> _CollisionBuild:
+    """Build a measured hull or a collision-aware convex decomposition."""
     hull = mesh.convex_hull
-    hull_volume = abs(hull.volume)
-    # The YCB scans are open surfaces, so this is the divergence-theorem volume
-    # rather than a true enclosed one; logged because a model whose integral
-    # overshoots would skip decomposition without any other signal.
-    convexity = abs(mesh.volume) / hull_volume if hull_volume > 0.0 else 1.0
-    logger.debug("mesh convexity (volume / hull volume): %.3f", convexity)
-    if convexity >= _SINGLE_HULL_CONVEXITY:
-        return [hull]
     try:
         import coacd
+        import trimesh
         from threadpoolctl import threadpool_limits
+
+        importlib.import_module("rtree")
     except ImportError as exc:
         logger.warning(
-            "%s is not installed: collision geometry stays a single convex hull, "
-            "which physics sees as a solid wedge for concave models. "
-            "Install so101-nexus[decomp] for a multi-hull decomposition.",
-            exc.name or "coacd",
+            "%s is not installed: collision geometry stays a single convex hull. "
+            "Install so101-nexus[decomp] for measured multi-hull geometry.",
+            exc.name or "a decomposition dependency",
         )
-        return [hull]
+        return _CollisionBuild(
+            parts=(hull,),
+            decomposer=_FALLBACK_DECOMPOSER,
+            decomposed=False,
+            settings=None,
+            hull_gap_p95_m=None,
+            hull_gap_max_m=None,
+        )
 
-    import trimesh
+    hull_gap_p95_m, hull_gap_max_m = _hull_surface_gap(hull, mesh)
+    logger.debug(
+        "hull surface gap: p95=%.6f m, max=%.6f m",
+        hull_gap_p95_m,
+        hull_gap_max_m,
+    )
+    if hull_gap_p95_m <= _HULL_GAP_GATE_M and hull_gap_max_m <= _HULL_GAP_MAX_GATE_M:
+        return _CollisionBuild(
+            parts=(hull,),
+            decomposer=_HULL_DECOMPOSER,
+            decomposed=False,
+            settings=None,
+            hull_gap_p95_m=hull_gap_p95_m,
+            hull_gap_max_m=hull_gap_max_m,
+        )
 
     coacd.set_log_level("error")
     with threadpool_limits(limits=1, user_api="openmp"):
-        parts = coacd.run_coacd(
+        pieces = coacd.run_coacd(
             coacd.Mesh(mesh.vertices, mesh.faces),
-            threshold=_COACD_THRESHOLD,
-            max_convex_hull=_COACD_MAX_HULLS,
-            preprocess_mode="on",
-            preprocess_resolution=_COACD_PREPROCESS_RESOLUTION,
-            seed=_COACD_SEED,
+            **_COACD_SETTINGS,
         )
-    # CoACD parts are near-convex, not exactly convex; MuJoCo collides the hull
-    # of a mesh geom anyway, so hulling here keeps the exported OBJ and the
-    # compiled collider identical. A sliver part can fail to hull at all, which
-    # is the same "drop it" case as a zero-volume one.
-    hulls = []
-    for vertices, faces in parts:
-        try:
-            hulls.append(trimesh.Trimesh(vertices, faces).convex_hull)
-        except Exception:  # qhull errors are not importable without scipy here
-            logger.debug("dropping a degenerate CoACD part")
-    return [part for part in hulls if abs(part.volume) > 0.0] or [hull]
-
-
-def _write_collision_parts(mesh: _ExportableMesh, out_dir: Path) -> None:
-    """Export the convex decomposition of ``mesh`` and its manifest into ``out_dir``.
-
-    The manifest is the cache sentinel, so it is removed before the parts are
-    rewritten and published atomically: an interrupted export leaves no manifest
-    and the next call rebuilds, instead of wedging the cache behind a truncated
-    one that ``ensure_ycb_assets`` would accept forever.
-    """
-    parts = _convex_parts(mesh)
-    volumes = [abs(part.volume) for part in parts]
-    total = sum(volumes)
-    fractions = (
-        [volume / total for volume in volumes] if total > 0.0 else [1.0 / len(parts)] * len(parts)
+    parts = tuple(
+        cast("_ExportableMesh", trimesh.Trimesh(vertices, faces)) for vertices, faces in pieces
     )
+    parts = tuple(part for part in parts if abs(part.volume) > 0.0)
+    if not parts:
+        raise RuntimeError("CoACD produced no positive-volume collision parts.")
+    max_vertices = int(_COACD_SETTINGS["max_ch_vertex"])
+    if any(len(part.vertices) > max_vertices for part in parts):
+        raise RuntimeError(
+            f"CoACD produced a collision part with more than {max_vertices} vertices."
+        )
+    return _CollisionBuild(
+        parts=parts,
+        decomposer=_decomposer_id(),
+        decomposed=True,
+        settings=_COACD_SETTINGS,
+        hull_gap_p95_m=hull_gap_p95_m,
+        hull_gap_max_m=hull_gap_max_m,
+    )
+
+
+def _sha256(path: Path) -> str:
+    """Return the SHA-256 digest of a file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _write_collision_parts(
+    mesh: _ExportableMesh,
+    out_dir: Path,
+    *,
+    model_id: str,
+    source_path: Path,
+) -> None:
+    """Export collision parts and their generation manifest into ``out_dir``."""
+    build = _build_collision_geometry(mesh)
+    volumes = [abs(part.volume) for part in build.parts]
+    total = sum(volumes)
+    fractions = [volume / total for volume in volumes]
 
     out_dir.mkdir(parents=True, exist_ok=True)
     manifest_path = out_dir / _MANIFEST_NAME
@@ -220,15 +287,35 @@ def _write_collision_parts(mesh: _ExportableMesh, out_dir: Path) -> None:
     for stale in out_dir.glob("collision_*.obj"):
         stale.unlink()
     entries = []
-    for index, (part, fraction) in enumerate(zip(parts, fractions, strict=True)):
+    for index, (part, volume, fraction) in enumerate(
+        zip(build.parts, volumes, fractions, strict=True)
+    ):
         name = f"collision_{index:03d}.obj"
         part.export(str(out_dir / name), file_type="obj")
-        entries.append({"file": name, "mass_fraction": fraction})
+        entries.append(
+            {
+                "file": name,
+                "mass_fraction": fraction,
+                "volume_m3": volume,
+                "n_vertices": len(part.vertices),
+            }
+        )
+    manifest = {
+        "model_id": model_id,
+        "source": source_path.name,
+        "source_sha256": _sha256(source_path),
+        "decomposer": build.decomposer,
+        "settings": dict(build.settings) if build.settings is not None else None,
+        "hull_gap_p95_m": build.hull_gap_p95_m,
+        "hull_gap_max_m": build.hull_gap_max_m,
+        "hull_gap_gate_m": _HULL_GAP_GATE_M,
+        "hull_gap_max_gate_m": _HULL_GAP_MAX_GATE_M,
+        "decomposed": build.decomposed,
+        "mass_split": "part volume / total part volume",
+        "parts": entries,
+    }
     pending = manifest_path.with_suffix(".json.pending")
-    pending.write_text(
-        json.dumps({"decomposer": _decomposer_id(), "parts": entries}, indent=2),
-        encoding="utf-8",
-    )
+    pending.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
     os.replace(pending, manifest_path)
 
 
@@ -294,48 +381,85 @@ def _texture_glb_path(model_id: str) -> Path:
     return orig if orig.exists() else base / "textured.glb"
 
 
-def _read_manifest(collision_dir: Path) -> dict | None:
-    """Return the parsed parts manifest, or ``None`` when it is absent or unusable.
+def _manifest_part_is_usable(part: object) -> bool:
+    if not isinstance(part, Mapping):
+        return False
+    part = cast("Mapping[str, object]", part)
+    name = part.get("file")
+    fraction_value = part.get("mass_fraction")
+    if not isinstance(name, str) or Path(name).name != name:
+        return False
+    if isinstance(fraction_value, bool) or not isinstance(fraction_value, (int, float)):
+        return False
+    fraction = float(fraction_value)
+    return math.isfinite(fraction) and fraction >= 0.0
 
-    Anything unreadable reads as absent so the cache rebuilds itself: the
-    manifest is the sentinel ``ensure_ycb_assets`` early-returns on, and a
-    truncated one would otherwise wedge the model behind a parse error forever.
-    """
+
+def _read_manifest(collision_dir: Path) -> dict | None:
+    """Return a usable collision manifest, or ``None``."""
     try:
         manifest = json.loads((collision_dir / _MANIFEST_NAME).read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return None
     if not isinstance(manifest, dict) or not isinstance(manifest.get("parts"), list):
         return None
+    parts = manifest["parts"]
+    if not parts or not all(_manifest_part_is_usable(part) for part in parts):
+        return None
     return manifest
 
 
-def _collision_parts_are_current(collision_dir: Path) -> bool:
-    """Return True when the cached parts were built by this install's decomposer.
+def _manifest_source_matches(collision_dir: Path, manifest: Mapping[str, object]) -> bool:
+    source = collision_dir.parent / str(manifest.get("source", ""))
+    try:
+        return manifest.get("source_sha256") == _sha256(source)
+    except OSError:
+        return False
 
-    A cache written by a different CoACD version (or by the single-hull fallback
-    before the ``decomp`` extra was installed) is rebuilt, so scene geometry
-    always matches the decomposer that is actually present. The reverse is never
-    true: an install without CoACD keeps whatever is cached rather than
-    overwriting a real decomposition with a coarse hull.
-    """
+
+def _manifest_generator_matches(manifest: Mapping[str, object]) -> bool:
+    current = _decomposer_id()
+    if current == _FALLBACK_DECOMPOSER:
+        return True
+    gates_match = (
+        manifest.get("hull_gap_gate_m") == _HULL_GAP_GATE_M
+        and manifest.get("hull_gap_max_gate_m") == _HULL_GAP_MAX_GATE_M
+    )
+    if not gates_match:
+        return False
+    if manifest.get("decomposed"):
+        return manifest.get("decomposer") == current and manifest.get("settings") == _COACD_SETTINGS
+    return (
+        manifest.get("decomposer") == _HULL_DECOMPOSER
+        and manifest.get("settings") is None
+        and manifest.get("hull_gap_p95_m") is not None
+        and manifest.get("hull_gap_max_m") is not None
+    )
+
+
+def _collision_parts_are_current(collision_dir: Path) -> bool:
+    """Return true when all cached parts match the scan and generator inputs."""
     manifest = _read_manifest(collision_dir)
     if manifest is None:
         return False
-    current = _decomposer_id()
-    return manifest.get("decomposer") == current or current == _HULL_DECOMPOSER
+    parts_exist = all((collision_dir / part["file"]).is_file() for part in manifest["parts"])
+    return (
+        parts_exist
+        and _manifest_source_matches(collision_dir, manifest)
+        and _manifest_generator_matches(manifest)
+    )
 
 
 def ensure_ycb_assets(model_id: str) -> Path:
     """Download YCB mesh assets from HuggingFace if not already cached.
 
-    Downloads from the ai-habitat/ycb dataset and converts GLB meshes to OBJ
-    format for use with MuJoCo. The visual mesh is exported directly; the
-    collision geometry is a cached convex decomposition of it (see
-    :func:`get_ycb_collision_parts`), so physics sees the concavities a single
-    hull would fill in. Decomposition needs the optional ``decomp`` extra;
-    without it the collision geometry falls back to one convex hull, which is
-    what ``YCBObject`` warns about.
+    Downloads the ai-habitat/ycb meshes and converts them to OBJ for MuJoCo.
+    The visual mesh stays unchanged. A deterministic surface-error gate keeps
+    one collision hull when it fits the scan. Other objects use a cached CoACD
+    decomposition, so physics sees concavities that one hull fills.
+
+    Decomposition needs the optional ``decomp`` extra. Without it, collision
+    geometry falls back to one convex hull.
 
     Returns the directory containing the model's mesh files.
     """
@@ -383,7 +507,12 @@ def ensure_ycb_assets(model_id: str) -> Path:
     mesh_dir.mkdir(parents=True, exist_ok=True)
     _convert_glb_to_obj(glb_path, visual_path)
 
-    _write_collision_parts(_load_exportable_mesh(glb_path), collision_dir)
+    _write_collision_parts(
+        _load_exportable_mesh(visual_path),
+        collision_dir,
+        model_id=model_id,
+        source_path=visual_path,
+    )
     # Single-hull cache from a release before the decomposition; nothing reads it.
     (mesh_dir / "collision.obj").unlink(missing_ok=True)
     preferred_glb = _texture_glb_path(model_id)

--- a/tests/core/test_ycb.py
+++ b/tests/core/test_ycb.py
@@ -6,6 +6,7 @@ import sys
 import types
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 from so101_nexus import ycb_assets
@@ -52,6 +53,8 @@ class _FakeMesh:
     """Stands in for a trimesh mesh; convex by construction, so no decomposition."""
 
     volume = 1.0
+    vertices = ((0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0))
+    faces = ((0, 1, 2), (0, 1, 3), (0, 2, 3), (1, 2, 3))
 
     def __init__(self):
         self.exports: list[tuple[str, str | None]] = []
@@ -173,20 +176,29 @@ def _write_cached_parts(
     files: tuple[str, ...] = ("collision_000.obj",),
     decomposer: str | None = None,
 ) -> Path:
-    """Write a v2 collision decomposition cache entry and return its directory."""
-    parts_dir = mesh_dir / "collision_v2"
+    """Write a collision-v3 cache entry and return its directory."""
+    mesh_dir.mkdir(parents=True, exist_ok=True)
+    source = mesh_dir / "visual.obj"
+    source.write_text("v", encoding="utf-8")
+    parts_dir = mesh_dir / "collision_v3"
     parts_dir.mkdir(parents=True, exist_ok=True)
     for name in files:
         (parts_dir / name).write_text("c", encoding="utf-8")
-    (parts_dir / "parts.json").write_text(
-        json.dumps(
-            {
-                "decomposer": ycb_assets._decomposer_id() if decomposer is None else decomposer,
-                "parts": [{"file": name, "mass_fraction": 1.0 / len(files)} for name in files],
-            }
-        ),
-        encoding="utf-8",
-    )
+    decomposed = decomposer is not None
+    manifest = {
+        "model_id": mesh_dir.name,
+        "source": source.name,
+        "source_sha256": ycb_assets._sha256(source),
+        "decomposer": decomposer or ycb_assets._HULL_DECOMPOSER,
+        "settings": ycb_assets._COACD_SETTINGS if decomposed else None,
+        "hull_gap_p95_m": 0.0,
+        "hull_gap_max_m": 0.0,
+        "hull_gap_gate_m": ycb_assets._HULL_GAP_GATE_M,
+        "hull_gap_max_gate_m": ycb_assets._HULL_GAP_MAX_GATE_M,
+        "decomposed": decomposed,
+        "parts": [{"file": name, "mass_fraction": 1.0 / len(files)} for name in files],
+    }
+    (parts_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
     return parts_dir
 
 
@@ -261,6 +273,8 @@ def test_ensure_ycb_assets_returns_when_texture_extract_finds_nothing(
     monkeypatch.setattr(ycb_assets, "_extract_glb_texture", lambda _g, _p: False)
     fake_trimesh = types.SimpleNamespace(Scene=_FakeScene, load=lambda *_a, **_k: _FakeMesh())
     _patch_module(monkeypatch, "trimesh", fake_trimesh)
+    _fake_coacd(monkeypatch, [])
+    monkeypatch.setattr(ycb_assets, "_hull_surface_gap", lambda _h, _m: (0.0, 0.0))
 
     mesh_dir = ycb_assets.ensure_ycb_assets(model_id)
 
@@ -295,6 +309,8 @@ def test_ensure_ycb_assets_download_and_decomposition(
         types.SimpleNamespace(snapshot_download=_snapshot_download),
     )
     monkeypatch.setattr(ycb_assets, "_convert_glb_to_obj", _convert_glb_to_obj)
+    _fake_coacd(monkeypatch, [])
+    monkeypatch.setattr(ycb_assets, "_hull_surface_gap", lambda _h, _m: (0.0, 0.0))
 
     mesh_dir = ycb_assets.ensure_ycb_assets(model_id)
     assert mesh_dir == tmp_path / model_id
@@ -303,12 +319,19 @@ def test_ensure_ycb_assets_download_and_decomposition(
         tmp_path / "meshes" / model_id / "google_16k" / "textured.glb",
         tmp_path / model_id / "visual.obj",
     )
-    parts_dir = tmp_path / model_id / "collision_v2"
+    parts_dir = tmp_path / model_id / "collision_v3"
     assert mesh.exports[-1] == (str(parts_dir / "collision_000.obj"), "obj")
-    assert json.loads((parts_dir / "parts.json").read_text(encoding="utf-8")) == {
-        "decomposer": ycb_assets._decomposer_id(),
-        "parts": [{"file": "collision_000.obj", "mass_fraction": 1.0}],
-    }
+    manifest = json.loads((parts_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["source"] == "visual.obj"
+    assert manifest["source_sha256"] == ycb_assets._sha256(mesh_dir / "visual.obj")
+    assert manifest["parts"] == [
+        {
+            "file": "collision_000.obj",
+            "mass_fraction": 1.0,
+            "volume_m3": 1.0,
+            "n_vertices": 4,
+        }
+    ]
 
 
 def test_ensure_ycb_assets_scene_path_for_hull(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
@@ -331,10 +354,12 @@ def test_ensure_ycb_assets_scene_path_for_hull(monkeypatch: pytest.MonkeyPatch, 
         types.SimpleNamespace(snapshot_download=_snapshot_download),
     )
     monkeypatch.setattr(ycb_assets, "_convert_glb_to_obj", lambda _g, p: p.write_text("v"))
+    _fake_coacd(monkeypatch, [])
+    monkeypatch.setattr(ycb_assets, "_hull_surface_gap", lambda _h, _m: (0.0, 0.0))
 
     ycb_assets.ensure_ycb_assets(model_id)
     assert mesh.exports[-1] == (
-        str(tmp_path / model_id / "collision_v2" / "collision_000.obj"),
+        str(tmp_path / model_id / "collision_v3" / "collision_000.obj"),
         "obj",
     )
 
@@ -364,7 +389,7 @@ def test_collision_parts_reject_a_truncated_manifest(
     monkeypatch.setattr(ycb_assets, "_CACHE_DIR", tmp_path)
     model_id = "058_golf_ball"
     parts_dir = _write_cached_parts(tmp_path / model_id)
-    (parts_dir / "parts.json").write_text('{"parts": [{"file":', encoding="utf-8")
+    (parts_dir / "manifest.json").write_text('{"parts": [{"file":', encoding="utf-8")
 
     assert not ycb_assets._collision_parts_are_current(parts_dir)
     with pytest.raises(FileNotFoundError, match="ensure_ycb_assets"):
@@ -381,12 +406,26 @@ def test_cached_parts_from_another_decomposer_are_rebuilt(
     """
     monkeypatch.setattr(ycb_assets, "_CACHE_DIR", tmp_path)
     parts_dir = _write_cached_parts(tmp_path / "058_golf_ball", decomposer="coacd 0.0.1")
-
     monkeypatch.setattr(ycb_assets, "_decomposer_id", lambda: "coacd 9.9.9")
     assert not ycb_assets._collision_parts_are_current(parts_dir)
 
-    monkeypatch.setattr(ycb_assets, "_decomposer_id", lambda: ycb_assets._HULL_DECOMPOSER)
+    monkeypatch.setattr(ycb_assets, "_decomposer_id", lambda: ycb_assets._FALLBACK_DECOMPOSER)
     assert ycb_assets._collision_parts_are_current(parts_dir)
+
+
+def test_cached_parts_are_rebuilt_when_the_visual_scan_changes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """The source hash must prevent parts from another scan from reaching physics."""
+    monkeypatch.setattr(ycb_assets, "_CACHE_DIR", tmp_path)
+    mesh_dir = tmp_path / "058_golf_ball"
+    parts_dir = _write_cached_parts(mesh_dir)
+    assert ycb_assets._collision_parts_are_current(parts_dir)
+
+    (mesh_dir / "visual.obj").write_text("changed", encoding="utf-8")
+
+    assert not ycb_assets._collision_parts_are_current(parts_dir)
 
 
 def test_extract_glb_texture_accepts_orig_extension(
@@ -563,6 +602,7 @@ def _fake_coacd(monkeypatch: pytest.MonkeyPatch, events: list[tuple]) -> None:
     _patch_module(
         monkeypatch, "threadpoolctl", types.SimpleNamespace(threadpool_limits=_threadpool_limits)
     )
+    _patch_module(monkeypatch, "rtree", types.SimpleNamespace())
 
 
 def _fake_trimesh_with_hulls(monkeypatch: pytest.MonkeyPatch, volumes: list[float]) -> None:
@@ -572,26 +612,61 @@ def _fake_trimesh_with_hulls(monkeypatch: pytest.MonkeyPatch, volumes: list[floa
         hull = _FakeMesh()
         hull.volume = volumes[len(hulls)]
         hulls.append(hull)
-        return types.SimpleNamespace(convex_hull=hull)
+        return hull
 
     _patch_module(monkeypatch, "trimesh", types.SimpleNamespace(Scene=_FakeScene, Trimesh=_trimesh))
 
 
-def test_convex_parts_keeps_single_hull_for_convex_meshes(monkeypatch: pytest.MonkeyPatch):
-    """A box or a ball is its own hull; decomposing it only buys collision geoms."""
+def test_collision_build_keeps_an_accurate_single_hull(monkeypatch: pytest.MonkeyPatch):
+    """CoACD must not damage an object whose convex hull already fits its scan."""
     events: list[tuple] = []
     _fake_coacd(monkeypatch, events)
-    mesh = _FakeMesh()
+    monkeypatch.setattr(
+        ycb_assets,
+        "_hull_surface_gap",
+        lambda _hull, _mesh: (
+            ycb_assets._HULL_GAP_GATE_M,
+            ycb_assets._HULL_GAP_MAX_GATE_M,
+        ),
+    )
+    mesh = _ConcaveMesh()
 
-    assert ycb_assets._convex_parts(mesh) == [mesh.convex_hull]
+    build = ycb_assets._build_collision_geometry(mesh)
+
+    assert build.parts == (mesh.convex_hull,)
+    assert not build.decomposed
+    assert build.settings is None
     assert events == []
 
 
-@pytest.mark.parametrize("missing", ["coacd", "threadpoolctl"])
-def test_convex_parts_falls_back_to_single_hull_without_the_extra(
+def test_collision_build_uses_the_audited_coacd_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A poor hull fit must use uncapped parts whose vertices match MuJoCo's limit."""
+    events: list[tuple] = []
+    _fake_coacd(monkeypatch, events)
+    _fake_trimesh_with_hulls(monkeypatch, [1.0, 3.0])
+    monkeypatch.setattr(
+        ycb_assets,
+        "_hull_surface_gap",
+        lambda _hull, _mesh: (ycb_assets._HULL_GAP_GATE_M + 0.001, 0.0),
+    )
+
+    build = ycb_assets._build_collision_geometry(_ConcaveMesh())
+
+    assert build.decomposed
+    assert build.settings == ycb_assets._COACD_SETTINGS
+    assert events[1] == ("run_coacd", ycb_assets._COACD_SETTINGS)
+    assert build.settings["max_convex_hull"] == -1
+    assert build.settings["decimate"] is True
+    assert build.settings["max_ch_vertex"] == 128
+
+
+@pytest.mark.parametrize("missing", ["coacd", "threadpoolctl", "rtree"])
+def test_collision_build_falls_back_to_single_hull_without_the_extra(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, missing: str
 ):
-    """The decomposer is an optional extra: a plain install must still build scenes."""
+    """The decomposer is optional, so a plain install must still build scenes."""
     import logging
 
     _fake_coacd(monkeypatch, [])
@@ -599,73 +674,128 @@ def test_convex_parts_falls_back_to_single_hull_without_the_extra(
     mesh = _ConcaveMesh()
 
     with caplog.at_level(logging.WARNING, logger="so101_nexus.ycb_assets"):
-        parts = ycb_assets._convex_parts(mesh)
+        build = ycb_assets._build_collision_geometry(mesh)
 
-    assert parts == [mesh.convex_hull]
-    # The warning must name the package that is actually missing.
+    assert build.parts == (mesh.convex_hull,)
+    assert build.decomposer == ycb_assets._FALLBACK_DECOMPOSER
     assert missing in caplog.records[0].getMessage()
 
 
-def test_write_collision_parts_weights_mass_by_part_volume(
+def test_write_collision_parts_records_provenance_and_mass(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ):
     events: list[tuple] = []
     _fake_coacd(monkeypatch, events)
     _fake_trimesh_with_hulls(monkeypatch, [1.0, 3.0])
+    monkeypatch.setattr(ycb_assets, "_hull_surface_gap", lambda _h, _m: (0.004, 0.012))
+    source = tmp_path / "visual.obj"
+    source.write_text("visual", encoding="utf-8")
+    out_dir = tmp_path / "collision_v3"
 
-    ycb_assets._write_collision_parts(_ConcaveMesh(), tmp_path)
+    ycb_assets._write_collision_parts(
+        _ConcaveMesh(),
+        out_dir,
+        model_id="037_scissors",
+        source_path=source,
+    )
 
-    manifest = json.loads((tmp_path / "parts.json").read_text(encoding="utf-8"))
-    assert manifest["parts"] == [
-        {"file": "collision_000.obj", "mass_fraction": 0.25},
-        {"file": "collision_001.obj", "mass_fraction": 0.75},
-    ]
+    manifest = json.loads((out_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert [part["mass_fraction"] for part in manifest["parts"]] == [0.25, 0.75]
     assert sum(part["mass_fraction"] for part in manifest["parts"]) == 1.0
-    # Scene geometry must not vary between runs: the search is seeded AND pinned
-    # to one OpenMP thread, because CoACD's thread scheduling changes the split.
+    assert manifest["model_id"] == "037_scissors"
+    assert manifest["source_sha256"] == ycb_assets._sha256(source)
+    assert manifest["settings"] == ycb_assets._COACD_SETTINGS
+    assert [part["n_vertices"] for part in manifest["parts"]] == [4, 4]
     assert events[0] == ("enter_limits", 1, "openmp")
-    assert events[1][0] == "run_coacd"
-    assert events[1][1]["seed"] == ycb_assets._COACD_SEED
+    assert events[1] == ("run_coacd", ycb_assets._COACD_SETTINGS)
     assert events[2] == ("exit_limits",)
 
 
 def test_write_collision_parts_drops_stale_parts(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     """A shorter decomposition must not leave orphan OBJs behind in the cache."""
-    (tmp_path).mkdir(parents=True, exist_ok=True)
+    tmp_path.mkdir(parents=True, exist_ok=True)
     (tmp_path / "collision_007.obj").write_text("stale", encoding="utf-8")
-    _patch_module(monkeypatch, "trimesh", types.SimpleNamespace(Scene=_FakeScene))
+    source = tmp_path / "visual.obj"
+    source.write_text("visual", encoding="utf-8")
+    _fake_coacd(monkeypatch, [])
+    monkeypatch.setattr(ycb_assets, "_hull_surface_gap", lambda _h, _m: (0.0, 0.0))
 
-    ycb_assets._write_collision_parts(_FakeMesh(), tmp_path)
+    ycb_assets._write_collision_parts(
+        _FakeMesh(),
+        tmp_path,
+        model_id="058_golf_ball",
+        source_path=source,
+    )
 
     assert sorted(p.name for p in tmp_path.glob("collision_*.obj")) == ["collision_000.obj"]
 
 
+def _exterior_collision_points(trimesh, parts, count: int) -> np.ndarray:
+    """Sample only the exterior faces of abutting convex parts."""
+    areas = np.asarray([part.area for part in parts], dtype=np.float64)
+    counts = np.maximum((count * areas / areas.sum()).astype(np.int64), 1)
+    planes = []
+    for part in parts:
+        hull = part.convex_hull
+        normals = np.asarray(hull.face_normals, dtype=np.float64)
+        offsets = np.einsum("ij,ij->i", normals, np.asarray(hull.triangles)[:, 0])
+        planes.append((normals, offsets))
+
+    kept = []
+    for part_index, (part, sample_count) in enumerate(zip(parts, counts, strict=True)):
+        points, face_ids = trimesh.sample.sample_surface(part, int(sample_count), seed=0)
+        points = np.asarray(points, dtype=np.float64)
+        probes = points + 5e-4 * np.asarray(part.face_normals)[face_ids]
+        interior = np.zeros(len(points), dtype=bool)
+        for other_index, (normals, offsets) in enumerate(planes):
+            if other_index != part_index:
+                interior |= ((probes @ normals.T) - offsets <= 0.0).all(axis=1)
+        kept.append(points[~interior])
+    return np.concatenate(kept)
+
+
 @pytest.mark.slow
 @pytest.mark.parametrize(
-    "model_id,min_convexity",
+    "model_id,decomposed",
     [
-        ("033_spatula", 0.55),  # 0.19 as a single hull
-        ("031_spoon", 0.60),  # 0.31 as a single hull
-        ("030_fork", 0.55),  # 0.45 as a single hull
+        ("009_gelatin_box", False),
+        ("011_banana", True),
+        ("030_fork", True),
+        ("031_spoon", True),
+        ("032_knife", True),
+        ("033_spatula", True),
+        ("037_scissors", True),
+        ("040_large_marker", False),
+        ("043_phillips_screwdriver", True),
+        ("058_golf_ball", False),
     ],
 )
-def test_decomposed_collision_geometry_tracks_the_visual_mesh(model_id: str, min_convexity: float):
-    """Collision volume must stay close to the scan, not balloon into a solid wedge.
-
-    Downloads and decomposes on a cold cache; cached runs only load the OBJs.
-    """
+def test_collision_geometry_tracks_the_visual_surface(model_id: str, decomposed: bool):
+    """The collision surface must not add more than 3.5 mm of bulk error."""
     pytest.importorskip("coacd")
+    pytest.importorskip("rtree")
     trimesh = pytest.importorskip("trimesh")
 
     ycb_assets.ensure_ycb_assets(model_id)
     visual = trimesh.load(str(ycb_assets.get_ycb_visual_mesh(model_id)), force="mesh")
     parts = [
-        trimesh.load(str(path), force="mesh").convex_hull
+        trimesh.load(str(path), force="mesh")
         for path in ycb_assets.get_ycb_collision_meshes(model_id)
     ]
-    convexity = abs(visual.volume) / sum(abs(part.volume) for part in parts)
-    assert convexity >= min_convexity, (
-        f"{model_id} collision volume is {1 / convexity:.2f}x the visual mesh "
-        f"(convexity {convexity:.2f} < {min_convexity})"
+    visual.update_faces(visual.nondegenerate_faces())
+    points = _exterior_collision_points(trimesh, parts, ycb_assets._HULL_GAP_SAMPLES)
+    distances = trimesh.proximity.closest_point(visual, points)[1]
+    p95 = float(np.percentile(distances, 95))
+    maximum = float(np.max(distances))
+
+    manifest = ycb_assets._read_manifest(ycb_assets._collision_dir(model_id))
+    assert manifest is not None
+    assert manifest["decomposed"] is decomposed
+    assert (len(parts) > 1) is decomposed
+    assert sum(part.mass_fraction for part in ycb_assets.get_ycb_collision_parts(model_id)) == (
+        pytest.approx(1.0)
     )
-    assert len(parts) > 1
+    if decomposed:
+        assert max(len(part.vertices) for part in parts) <= 128
+    assert p95 <= 0.0035, f"{model_id} adds {p95 * 1000:.2f} mm of p95 collision error"
+    assert maximum <= 0.016, f"{model_id} adds {maximum * 1000:.2f} mm of maximum collision error"

--- a/uv.lock
+++ b/uv.lock
@@ -559,16 +559,16 @@ wheels = [
 
 [[package]]
 name = "coacd"
-version = "1.0.11"
+version = "1.0.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/3b/434beab9e1754ca0ae3a619b383243dd85aa65d03a4dc7333c8296c97a92/coacd-1.0.11-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:adbc58259a721cc5ede24cc8c2671a95e75a8a52dc1ee4d953d80d236b192da9", size = 3299264, upload-time = "2026-05-04T19:23:36.183Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/a7/06f63baa29198f681ba60848e3271cc625eddd61cd4e59071f56ffce9362/coacd-1.0.11-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e376fadb22790444c7253f0cee9104a1af01ec965488c1318e84e3b2dbf1e2a3", size = 2573832, upload-time = "2026-05-04T19:23:38.008Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/b4/057c78f7b16b87871cfcecc6febe70522e77a2a33f8788960377152c224d/coacd-1.0.11-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a60f700a52e5b40462e508c14bb756cd63ce7e6a95ff72ae0b1592be1dbb0106", size = 2640170, upload-time = "2026-05-04T19:23:39.322Z" },
-    { url = "https://files.pythonhosted.org/packages/00/83/c50472ce98175fddd86d4aba861fea89f30350a5487880b3a81d34915a85/coacd-1.0.11-cp39-abi3-win_amd64.whl", hash = "sha256:4de22f70d1a3fa8c44698c8006a223fe5fb0ee84b76adecf3726cf2003e9145f", size = 1465079, upload-time = "2026-05-04T19:23:41.604Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/d0/424900eda088a32e01aca62eca136a43db472c2cf4ab707c028aba56c13b/coacd-1.0.13-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:9a3c9500fcb46b624e8828134829708d8ed5d8abf5b71f05ce5395121187d47b", size = 3423733, upload-time = "2026-08-19T04:50:32.042Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/65/5fb42e1aded3f832beb8310c32756d96e56f3c8b93c8437837e23b486c0f/coacd-1.0.13-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:95ea07f1b1956707775ce957d03d4fc4747abb8db777139e0d49640bbc6d9399", size = 2584653, upload-time = "2026-08-19T04:50:33.62Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e9/74e2e1d8afb1c73cb74d2b2e55b3c2ec6c49d75d4d9cd9142c265371402d/coacd-1.0.13-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cb360e184333174d98bbfee714ef9e8714cb0440d78abd081087e660d2a26095", size = 2651984, upload-time = "2026-08-19T04:50:34.989Z" },
+    { url = "https://files.pythonhosted.org/packages/33/11/48a72d2ecc108d087ad9f79a5305d81798df5e6352e694b76dc1f4bf88db/coacd-1.0.13-cp39-abi3-win_amd64.whl", hash = "sha256:1f7c613769a90d1d6d467b764f6367cd5c524ef270c30472aa86749c11a74d03", size = 1485399, upload-time = "2026-08-19T04:50:36.16Z" },
 ]
 
 [[package]]
@@ -3330,6 +3330,22 @@ wheels = [
 ]
 
 [[package]]
+name = "rtree"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/09/7302695875a019514de9a5dd17b8320e7a19d6e7bc8f85dcfb79a4ce2da3/rtree-1.4.1.tar.gz", hash = "sha256:c6b1b3550881e57ebe530cc6cffefc87cd9bf49c30b37b894065a9f810875e46", size = 52425, upload-time = "2025-08-13T19:32:01.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/d9/108cd989a4c0954e60b3cdc86fd2826407702b5375f6dfdab2802e5fed98/rtree-1.4.1-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:d672184298527522d4914d8ae53bf76982b86ca420b0acde9298a7a87d81d4a4", size = 468484, upload-time = "2025-08-13T19:31:50.593Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/cf/2710b6fd6b07ea0aef317b29f335790ba6adf06a28ac236078ed9bd8a91d/rtree-1.4.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a7e48d805e12011c2cf739a29d6a60ae852fb1de9fc84220bbcef67e6e595d7d", size = 436325, upload-time = "2025-08-13T19:31:52.367Z" },
+    { url = "https://files.pythonhosted.org/packages/55/e1/4d075268a46e68db3cac51846eb6a3ab96ed481c585c5a1ad411b3c23aad/rtree-1.4.1-py3-none-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efa8c4496e31e9ad58ff6c7df89abceac7022d906cb64a3e18e4fceae6b77f65", size = 459789, upload-time = "2025-08-13T19:31:53.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/75/e5d44be90525cd28503e7f836d077ae6663ec0687a13ba7810b4114b3668/rtree-1.4.1-py3-none-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:12de4578f1b3381a93a655846900be4e3d5f4cd5e306b8b00aa77c1121dc7e8c", size = 507644, upload-time = "2025-08-13T19:31:55.164Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/85/b8684f769a142163b52859a38a486493b05bafb4f2fb71d4f945de28ebf9/rtree-1.4.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:b558edda52eca3e6d1ee629042192c65e6b7f2c150d6d6cd207ce82f85be3967", size = 1454478, upload-time = "2025-08-13T19:31:56.808Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a4/c2292b95246b9165cc43a0c3757e80995d58bc9b43da5cb47ad6e3535213/rtree-1.4.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f155bc8d6bac9dcd383481dee8c130947a4866db1d16cb6dff442329a038a0dc", size = 1555140, upload-time = "2025-08-13T19:31:58.031Z" },
+    { url = "https://files.pythonhosted.org/packages/74/25/5282c8270bfcd620d3e73beb35b40ac4ab00f0a898d98ebeb41ef0989ec8/rtree-1.4.1-py3-none-win_amd64.whl", hash = "sha256:efe125f416fd27150197ab8521158662943a40f87acab8028a1aac4ad667a489", size = 389358, upload-time = "2025-08-13T19:31:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/50/0a9e7e7afe7339bd5e36911f0ceb15fed51945836ed803ae5afd661057fd/rtree-1.4.1-py3-none-win_arm64.whl", hash = "sha256:3d46f55729b28138e897ffef32f7ce93ac335cb67f9120125ad3742a220800f0", size = 355253, upload-time = "2025-08-13T19:32:00.296Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3533,6 +3549,7 @@ dependencies = [
 [package.optional-dependencies]
 decomp = [
     { name = "coacd" },
+    { name = "rtree" },
     { name = "threadpoolctl" },
 ]
 rocm = [
@@ -3589,7 +3606,7 @@ visual = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coacd", marker = "extra == 'decomp'", specifier = ">=1.0.5,<2" },
+    { name = "coacd", marker = "extra == 'decomp'", specifier = ">=1.0.13,<2" },
     { name = "gradio", marker = "extra == 'teleop'", specifier = ">=5.0.0" },
     { name = "gymnasium", specifier = ">=1.0.0,<2" },
     { name = "huggingface-hub", specifier = "<2" },
@@ -3602,6 +3619,7 @@ requires-dist = [
     { name = "pillow", marker = "extra == 'viz'" },
     { name = "plotly", marker = "extra == 'teleop'", specifier = ">=6.0.0" },
     { name = "pytorch-triton-rocm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'rocm'", index = "https://download.pytorch.org/whl/rocm7.2", conflict = { package = "so101-nexus", extra = "rocm" } },
+    { name = "rtree", marker = "extra == 'decomp'", specifier = ">=1.4,<2" },
     { name = "scipy", specifier = "<2" },
     { name = "tensorboard", marker = "extra == 'train'", specifier = ">=2.0.0" },
     { name = "threadpoolctl", marker = "extra == 'decomp'", specifier = ">=3.1,<4" },


### PR DESCRIPTION
## Summary
- Replace the unreliable open-scan volume gate with a deterministic hull-to-scan surface-error gate.
- Generate `collision_v3` parts with audited CoACD settings and a 128-vertex cap per part.
- Record source provenance and generation inputs in the collision manifest.
- Add fidelity, cache, and MuJoCo compilation coverage.

## Validation
- `make format lint typecheck`
- `make test` - 1,564 passed, 2 skipped
- `uv run pytest tests/mujoco/test_envs.py::test_pick_ycb_object[037_scissors] tests/core/test_object_slots.py::TestMultiPartCollision::test_every_part_becomes_a_collision_geom -q`

## Evidence
The full audit shows p95 collision-surface error of 2.07 mm to 3.02 mm for decomposed models. The old single hull gives 5.78 mm to 25.65 mm.