### PR TITLE
feat(objects): add GSO object import and shared mesh-asset pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,27 @@ for the public-API and deprecation policy.
 
 ### Added
 
-### Changed
-
-### Fixed
-
-### Removed
+- `GSOObject` and 12 curated [Google Scanned Objects](https://research.google/blog/scanned-objects-by-google-research-a-dataset-of-3d-scanned-common-household-items/)
+  (`GSO_OBJECTS`), alongside the existing 10 `YCBObject` items, sharing the
+  same convex-hull collision pipeline. Assets download on demand from a
+  Hugging Face mirror (`SO101_GSO_HF_REPO` env override), cached at
+  `~/.cache/so101_nexus/gso/{model_id}/`. GSO ships no benchmark masses, so
+  `GSO_MASSES` holds a hand-estimated mass per object; pass `mass_override`
+  to replace it. See the GSO section of [Scene Objects and Assets](/docs/api/objects)
+  and `src/so101_nexus/GSO_PROVENANCE.md`.
+- `so101_nexus.mesh_assets`: the source-parameterized download/decompose/cache
+  engine `ycb_assets.py` and the new `gso_assets.py` both build on.
+- `so101_nexus.ycb_geometry.POSE_OVERRIDES`: settle-test-validated rest-pose
+  corrections for 7 objects (both datasets) whose default "thinnest axis up"
+  heuristic tips over under real physics. `get_mujoco_ycb_rest_pose` now takes
+  an optional `model_id` to look one up.
+- `so101_nexus.ycb_geometry.GRASP_ADVISORY`: an informational note on 4
+  objects whose real cross-section exceeds the SO-101 gripper's opening at
+  every sampled pose - not a construction-time error, but a prompt to
+  spot-check the object via teleoperation before a grasp task.
+- `scripts/validate_object_rest_poses.py`: the settle-test and grasp-screen
+  audit script behind the two additions above; its findings are recorded in
+  `src/so101_nexus/gso_pose_validation_results.json`.
 
 ## [0.5.2] - 2026-08-25
 

--- a/docs/content/docs/api/configs.mdx
+++ b/docs/content/docs/api/configs.mdx
@@ -324,7 +324,7 @@ Extends `EnvironmentConfig` with parameters for pick and lift tasks.
 from so101_nexus import PickConfig, CubeObject, YCBObject
 
 config = PickConfig(
-    objects=[CubeObject(color="blue"), YCBObject("011_banana")],
+    objects=[CubeObject(color="blue"), YCBObject("009_gelatin_box")],
     n_distractors=2,
 )
 ```
@@ -360,7 +360,7 @@ from so101_nexus import PickAndPlaceConfig, YCBObject
 config = PickAndPlaceConfig(cube_colors="blue", target_colors="green")
 
 # Object-pool path (carries a YCB object):
-config = PickAndPlaceConfig(objects=[YCBObject("011_banana")], target_colors="green")
+config = PickAndPlaceConfig(objects=[YCBObject("009_gelatin_box")], target_colors="green")
 ```
 
 ### Additional Parameters

--- a/docs/content/docs/api/objects.mdx
+++ b/docs/content/docs/api/objects.mdx
@@ -6,10 +6,10 @@ description: Constructor reference for cubes, YCB objects, and meshes, plus the 
 Scene objects define what the robot interacts with. All object types live in `so101_nexus` and share the abstract `SceneObject` base class.
 
 ```python
-from so101_nexus import CubeObject, MeshObject, YCBObject
+from so101_nexus import CubeObject, GSOObject, MeshObject, YCBObject
 ```
 
-All three concrete object types work on the MuJoCo and MuJoCo Warp backends, which build their scenes through the same `so101_nexus.object_slots.build_object_scene_xml`.
+All four concrete object types work on the MuJoCo and MuJoCo Warp backends, which build their scenes through the same `so101_nexus.object_slots.build_object_scene_xml`.
 
 ## SceneObject (abstract)
 
@@ -69,6 +69,17 @@ repr(banana)  # "banana"
 | `043_phillips_screwdriver` | phillips screwdriver |
 | `058_golf_ball` | golf ball |
 
+Every rest pose above is settle-tested against real MuJoCo physics (see
+[`get_mujoco_ycb_rest_pose()`](#get_mujoco_ycb_rest_pose)); a few needed a
+corrected orientation because the default "thinnest axis up" guess tips over
+under real dynamics. A handful of objects (both YCB and GSO) also have a
+**grasp advisory**: a geometric screen found no tested cross-section that
+fits inside the SO-101 gripper's aperture, so the object is likely too wide
+to close on with this arm. This is advisory only, not a construction-time
+error - spot-check via teleoperation or a policy rollout before relying on a
+flagged object for a real grasp task. The current list is in
+`so101_nexus.ycb_geometry.GRASP_ADVISORY`.
+
 Passing any other `model_id` raises an error. The same mapping is available at runtime:
 
 ```python
@@ -77,6 +88,65 @@ from so101_nexus import YCB_OBJECTS
 for model_id, name in YCB_OBJECTS.items():
     print(f"{model_id}: {name}")
 ```
+
+
+## GSOObject
+
+A [Google Scanned Objects](https://research.google/blog/scanned-objects-by-google-research-a-dataset-of-3d-scanned-common-household-items/)
+(GSO) object loaded from mesh files, sharing `YCBObject`'s convex-hull
+collision pipeline. Assets are downloaded on first use and cached (see [GSO
+assets](#gso-assets)).
+
+```python
+from so101_nexus import GSOObject
+
+clamp = GSOObject("Pony_C_Clamp_1440")
+repr(clamp)  # "C-clamp"
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `model_id` | `str` | required | GSO model identifier. Must be a key in `GSO_OBJECTS`. |
+| `mass_override` | `float \| None` | `None` | Override the default mass. Uses the hand-estimated mass when `None`. |
+
+`__repr__()` returns the human-readable name from the `GSO_OBJECTS` dictionary.
+
+Unlike YCB, GSO ships no benchmark-measured masses. Each `model_id`'s default
+mass in `GSO_MASSES` is a hand estimate: convex-hull volume from the mirrored
+scan times an assumed effective density for the filled/packaged object,
+rounded to the nearest 5 g. Pass `mass_override` to replace it with a
+measured value.
+
+### Model IDs
+
+`model_id` must be one of the twelve supported IDs, which are also the members of the `GsoModelId` type alias:
+
+| Model ID | `GSO_OBJECTS` name |
+|----------|--------------------|
+| `Pony_C_Clamp_1440` | C-clamp |
+| `Cole_Hardware_Mini_Honey_Dipper` | honey dipper |
+| `OXO_Soft_Works_Can_Opener_SnapLock` | can opener |
+| `3M_Vinyl_Tape_Green_1_x_36_yd` | tape roll |
+| `Shurtape_Gaffers_Tape_Silver_2_x_60_yd` | gaffer tape roll |
+| `Big_O_Sponges_Assorted_Cellulose_12_pack` | sponge pack |
+| `BIA_Porcelain_Ramekin_With_Glazed_Rim_35_45_oz_cup` | ramekin |
+| `CoQ10` | supplement bottle |
+| `Wilton_Pearlized_Sugar_Sprinkles_525_oz_Gold` | sprinkles canister |
+| `Marc_Anthony_Strictly_Curls_Curl_Envy_Perfect_Curl_Cream_6_fl_oz_bottle` | lotion bottle |
+| `Black_Elderberry_Syrup_54_oz_Gaia_Herbs` | syrup bottle |
+| `Nestle_Raisinets_Milk_Chocolate_35_oz_992_g` | candy box |
+
+Passing any other `model_id` raises an error. The same mapping is available at runtime:
+
+```python
+from so101_nexus import GSO_OBJECTS
+
+for model_id, name in GSO_OBJECTS.items():
+    print(f"{model_id}: {name}")
+```
+
+See the [YCB section above](#ycbobject) for the grasp advisory note; it
+applies to GSO objects too.
 
 ## MeshObject
 
@@ -207,6 +277,82 @@ rm -rf ~/.cache/so101_nexus/ycb/011_banana
 
 **Firewall or proxy.** Downloads go through the Hugging Face Hub client. Behind a proxy, set the standard `HTTPS_PROXY`, `HF_ENDPOINT`, or `HF_HUB_DISABLE_TELEMETRY` variables.
 
+## GSO assets
+
+GSO mesh assets are downloaded from a Hugging Face mirror on first use and cached at:
+
+```
+~/.cache/so101_nexus/gso/{model_id}/
+```
+
+The cache layout, manifest format, CoACD decomposition, and texture
+extraction are identical to [YCB assets](#ycb-assets) above - both datasets
+share the same generator (`so101_nexus.mesh_assets`), just with a different
+source repository and cache subdirectory.
+
+Creating a `GSOObject` and stepping an environment downloads whatever is missing. You can also trigger the download explicitly:
+
+```python
+from so101_nexus import ensure_gso_assets
+
+path = ensure_gso_assets("Pony_C_Clamp_1440")
+```
+
+### `ensure_gso_assets()`
+
+```python
+def ensure_gso_assets(model_id: str) -> Path
+```
+
+Downloads the mesh assets for `model_id` if they are not already cached, then returns the cache directory.
+
+### Path helpers
+
+These mirror the [YCB path helpers](#path-helpers): they resolve cache paths and never trigger a download. Call `ensure_gso_assets` first if the assets may not be present yet.
+
+| Function | Returns |
+|----------|---------|
+| `get_gso_mesh_dir(model_id)` | The model's cache directory |
+| `get_gso_collision_parts(model_id)` | `GSOCollisionPart(path, mass_fraction)` per convex part |
+| `get_gso_collision_meshes(model_id)` | Paths of the convex collision parts |
+| `get_gso_collision_mesh(model_id)` | Path of the first convex collision part |
+| `get_gso_visual_mesh(model_id)` | Path to `visual.obj` |
+| `get_gso_texture_file(model_id)` | Expected path to the optional `texture.png` |
+
+```python
+from so101_nexus import (
+    get_gso_collision_meshes,
+    get_gso_mesh_dir,
+    get_gso_texture_file,
+    get_gso_visual_mesh,
+)
+
+mesh_dir = get_gso_mesh_dir("Pony_C_Clamp_1440")
+collision_parts = get_gso_collision_meshes("Pony_C_Clamp_1440")
+visual = get_gso_visual_mesh("Pony_C_Clamp_1440")
+texture = get_gso_texture_file("Pony_C_Clamp_1440")
+```
+
+Each helper validates `model_id` against the supported set and raises on an unknown ID.
+
+### Custom source repository
+
+Assets are fetched from a Hugging Face dataset mirror by default. Override the source with `SO101_GSO_HF_REPO`, which is useful for private mirrors or custom object sets that follow the same directory layout:
+
+```bash
+export SO101_GSO_HF_REPO="your-org/your-gso-repo"
+```
+
+### Download troubleshooting
+
+**Interrupted download.** A partial cache directory is not repaired automatically. Delete it and retry:
+
+```bash
+rm -rf ~/.cache/so101_nexus/gso/Pony_C_Clamp_1440
+```
+
+**Firewall or proxy.** Downloads go through the Hugging Face Hub client. Behind a proxy, set the standard `HTTPS_PROXY`, `HF_ENDPOINT`, or `HF_HUB_DISABLE_TELEMETRY` variables.
+
 ## Simulation assets
 
 These helpers resolve paths to the assets bundled with the package.
@@ -234,15 +380,19 @@ Return the directory and the `so101.xml` path of the vendored MuJoCo Menagerie m
 def get_mujoco_ycb_rest_pose(
     verts: np.ndarray,
     margin: float = 0.002,
+    model_id: str | None = None,
 ) -> tuple[np.ndarray, float]
 ```
 
-Computes a stable rest orientation and spawn height for a YCB mesh by rotating its thinnest axis to point up.
+Computes a stable rest orientation and spawn height for a scanned mesh (YCB or GSO). `model_id`
+looks up a settle-test-validated correction in `POSE_OVERRIDES` first; without a match, the mesh's
+thinnest axis is rotated to point up as a guess.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `verts` | `np.ndarray` | required | Vertex array of the object mesh |
 | `margin` | `float` | `0.002` | Offset above the surface to avoid interpenetration |
+| `model_id` | `str \| None` | `None` | Dataset identifier to check against `POSE_OVERRIDES` before falling back to the heuristic |
 
 Returns `(quaternion, spawn_z)`, where `quaternion` is a NumPy array in wxyz order and `spawn_z` is the spawn height in meters.
 

--- a/docs/content/docs/concepts/customization.mdx
+++ b/docs/content/docs/concepts/customization.mdx
@@ -49,10 +49,10 @@ from so101_nexus import PickConfig, CubeObject, YCBObject
 config = PickConfig(objects=CubeObject(color="blue"))
 
 # Or a real-world scanned object; YCB assets download on first use.
-config = PickConfig(objects=YCBObject(model_id="011_banana"))
+config = PickConfig(objects=YCBObject(model_id="009_gelatin_box"))
 ```
 
-Ten YCB models ship, including `011_banana` and `058_golf_ball`. The full list and every
+Ten YCB models ship, including `009_gelatin_box` and `032_knife`. The full list and every
 constructor parameter for `CubeObject`, `YCBObject`, and `MeshObject` are in the
 [Objects reference](/docs/api/objects).
 
@@ -67,8 +67,8 @@ from so101_nexus import PickConfig, CubeObject, YCBObject
 config = PickConfig(
     objects=[
         CubeObject(color="blue"),
-        YCBObject(model_id="058_golf_ball"),
-        YCBObject(model_id="011_banana"),
+        YCBObject(model_id="032_knife"),
+        YCBObject(model_id="009_gelatin_box"),
     ],
 )
 ```
@@ -287,7 +287,7 @@ PickLift environments. Adds the object pool, distractors, and `lift_threshold`.
 from so101_nexus import PickConfig, CubeObject, YCBObject
 
 config = PickConfig(
-    objects=[CubeObject(color="blue"), YCBObject(model_id="011_banana")],
+    objects=[CubeObject(color="blue"), YCBObject(model_id="009_gelatin_box")],
     n_distractors=1,
     lift_threshold=0.06,
 )

--- a/docs/content/docs/getting-started/quickstart.mdx
+++ b/docs/content/docs/getting-started/quickstart.mdx
@@ -40,14 +40,14 @@ Every task uses the same Gymnasium API, so swapping the id is the only change.
 
 ## Use a different object
 
-Pass a config to change what is on the table. Here the default cube becomes a YCB banana:
+Pass a config to change what is on the table. Here the default cube becomes a YCB gelatin box:
 
 ```python
 import gymnasium as gym
 import so101_nexus.mujoco
 from so101_nexus import PickConfig, YCBObject
 
-config = PickConfig(objects=YCBObject(model_id="011_banana"))
+config = PickConfig(objects=YCBObject(model_id="009_gelatin_box"))
 env = gym.make("MuJoCoPickLift-v1", config=config, render_mode="human")
 obs, info = env.reset(seed=0)
 env.close()

--- a/docs/content/docs/workflow/teleoperation.mdx
+++ b/docs/content/docs/workflow/teleoperation.mdx
@@ -141,8 +141,8 @@ reset_settle_frames = 5
 n_distractors = 1
 objects = [
   { type = "cube", color = "green" },
-  { type = "ycb", model_id = "011_banana" },
-  { type = "ycb", model_id = "058_golf_ball" },
+  { type = "ycb", model_id = "009_gelatin_box" },
+  { type = "ycb", model_id = "032_knife" },
 ]
 
 [pick_and_place]
@@ -164,7 +164,7 @@ uv run so101-nexus teleop \
 ```
 
 The profile object schema matches the classes in [Scene Objects](/docs/api/objects). String
-specs such as `cube:blue` and `ycb:011_banana` work for built-in object choices. Mesh objects
+specs such as `cube:blue` and `ycb:009_gelatin_box` work for built-in object choices. Mesh objects
 use mapping syntax because file paths may contain separator characters:
 
 ```toml
@@ -189,7 +189,7 @@ from so101_nexus import CubeObject, PickConfig, YCBObject
 
 def build_config(env_id, base_config):
     return PickConfig(
-        objects=[CubeObject(color="green"), YCBObject("011_banana")],
+        objects=[CubeObject(color="green"), YCBObject("009_gelatin_box")],
         n_distractors=1,
     )
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ ignore = [
 "**/tests/**/*.py" = ["D", "PT006"]
 ".github/**/*.py" = ["D"]
 "examples/**/*.py" = ["D"]
+"scripts/**/*.py" = ["D"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 12

--- a/scripts/validate_object_rest_poses.py
+++ b/scripts/validate_object_rest_poses.py
@@ -1,0 +1,406 @@
+"""Settle-test and grasp-screen every supported YCB and GSO object.
+
+``get_mujoco_ycb_rest_pose`` picks a rest orientation from the object's AABB
+alone; it is a heuristic, not a physics result. This script validates it
+against real MuJoCo physics and records a corrected quaternion for any
+object whose heuristic pose does not settle stably (see
+``so101_nexus.ycb_geometry.POSE_OVERRIDES``).
+
+It also runs a grasp screen: from the settled pose, measure the object's
+collision-mesh cross-section width at several height/yaw slices and compare
+the narrowest one to the SO-101 jaw's aperture interval
+(``_JAW_MIN_APERTURE_M``..``_JAW_MAX_APERTURE_M``). This is advisory only
+(``so101_nexus.ycb_geometry.GRASP_ADVISORY``), not a gate on object support:
+it is a deterministic geometric comparison over a finite set of candidate
+poses and slices, not a dynamic grasp attempt or a collision-checked
+approach path, and the jaw's real aperture is depth-dependent in ways this
+check does not model. A full closed-loop dynamic grasp simulation (arm
+reaches in, closes the gripper, evaluates contact normals) was attempted
+first and abandoned: pass/fail was sensitive to solver warm-start state
+carried over between candidates, not a trustworthy per-object signal.
+
+``_JAW_MIN_APERTURE_M``/``_JAW_MAX_APERTURE_M`` come from two measurements
+(see GSO_OBJECT_IMPORT.md and the commit that added this script): a
+forward-kinematics sweep of the real gripper finger meshes (17-61 mm
+closed-to-open), and an isolated cylinder-contact calibration using
+``so101_nexus.grasp.opposing_normals_ok`` (reliable up to 40 mm near the
+pivot, unreliable at 46 mm+, untested elsewhere along the finger).
+
+Not a pytest suite: this is an audit script whose findings are recorded in
+``so101_nexus.ycb_geometry``. Run with ``uv run python
+scripts/validate_object_rest_poses.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import mujoco
+import numpy as np
+
+from so101_nexus import get_so101_mujoco_model_path
+from so101_nexus.constants import GSO_OBJECTS, YCB_OBJECTS
+from so101_nexus.gso_assets import ensure_gso_assets
+from so101_nexus.object_slots import (
+    _body_frame_collision_verts,
+    _slot_collision_geom_ids,
+    build_object_scene_xml,
+)
+from so101_nexus.objects import GSOObject, SceneObject, YCBObject
+from so101_nexus.scene import MUJOCO_SCENE_OPTION_XML
+from so101_nexus.ycb_assets import ensure_ycb_assets
+from so101_nexus.ycb_geometry import get_mujoco_ycb_rest_pose
+
+_ROBOT_XML = str(get_so101_mujoco_model_path())
+
+_SETTLE_STEPS = 500
+_SETTLE_DROP_M = 0.02
+_TRANSLATION_GATE_M = 0.01
+_ROTATION_GATE_DEG = 10.0
+
+# From the forward-kinematics/cylinder-contact calibration in the module
+# docstring.
+_JAW_MIN_APERTURE_M = 0.017
+_JAW_MAX_APERTURE_M = 0.032
+
+_GRASP_HEIGHT_FRACTIONS = (0.15, 0.3, 0.45, 0.5, 0.6, 0.7, 0.85)
+_GRASP_YAWS_DEG = (0.0, 30.0, 60.0, 90.0, 120.0, 150.0)
+_SLICE_HALF_THICKNESS_M = 0.003
+
+
+def _quat_angle_deg(q1: np.ndarray, q2: np.ndarray) -> float:
+    """Geodesic angle in degrees between two wxyz quaternions (double-cover safe)."""
+    dot = float(np.clip(abs(np.dot(q1, q2)), -1.0, 1.0))
+    return float(np.degrees(2.0 * np.arccos(dot)))
+
+
+_ROTATIONALLY_SYMMETRIC_MODEL_IDS = frozenset({"058_golf_ball"})
+
+
+@dataclass
+class SettleResult:
+    model_id: str
+    predicted_quat: np.ndarray
+    predicted_spawn_z: float
+    settled_pos: np.ndarray
+    settled_quat: np.ndarray
+    translation_delta_m: float
+    rotation_delta_deg: float
+
+    @property
+    def passed(self) -> bool:
+        if self.translation_delta_m > _TRANSLATION_GATE_M:
+            return False
+        if self.model_id in _ROTATIONALLY_SYMMETRIC_MODEL_IDS:
+            return True
+        return self.rotation_delta_deg <= _ROTATION_GATE_DEG
+
+
+@dataclass
+class GraspResult:
+    model_id: str
+    passed: bool
+    height_fraction: float | None = None
+    yaw_deg: float | None = None
+    width_mm: float | None = None
+    detail: str = ""
+
+
+@dataclass
+class ObjectReport:
+    model_id: str
+    settle: SettleResult
+    grasp: GraspResult
+    override_quat: np.ndarray | None = None
+    dropped: bool = False
+    notes: list[str] = field(default_factory=list)
+
+
+def _compile(obj: SceneObject) -> mujoco.MjModel:
+    xml = build_object_scene_xml(
+        [obj],
+        ["probe_slot"],
+        [0.5, 0.5, 0.5, 1.0],
+        option_xml=MUJOCO_SCENE_OPTION_XML,
+        robot_xml_path=_ROBOT_XML,
+        model_name="pose_grasp_probe",
+    )
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".xml", dir=str(get_so101_mujoco_model_path().parent), delete=False
+    ) as f:
+        f.write(xml)
+        path = f.name
+    model = mujoco.MjModel.from_xml_path(path)
+    Path(path).unlink()
+    return model
+
+
+def _predicted_pose(model: mujoco.MjModel, obj: SceneObject) -> tuple[np.ndarray, float]:
+    geom_ids = _slot_collision_geom_ids(model, "probe_slot", obj)
+    verts = _body_frame_collision_verts(model, geom_ids)
+    return get_mujoco_ycb_rest_pose(verts)
+
+
+def _settle_from_quat(
+    obj: SceneObject, model_id: str, quat: np.ndarray, spawn_z: float
+) -> SettleResult:
+    """Drop the object from ``quat`` 2 cm up and report where it actually settles."""
+    model = _compile(obj)
+    data = mujoco.MjData(model)
+    joint_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, "probe_slot_joint")
+    qadr = model.jnt_qposadr[joint_id]
+    start_pos = np.array([0.15, 0.0, spawn_z + _SETTLE_DROP_M])
+    data.qpos[qadr : qadr + 3] = start_pos
+    data.qpos[qadr + 3 : qadr + 7] = quat
+    mujoco.mj_forward(model, data)
+    for _ in range(_SETTLE_STEPS):
+        mujoco.mj_step(model, data)
+
+    settled_pos = data.qpos[qadr : qadr + 3].copy()
+    settled_quat = data.qpos[qadr + 3 : qadr + 7].copy()
+    translation_delta = float(
+        max(
+            np.linalg.norm(settled_pos[:2] - start_pos[:2]),
+            abs(settled_pos[2] - spawn_z),
+        )
+    )
+    return SettleResult(
+        model_id=model_id,
+        predicted_quat=quat,
+        predicted_spawn_z=spawn_z,
+        settled_pos=settled_pos,
+        settled_quat=settled_quat,
+        translation_delta_m=translation_delta,
+        rotation_delta_deg=_quat_angle_deg(quat, settled_quat),
+    )
+
+
+def _spawn_z_for_quat(obj: SceneObject, quat: np.ndarray) -> float:
+    """Return the floor-clearance spawn height for an arbitrary candidate quaternion."""
+    model = _compile(obj)
+    geom_ids = _slot_collision_geom_ids(model, "probe_slot", obj)
+    verts = _body_frame_collision_verts(model, geom_ids)
+    rot = np.zeros(9)
+    mujoco.mju_quat2Mat(rot, quat)
+    rotated = verts @ rot.reshape(3, 3).T
+    return float(-rotated[:, 2].min()) + 0.002
+
+
+def run_settle_test(obj: SceneObject, model_id: str) -> SettleResult:
+    """Settle-test the heuristic's own predicted rest quaternion."""
+    model = _compile(obj)
+    quat, spawn_z = _predicted_pose(model, obj)
+    return _settle_from_quat(obj, model_id, quat, spawn_z)
+
+
+def run_grasp_check(obj: SceneObject, model_id: str, settled_quat: np.ndarray) -> GraspResult:
+    """Find a reachable cross-section within the jaw's validated aperture interval.
+
+    ``settled_quat`` fixes the object's orientation (from the settle test);
+    only orientation matters for the shape's cross-section, not position.
+    Slices near the top/bottom 15% of the object's height are skipped so the
+    result is not a corner or rim, matching the spec's "not the raw AABB".
+    """
+    model = _compile(obj)
+    geom_ids = _slot_collision_geom_ids(model, "probe_slot", obj)
+    verts_body = _body_frame_collision_verts(model, geom_ids)
+    rot = np.zeros(9)
+    mujoco.mju_quat2Mat(rot, settled_quat)
+    world = verts_body @ rot.reshape(3, 3).T
+    z_lo, z_hi = float(world[:, 2].min()), float(world[:, 2].max())
+    height = z_hi - z_lo
+    if height <= 0.0:
+        return GraspResult(model_id=model_id, passed=False, detail="degenerate zero-height mesh")
+
+    best: tuple[float, float, float] | None = None
+    for frac in _GRASP_HEIGHT_FRACTIONS:
+        slice_z = z_lo + frac * height
+        band = world[np.abs(world[:, 2] - slice_z) <= _SLICE_HALF_THICKNESS_M]
+        if band.shape[0] < 4:
+            continue
+        for yaw_deg in _GRASP_YAWS_DEG:
+            yaw = np.radians(yaw_deg)
+            closing_width = float(np.ptp(band[:, 0] * np.cos(yaw) + band[:, 1] * np.sin(yaw)))
+            in_band = _JAW_MIN_APERTURE_M <= closing_width <= _JAW_MAX_APERTURE_M
+            if in_band and (best is None or closing_width < best[0]):
+                best = (closing_width, frac, yaw_deg)
+
+    if best is None:
+        return GraspResult(
+            model_id=model_id,
+            passed=False,
+            detail=(
+                "no height/yaw slice within the "
+                f"{_JAW_MIN_APERTURE_M * 1000:.0f}-{_JAW_MAX_APERTURE_M * 1000:.0f} mm "
+                "jaw aperture interval"
+            ),
+        )
+    width, frac, yaw_deg = best
+    return GraspResult(
+        model_id=model_id,
+        passed=True,
+        height_fraction=frac,
+        yaw_deg=yaw_deg,
+        width_mm=width * 1000,
+    )
+
+
+def _axis_up_seeds() -> list[np.ndarray]:
+    """Starting orientations for the override search: each convex-hull axis up.
+
+    These are only starting points for a real settle simulation; the
+    candidate is wherever physics actually put the object, which may differ
+    from the seed it was dropped from.
+    """
+    return [
+        np.array([1.0, 0.0, 0.0, 0.0]),
+        np.array([0.7071068, 0.0, 0.7071068, 0.0]),
+        np.array([0.7071068, 0.7071068, 0.0, 0.0]),
+    ]
+
+
+def validate_one(obj: SceneObject, model_id: str) -> ObjectReport:
+    """Settle-test ``obj``, correcting the pose if unstable; grasp-screen is advisory only."""
+    settle = run_settle_test(obj, model_id)
+    grasp = run_grasp_check(obj, model_id, settle.settled_quat)
+    report = ObjectReport(model_id=model_id, settle=settle, grasp=grasp)
+
+    if settle.passed:
+        return report
+
+    report.notes.append(
+        f"heuristic settle failed (dx={settle.translation_delta_m * 1000:.1f}mm, "
+        f"drot={settle.rotation_delta_deg:.1f}deg)"
+    )
+
+    candidate_seeds = [settle.predicted_quat, settle.settled_quat, *_axis_up_seeds()]
+    seen: list[np.ndarray] = []
+    for seed in candidate_seeds:
+        seed_settle = _settle_from_quat(obj, model_id, seed, _spawn_z_for_quat(obj, seed))
+        candidate = seed_settle.settled_quat
+        if any(_quat_angle_deg(candidate, u) < 5.0 for u in seen):
+            continue
+        seen.append(candidate)
+        # Re-verify the candidate is a genuine fixed point, not a mid-tumble
+        # snapshot after only 500 steps.
+        cand_settle = _settle_from_quat(obj, model_id, candidate, _spawn_z_for_quat(obj, candidate))
+        if not cand_settle.passed:
+            continue
+        report.settle = cand_settle
+        report.grasp = run_grasp_check(obj, model_id, cand_settle.settled_quat)
+        report.override_quat = candidate
+        report.notes.append(f"override accepted: quat={candidate.tolist()}")
+        return report
+
+    report.dropped = True
+    report.notes.append("no candidate pose settled stably")
+    return report
+
+
+def _collect_targets(only: list[str] | None) -> list[tuple[str, SceneObject]]:
+    targets: list[tuple[str, SceneObject]] = []
+    for model_id in YCB_OBJECTS:
+        if only and model_id not in only:
+            continue
+        ensure_ycb_assets(model_id)
+        targets.append((model_id, YCBObject(model_id=model_id)))
+    for model_id in GSO_OBJECTS:
+        if only and model_id not in only:
+            continue
+        ensure_gso_assets(model_id)
+        targets.append((model_id, GSOObject(model_id=model_id)))
+    return targets
+
+
+def _print_report(report: ObjectReport) -> None:
+    print(f"=== {report.model_id} ===", flush=True)
+    print(
+        f"  settle: pass={report.settle.passed} "
+        f"dx={report.settle.translation_delta_m * 1000:.2f}mm "
+        f"drot={report.settle.rotation_delta_deg:.2f}deg",
+        flush=True,
+    )
+    print(
+        f"  grasp (advisory): pass={report.grasp.passed} "
+        f"height_frac={report.grasp.height_fraction} yaw={report.grasp.yaw_deg} "
+        f"width_mm={report.grasp.width_mm} {report.grasp.detail}",
+        flush=True,
+    )
+    if report.override_quat is not None:
+        print(f"  OVERRIDE quat={report.override_quat.tolist()}", flush=True)
+    if report.dropped:
+        print("  DROPPED: no candidate pose settled stably", flush=True)
+    for note in report.notes:
+        print(f"  note: {note}", flush=True)
+
+
+def _print_summary(reports: list[ObjectReport]) -> None:
+    print("\n=== summary ===")
+    for report in reports:
+        if report.dropped:
+            status = "DROP"
+        elif report.override_quat is not None:
+            status = "OVERRIDE"
+        else:
+            status = "OK"
+        print(
+            f"{report.model_id:70s} settle={report.settle.passed!s:5s} "
+            f"grasp(advisory)={report.grasp.passed!s:5s} -> {status}"
+        )
+
+
+def _write_results(reports: list[ObjectReport], json_out: Path) -> None:
+    payload = {
+        r.model_id: {
+            "settle_pass": r.settle.passed,
+            "settle_translation_delta_mm": r.settle.translation_delta_m * 1000,
+            "settle_rotation_delta_deg": r.settle.rotation_delta_deg,
+            "grasp_pass": r.grasp.passed,
+            "grasp_height_fraction": r.grasp.height_fraction,
+            "grasp_yaw_deg": r.grasp.yaw_deg,
+            "grasp_width_mm": r.grasp.width_mm,
+            "override_quat": r.override_quat.tolist() if r.override_quat is not None else None,
+            "dropped": r.dropped,
+            "notes": r.notes,
+        }
+        for r in reports
+    }
+    json_out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(f"\nWrote {json_out}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--only", nargs="*", default=None, help="restrict to these model_ids")
+    parser.add_argument(
+        "--json-out",
+        type=Path,
+        default=Path(__file__).resolve().parents[1]
+        / "src"
+        / "so101_nexus"
+        / "gso_pose_validation_results.json",
+    )
+    args = parser.parse_args()
+
+    reports = []
+    for model_id, obj in _collect_targets(args.only):
+        report = validate_one(obj, model_id)
+        reports.append(report)
+        _print_report(report)
+
+    _print_summary(reports)
+    if args.json_out:
+        _write_results(reports, args.json_out)
+
+    if any(r.dropped for r in reports):
+        dropped = [r.model_id for r in reports if r.dropped]
+        print(f"\nFAIL: {len(dropped)} object(s) dropped, no pose settled stably: {dropped}")
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/so101_nexus/GSO_PROVENANCE.md
+++ b/src/so101_nexus/GSO_PROVENANCE.md
@@ -1,0 +1,50 @@
+# Provenance
+
+GSO (Google Scanned Objects) assets are not vendored in this repository. They
+are downloaded on first use, the same way YCB assets are (see
+`so101_nexus.gso_assets`).
+
+- Original dataset: [Google Scanned Objects](https://research.google/blog/scanned-objects-by-google-research-a-dataset-of-3d-scanned-common-household-items/)
+  (1,030 objects), published by Google Research.
+- License: CC-BY-4.0. Confirmed per-object via the Fuel API, e.g.
+  `https://fuel.gazebosim.org/1.0/GoogleResearch/models/<model_id>`
+  (`license_name: "Creative Commons Attribution 4.0 International"`).
+- Mesh mirror used to build the Hugging Face dataset this library downloads
+  from: [kevinzakka/mujoco_scanned_objects](https://github.com/kevinzakka/mujoco_scanned_objects)
+  (real-world-scale `.obj` + PNG texture, no rescale needed). The MJCF files
+  in that repository are MIT-licensed; the `.obj`/`.png` mesh and texture
+  assets themselves stay CC-BY-4.0 from Google.
+- Hugging Face mirror: the `SO101_GSO_HF_REPO` environment variable default
+  (`so101_nexus.gso_assets._HF_REPO_ID`), following the same directory layout
+  as the YCB mirror (`ai-habitat/ycb`).
+
+## Object selection
+
+12 objects were curated from the full 1,030-object GSO corpus (see
+`GSO_OBJECT_IMPORT.md` at the repository root for the original selection
+criteria and dimensions). Scissors was deliberately excluded from the GSO
+selection because it duplicates an existing YCB category
+(`037_scissors`); no salt/pepper shaker exists in the GSO corpus.
+
+## Mass estimation
+
+Unlike YCB, GSO ships no benchmark-measured masses. Every `model_id` in
+`GSO_MASSES` (`so101_nexus.constants`) uses a hand-estimated mass: convex-hull
+volume from the mirrored scan times an assumed effective density for the
+filled/packaged object, rounded to the nearest 5 g. See the inline comment on
+each entry for the volume and assumed density. Pass `mass_override` to
+`GSOObject` to replace an estimate with a measured value.
+
+## Pose and grasp validation
+
+`so101_nexus.ycb_geometry.get_mujoco_ycb_rest_pose()`'s default heuristic
+(rotate the mesh's thinnest AABB axis to point up) is a bounding-box guess,
+not a physics result. `scripts/validate_object_rest_poses.py` settle-tests
+every supported YCB and GSO model against real MuJoCo physics and records a
+corrected quaternion in `POSE_OVERRIDES` for any model whose heuristic pose is
+dynamically unstable. The same script also runs an advisory (non-gating)
+geometric grasp screen; objects it flags are recorded in `GRASP_ADVISORY` with
+a short note, not removed from the supported set. See the module docstring of
+`so101_nexus.ycb_geometry` for the exact methodology and its limits, and
+`src/so101_nexus/gso_pose_validation_results.json` for full per-object
+results.

--- a/src/so101_nexus/__init__.py
+++ b/src/so101_nexus/__init__.py
@@ -20,6 +20,7 @@ from so101_nexus.config import (
     SO101_TCP_SITE_NAME,
     ControlMode,
     EnvironmentConfig,
+    GsoModelId,
     LookAtConfig,
     MoveConfig,
     MoveDirection,
@@ -38,6 +39,8 @@ from so101_nexus.config import (
 )
 from so101_nexus.constants import (
     COLOR_MAP,
+    GSO_MASSES,
+    GSO_OBJECTS,
     YCB_OBJECTS,
     ColorConfig,
     ColorName,
@@ -50,6 +53,16 @@ from so101_nexus.gaze import (
     object_in_view,
 )
 from so101_nexus.grasp import opposing_normals_ok
+from so101_nexus.gso_assets import (
+    GSOCollisionPart,
+    ensure_gso_assets,
+    get_gso_collision_mesh,
+    get_gso_collision_meshes,
+    get_gso_collision_parts,
+    get_gso_mesh_dir,
+    get_gso_texture_file,
+    get_gso_visual_mesh,
+)
 from so101_nexus.kinematics import (
     EE_ACTION_DIM,
     EE_DELTA_ACTION_SCALE,
@@ -63,7 +76,9 @@ from so101_nexus.lerobot_dataset import (
 )
 from so101_nexus.objects import (
     CubeObject,
+    GSOObject,
     MeshObject,
+    ScannedMeshObject,
     SceneObject,
     YCBObject,
 )
@@ -187,6 +202,8 @@ __all__ = [
     "EE_DELTA_ACTION_SCALE",
     "EE_ORIENTATION_WEIGHT",
     "EXTENDED_POSE",
+    "GSO_MASSES",
+    "GSO_OBJECTS",
     "JOINT_CONTROL_MODES",
     "POSES",
     "REST_POSE",
@@ -204,10 +221,13 @@ __all__ = [
     "CubeObject",
     "EndEffectorPose",
     "EnvironmentConfig",
+    "GSOCollisionPart",
+    "GSOObject",
     "GazeDirection",
     "GazeState",
     "GraspState",
     "GripperContactForce",
+    "GsoModelId",
     "JointEfforts",
     "JointPositions",
     "JointVelocities",
@@ -228,6 +248,7 @@ __all__ = [
     "RewardConfig",
     "RobotCameraPreset",
     "RobotConfig",
+    "ScannedMeshObject",
     "SceneObject",
     "StackCubeConfig",
     "TargetOffset",
@@ -242,9 +263,16 @@ __all__ = [
     "dataset_row_to_sim_qpos",
     "describe_pick_target",
     "direction_to_object",
+    "ensure_gso_assets",
     "ensure_ycb_assets",
     "gaze_angle_rad",
     "gaze_cosine",
+    "get_gso_collision_mesh",
+    "get_gso_collision_meshes",
+    "get_gso_collision_parts",
+    "get_gso_mesh_dir",
+    "get_gso_texture_file",
+    "get_gso_visual_mesh",
     "get_mujoco_ycb_rest_pose",
     "get_so101_mujoco_model_dir",
     "get_so101_mujoco_model_path",

--- a/src/so101_nexus/config.py
+++ b/src/so101_nexus/config.py
@@ -81,6 +81,21 @@ YcbModelId = Literal[
     "058_golf_ball",
 ]
 
+GsoModelId = Literal[
+    "Pony_C_Clamp_1440",
+    "Cole_Hardware_Mini_Honey_Dipper",
+    "OXO_Soft_Works_Can_Opener_SnapLock",
+    "3M_Vinyl_Tape_Green_1_x_36_yd",
+    "Shurtape_Gaffers_Tape_Silver_2_x_60_yd",
+    "Big_O_Sponges_Assorted_Cellulose_12_pack",
+    "BIA_Porcelain_Ramekin_With_Glazed_Rim_35_45_oz_cup",
+    "CoQ10",
+    "Wilton_Pearlized_Sugar_Sprinkles_525_oz_Gold",
+    "Marc_Anthony_Strictly_Curls_Curl_Envy_Perfect_Curl_Cream_6_fl_oz_bottle",
+    "Black_Elderberry_Syrup_54_oz_Gaia_Herbs",
+    "Nestle_Raisinets_Milk_Chocolate_35_oz_992_g",
+]
+
 SO101_JOINT_NAMES: tuple[str, ...] = (
     "shoulder_pan",
     "shoulder_lift",
@@ -1015,10 +1030,11 @@ class PickConfig(EnvironmentConfig):
         Pool of scene objects to sample from. Accepts a single ``SceneObject``,
         a list of ``SceneObject``, or ``None`` (defaults to ``[CubeObject()]``).
         A single object is automatically wrapped in a list.
-        ``YCBObject`` entries collide as a convex decomposition of the scan, which
-        needs the ``decomp`` extra; without it they fall back to a single convex
-        hull that makes several YCB models ungraspable regardless of the policy.
-        Read ``YCBObject``'s docstring before putting one in a grasping task's pool.
+        ``YCBObject``/``GSOObject`` entries collide as a convex decomposition of
+        the scan, which needs the ``decomp`` extra; without it they fall back to
+        a single convex hull that makes several models ungraspable regardless of
+        the policy. Read ``YCBObject``'s docstring before putting a scanned-mesh
+        object in a grasping task's pool.
     n_distractors : int
         Number of distractor objects to place. 0 means single-object scene.
     lift_threshold : float
@@ -1082,7 +1098,7 @@ class PickAndPlaceConfig(EnvironmentConfig):
     The carried object is chosen per episode from an object pool. By default the
     pool is one cube per colour in ``cube_colors`` (so selecting the target slot
     reproduces the legacy per-episode cube-colour variation); pass ``objects`` to
-    carry ``YCBObject`` / ``MeshObject`` instead. The goal disc colour is sampled
+    carry ``YCBObject`` / ``GSOObject`` / ``MeshObject`` instead. The goal disc colour is sampled
     from ``target_colors``.
 
     Parameters

--- a/src/so101_nexus/constants.py
+++ b/src/so101_nexus/constants.py
@@ -44,6 +44,50 @@ YCB_OBJECTS: dict[str, str] = {
     "058_golf_ball": "golf ball",
 }
 
+GSO_OBJECTS: dict[str, str] = {
+    "Pony_C_Clamp_1440": "C-clamp",
+    "Cole_Hardware_Mini_Honey_Dipper": "honey dipper",
+    "OXO_Soft_Works_Can_Opener_SnapLock": "can opener",
+    "3M_Vinyl_Tape_Green_1_x_36_yd": "tape roll",
+    "Shurtape_Gaffers_Tape_Silver_2_x_60_yd": "gaffer tape roll",
+    "Big_O_Sponges_Assorted_Cellulose_12_pack": "sponge pack",
+    "BIA_Porcelain_Ramekin_With_Glazed_Rim_35_45_oz_cup": "ramekin",
+    "CoQ10": "supplement bottle",
+    "Wilton_Pearlized_Sugar_Sprinkles_525_oz_Gold": "sprinkles canister",
+    "Marc_Anthony_Strictly_Curls_Curl_Envy_Perfect_Curl_Cream_6_fl_oz_bottle": "lotion bottle",
+    "Black_Elderberry_Syrup_54_oz_Gaia_Herbs": "syrup bottle",
+    "Nestle_Raisinets_Milk_Chocolate_35_oz_992_g": "candy box",
+}
+
+GSO_MASSES: dict[str, float] = {
+    # GSO ships no benchmark masses (unlike YCB); each value is convex-hull
+    # volume times an assumed effective density for the packaged object.
+    # 448 cm^3 hull, ~0.78 g/cm^3 effective (open steel frame)
+    "Pony_C_Clamp_1440": 0.350,
+    # 26 cm^3 hull, ~0.70 g/cm^3 effective (solid wood)
+    "Cole_Hardware_Mini_Honey_Dipper": 0.018,
+    # 318 cm^3 hull, ~0.57 g/cm^3 effective (plastic + metal gears)
+    "OXO_Soft_Works_Can_Opener_SnapLock": 0.180,
+    # 244 cm^3 hull, ~0.41 g/cm^3 effective (vinyl roll + card)
+    "3M_Vinyl_Tape_Green_1_x_36_yd": 0.100,
+    # 895 cm^3 hull, ~0.56 g/cm^3 effective (cloth tape roll)
+    "Shurtape_Gaffers_Tape_Silver_2_x_60_yd": 0.500,
+    # 149 cm^3 hull, ~1.01 g/cm^3 effective (packed sponges)
+    "Big_O_Sponges_Assorted_Cellulose_12_pack": 0.150,
+    # 233 cm^3 hull, ~0.52 g/cm^3 effective (hollow bowl)
+    "BIA_Porcelain_Ramekin_With_Glazed_Rim_35_45_oz_cup": 0.120,
+    # 139 cm^3 hull, ~0.54 g/cm^3 effective (bottle + pills)
+    "CoQ10": 0.075,
+    # 214 cm^3 hull, ~0.84 g/cm^3 effective (sugar-filled canister)
+    "Wilton_Pearlized_Sugar_Sprinkles_525_oz_Gold": 0.180,
+    # 941 cm^3 hull, ~0.24 g/cm^3 effective (squeeze bottle, mostly cream)
+    "Marc_Anthony_Strictly_Curls_Curl_Envy_Perfect_Curl_Cream_6_fl_oz_bottle": 0.230,
+    # 459 cm^3 hull, ~0.59 g/cm^3 effective (glass bottle + syrup)
+    "Black_Elderberry_Syrup_54_oz_Gaia_Herbs": 0.270,
+    # 248 cm^3 hull, ~0.46 g/cm^3 effective (cardboard box + candy)
+    "Nestle_Raisinets_Milk_Chocolate_35_oz_992_g": 0.115,
+}
+
 
 def validate_color_config(colors: ColorConfig, field_name: str) -> None:
     """Raise ``ValueError`` on an empty list or a color name not in ``COLOR_MAP``."""

--- a/src/so101_nexus/gso_assets.py
+++ b/src/so101_nexus/gso_assets.py
@@ -1,0 +1,177 @@
+"""GSO (Google Scanned Objects) mesh asset management - downloads from HuggingFace on demand.
+
+The cache-check/download/decompose/manifest orchestration is source-agnostic
+and lives in ``so101_nexus.mesh_assets`` as ``ensure_scanned_mesh_assets``,
+shared with ``so101_nexus.ycb_assets``. This module supplies only what is
+specific to the GSO mirror: the repository id, the cache directory, and the
+``fetch``/``ensure_texture`` hooks.
+
+Unlike ai-habitat/ycb, the mirrored GSO scans (from
+https://github.com/kevinzakka/mujoco_scanned_objects, itself mirroring Google
+Scanned Objects, CC-BY-4.0) already ship real-world-scale OBJ + PNG, so there
+is no GLB conversion or embedded-texture extraction step - the downloaded
+files are used directly as ``visual.obj`` / ``texture.png``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from pathlib import Path
+
+from so101_nexus.constants import GSO_OBJECTS
+from so101_nexus.mesh_assets import (
+    _COLLISION_SUBDIR,
+    MeshCollisionPart,
+    ensure_scanned_mesh_assets,
+    read_collision_parts,
+)
+
+logger = logging.getLogger(__name__)
+
+_HF_REPO_ID = os.environ.get("SO101_GSO_HF_REPO", "johnsutor/gso-so101-nexus")
+_CACHE_DIR = Path.home() / ".cache" / "so101_nexus" / "gso"
+
+# Backward-compatible-style public alias, mirroring ``YCBCollisionPart``; the
+# dataclass itself lives in ``mesh_assets`` so YCB and GSO share one type.
+GSOCollisionPart = MeshCollisionPart
+
+
+def _validate_model_id(model_id: str) -> None:
+    if model_id not in GSO_OBJECTS:
+        raise ValueError(f"model_id must be one of {list(GSO_OBJECTS)}, got {model_id!r}")
+
+
+def get_gso_mesh_dir(model_id: str) -> Path:
+    """Return the local cache directory for a GSO model's mesh files."""
+    _validate_model_id(model_id)
+    return _CACHE_DIR / model_id
+
+
+def get_gso_texture_file(model_id: str) -> Path:
+    """Return the expected local cache path for a GSO model's texture image."""
+    _validate_model_id(model_id)
+    return _CACHE_DIR / model_id / "texture.png"
+
+
+def _collision_dir(model_id: str) -> Path:
+    """Return the versioned directory holding a model's convex collision parts."""
+    return _CACHE_DIR / model_id / _COLLISION_SUBDIR
+
+
+def ensure_gso_assets(model_id: str) -> Path:
+    """Download GSO mesh assets from HuggingFace if not already cached.
+
+    Downloads the mirrored ``meshes/{model_id}/model.obj`` and ``texture.png``
+    (already real-world scale, so no conversion is needed). A deterministic
+    surface-error gate keeps one collision hull when it fits the scan; other
+    objects use a cached CoACD decomposition, so physics sees concavities that
+    one hull fills - the same pipeline ``ensure_ycb_assets`` uses.
+
+    Decomposition needs the optional ``decomp`` extra. Without it, collision
+    geometry falls back to one convex hull.
+
+    Returns the directory containing the model's mesh files.
+    """
+    _validate_model_id(model_id)
+    mesh_dir = _CACHE_DIR / model_id
+    collision_dir = _collision_dir(model_id)
+    visual_path = mesh_dir / "visual.obj"
+    texture_path = mesh_dir / "texture.png"
+    downloaded_obj = _CACHE_DIR / "meshes" / model_id / "model.obj"
+    downloaded_texture = _CACHE_DIR / "meshes" / model_id / "texture.png"
+
+    def _snapshot_download() -> None:
+        from huggingface_hub import snapshot_download
+
+        snapshot_download(
+            repo_id=_HF_REPO_ID,
+            repo_type="dataset",
+            allow_patterns=[f"meshes/{model_id}/*"],
+            local_dir=str(_CACHE_DIR),
+        )
+
+    def _ensure_texture() -> None:
+        if not downloaded_texture.exists():
+            _snapshot_download()
+        if downloaded_texture.exists():
+            texture_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(downloaded_texture, texture_path)
+        else:
+            logger.warning(
+                "GSO mirror has no texture.png for %r; object will render in "
+                "MuJoCo's default gray.",
+                model_id,
+            )
+
+    def _fetch() -> None:
+        _snapshot_download()
+        mesh_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(downloaded_obj, visual_path)
+        _ensure_texture()
+
+    return ensure_scanned_mesh_assets(
+        model_id=model_id,
+        mesh_dir=mesh_dir,
+        collision_dir=collision_dir,
+        visual_path=visual_path,
+        texture_path=texture_path,
+        fetch=_fetch,
+        ensure_texture=_ensure_texture,
+    )
+
+
+def get_gso_collision_parts(model_id: str) -> list[MeshCollisionPart]:
+    """Return the cached convex collision parts of a GSO model, in export order.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the model has not been prepared yet; call
+        :func:`ensure_gso_assets` first.
+    """
+    _validate_model_id(model_id)
+    return read_collision_parts(_collision_dir(model_id), f"ensure_gso_assets({model_id!r})")
+
+
+def get_gso_collision_meshes(model_id: str) -> list[Path]:
+    """Return the OBJ paths of a GSO model's convex collision parts.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the model has not been prepared yet; call
+        :func:`ensure_gso_assets` first.
+    """
+    return [part.path for part in get_gso_collision_parts(model_id)]
+
+
+def get_gso_collision_mesh(model_id: str) -> Path:
+    """Return the path to the first convex part of a GSO model's collision mesh.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the model has not been prepared yet; call
+        :func:`ensure_gso_assets` first.
+    """
+    return get_gso_collision_parts(model_id)[0].path
+
+
+def get_gso_visual_mesh(model_id: str) -> Path:
+    """Return the path to the visual mesh for a GSO model."""
+    _validate_model_id(model_id)
+    return _CACHE_DIR / model_id / "visual.obj"
+
+
+__all__ = [
+    "GSOCollisionPart",
+    "ensure_gso_assets",
+    "get_gso_collision_mesh",
+    "get_gso_collision_meshes",
+    "get_gso_collision_parts",
+    "get_gso_mesh_dir",
+    "get_gso_texture_file",
+    "get_gso_visual_mesh",
+]

--- a/src/so101_nexus/gso_pose_validation_results.json
+++ b/src/so101_nexus/gso_pose_validation_results.json
@@ -1,0 +1,322 @@
+{
+  "009_gelatin_box": {
+    "settle_pass": true,
+    "settle_translation_delta_mm": 6.701380032202776,
+    "settle_rotation_delta_deg": 7.1198903529232025,
+    "grasp_pass": false,
+    "grasp_height_fraction": null,
+    "grasp_yaw_deg": null,
+    "grasp_width_mm": null,
+    "override_quat": null,
+    "dropped": false,
+    "notes": []
+  },
+  "011_banana": {
+    "settle_pass": true,
+    "settle_translation_delta_mm": 1.9239752260562413,
+    "settle_rotation_delta_deg": 1.018932460134546,
+    "grasp_pass": false,
+    "grasp_height_fraction": null,
+    "grasp_yaw_deg": null,
+    "grasp_width_mm": null,
+    "override_quat": null,
+    "dropped": false,
+    "notes": []
+  },
+  "030_fork": {
+    "settle_pass": true,
+    "settle_translation_delta_mm": 2.068879539993333,
+    "settle_rotation_delta_deg": 8.00910673140078e-06,
+    "grasp_pass": true,
+    "grasp_height_fraction": 0.85,
+    "grasp_yaw_deg": 120.0,
+    "grasp_width_mm": 24.35177651821131,
+    "override_quat": [
+      0.9487688362649201,
+      0.05192379329375049,
+      0.015387636719621154,
+      0.3112954154154558
+    ],
+    "dropped": false,
+    "notes": [
+      "heuristic settle failed (dx=19.1mm, drot=0.0deg)",
+      "override accepted: quat=[0.9487688362649201, 0.05192379329375049, 0.015387636719621154, 0.3112954154154558]"
+    ]
+  },
+  "031_spoon": {
+    "settle_pass": true,
+    "settle_translation_delta_mm": 6.9659670714159665,
+    "settle_rotation_delta_deg": 1.7797475602147106,
+    "grasp_pass": false,
+    "grasp_height_fraction": null,
+    "grasp_yaw_deg": null,
+    "grasp_width_mm": null,
+    "override_quat": null,
+    "dropped": false,
+    "notes": []
+  },
+  "032_knife": {
+    "settle_pass": true,
+    "settle_translation_delta_mm": 3.6103424167378106,
+    "settle_rotation_delta_deg": 8.22099954320336,
+    "grasp_pass": true,
+    "grasp_height_fraction": 0.85,
+    "grasp_yaw_deg": 90.0,
+    "grasp_width_mm": 27.564817436085605,
+    "override_quat": [
+      0.9370767109522925,
+      0.3489106280209861,
+      0.010219865920332777,
+      -0.006645734376632088
+    ],
+    "dropped": false,
+    "notes": [
+      "heuristic settle failed (dx=40.6mm, drot=49.2deg)",
+      "override accepted: quat=[0.9370767109522925, 0.3489106280209861, 0.010219865920332777, -0.006645734376632088]"
+    ]
+  },
+  "033_spatula": {
+    "settle_pass": true,
+    "settle_translation_delta_mm": 2.523918951978694,
+    "settle_rotation_delta_deg": 0.1560484842418065,
+    "grasp_pass": false,
+    "grasp_height_fraction": null,
+    "grasp_yaw_deg": null,
+    "grasp_width_mm": null,
+    "override_quat": null,
+    "dropped": false,
+    "notes": []
+  },
+  "037_scissors": {
+    "settle_pass": true,
+    "settle_translation_delta_mm": 2.237290515990635,
+    "settle_rotation_delta_deg": 0.25415636611119125,
+    "grasp_pass": false,
+    "grasp_height_fraction": null,
+    "grasp_yaw_deg": null,
+    "grasp_width_mm": null,
+    "override_quat": null,
+    "dropped": false,
+    "notes": []
+  },
+  "040_large_marker": {
+    "settle_pass": true,
+    "settle_translation_delta_mm": 2.104670108933244,
+    "settle_rotation_delta_deg": 0.025516853383843005,
+    "grasp_pass": true,
+    "grasp_height_fraction": 0.15,
+    "grasp_yaw_deg": 0.0,
+    "grasp_width_mm": 18.581599869991074,
+    "override_quat": [
+      0.9868061963150316,
+      -0.0036756068674924118,
+      0.1618641914243856,
+      6.605258629754342e-05
+    ],
+    "dropped": false,
+    "notes": [
+      "heuristic settle failed (dx=13.2mm, drot=18.6deg)",
+      "override accepted: quat=[0.9868061963150316, -0.0036756068674924118, 0.1618641914243856, 6.605258629754342e-05]"
+    ]
+  },
+  "043_phillips_screwdriver": {
+    "settle_pass": true,
+    "settle_translation_delta_mm": 1.840119661400067,
+    "settle_rotation_delta_deg": 1.1580608141205704,
+    "grasp_pass": false,
+    "grasp_height_fraction": null,
+    "grasp_yaw_deg": null,
+    "grasp_width_mm": null,
+    "override_quat": [
+      0.9869994957430818,
+      0.02660164354705449,
+      0.02117028873260648,
+      0.1570864947679341
+    ],
+    "dropped": false,
+    "notes": [
+      "heuristic settle failed (dx=13.0mm, drot=18.5deg)",
+      "override accepted: quat=[0.9869994957430818, 0.02660164354705449, 0.02117028873260648, 0.1570864947679341]"
+    ]
+  },
+  "058_golf_ball": {
+    "settle_pass": true,
+    "settle_translation_delta_mm": 7.007797141468333,
+    "settle_rotation_delta_deg": 17.78666526113016,
+    "grasp_pass": false,
+    "grasp_height_fraction": null,
+    "grasp_yaw_deg": null,
+    "grasp_width_mm": null,
+    "override_quat": null,
+    "dropped": false,
+    "notes": []
+  },
+  "Pony_C_Clamp_1440": {
+    "settle_pass": true,
+    "settle_translation_delta_mm": 5.9443857993649525,
+    "settle_rotation_delta_deg": 6.04360755373522,
+    "grasp_pass": true,
+    "grasp_height_fraction": 0.85,
+    "grasp_yaw_deg": 0.0,
+    "grasp_width_mm": 27.289227366924425,
+    "override_quat": [
+      0.7252865768758933,
+      -0.2984139667764899,
+      0.36029176430034454,
+      -0.5050725991515618
+    ],
+    "dropped": false,
+    "notes": [
+      "heuristic settle failed (dx=22.6mm, drot=3.0deg)",
+      "override accepted: quat=[0.7252865768758933, -0.2984139667764899, 0.36029176430034454, -0.5050725991515618]"
+    ]
+  },
+  "Cole_Hardware_Mini_Honey_Dipper": {
+    "settle_pass": true,
+    "settle_translation_delta_mm": 1.5765153330665331,
+    "settle_rotation_delta_deg": 5.159289453316725,
+    "grasp_pass": true,
+    "grasp_height_fraction": 0.85,
+    "grasp_yaw_deg": 0.0,
+    "grasp_width_mm": 18.270835696488728,
+    "override_quat": null,
+    "dropped": false,
+    "notes": []
+  },
+  "OXO_Soft_Works_Can_Opener_SnapLock": {
+    "settle_pass": true,
+    "settle_translation_delta_mm": 2.097789645894282,
+    "settle_rotation_delta_deg": 0.0,
+    "grasp_pass": false,
+    "grasp_height_fraction": null,
+    "grasp_yaw_deg": null,
+    "grasp_width_mm": null,
+    "override_quat": [
+      0.9124123190985273,
+      -0.0022104422621626748,
+      -0.005014702029669815,
+      0.40923553934843887
+    ],
+    "dropped": false,
+    "notes": [
+      "heuristic settle failed (dx=20.0mm, drot=0.1deg)",
+      "override accepted: quat=[0.9124123190985273, -0.0022104422621626748, -0.005014702029669815, 0.40923553934843887]"
+    ]
+  },
+  "3M_Vinyl_Tape_Green_1_x_36_yd": {
+    "settle_pass": true,
+    "settle_translation_delta_mm": 2.644031655643943,
+    "settle_rotation_delta_deg": 0.694074006856339,
+    "grasp_pass": false,
+    "grasp_height_fraction": null,
+    "grasp_yaw_deg": null,
+    "grasp_width_mm": null,
+    "override_quat": null,
+    "dropped": false,
+    "notes": []
+  },
+  "Shurtape_Gaffers_Tape_Silver_2_x_60_yd": {
+    "settle_pass": true,
+    "settle_translation_delta_mm": 2.1011290463156254,
+    "settle_rotation_delta_deg": 0.4426478208243436,
+    "grasp_pass": false,
+    "grasp_height_fraction": null,
+    "grasp_yaw_deg": null,
+    "grasp_width_mm": null,
+    "override_quat": [
+      0.700240155426634,
+      -0.01148416578855433,
+      0.7137190536397818,
+      -0.01170261234763929
+    ],
+    "dropped": false,
+    "notes": [
+      "heuristic settle failed (dx=126.4mm, drot=57.1deg)",
+      "override accepted: quat=[0.700240155426634, -0.01148416578855433, 0.7137190536397818, -0.01170261234763929]"
+    ]
+  },
+  "Big_O_Sponges_Assorted_Cellulose_12_pack": {
+    "settle_pass": true,
+    "settle_translation_delta_mm": 3.633726558664299,
+    "settle_rotation_delta_deg": 0.39533116748748764,
+    "grasp_pass": false,
+    "grasp_height_fraction": null,
+    "grasp_yaw_deg": null,
+    "grasp_width_mm": null,
+    "override_quat": null,
+    "dropped": false,
+    "notes": []
+  },
+  "BIA_Porcelain_Ramekin_With_Glazed_Rim_35_45_oz_cup": {
+    "settle_pass": true,
+    "settle_translation_delta_mm": 2.3780054116009954,
+    "settle_rotation_delta_deg": 0.690946198671808,
+    "grasp_pass": false,
+    "grasp_height_fraction": null,
+    "grasp_yaw_deg": null,
+    "grasp_width_mm": null,
+    "override_quat": null,
+    "dropped": false,
+    "notes": []
+  },
+  "CoQ10": {
+    "settle_pass": true,
+    "settle_translation_delta_mm": 2.7359602663235942,
+    "settle_rotation_delta_deg": 1.2858670917266446,
+    "grasp_pass": false,
+    "grasp_height_fraction": null,
+    "grasp_yaw_deg": null,
+    "grasp_width_mm": null,
+    "override_quat": null,
+    "dropped": false,
+    "notes": []
+  },
+  "Wilton_Pearlized_Sugar_Sprinkles_525_oz_Gold": {
+    "settle_pass": true,
+    "settle_translation_delta_mm": 4.023235710701997,
+    "settle_rotation_delta_deg": 4.046256349465329,
+    "grasp_pass": false,
+    "grasp_height_fraction": null,
+    "grasp_yaw_deg": null,
+    "grasp_width_mm": null,
+    "override_quat": null,
+    "dropped": false,
+    "notes": []
+  },
+  "Marc_Anthony_Strictly_Curls_Curl_Envy_Perfect_Curl_Cream_6_fl_oz_bottle": {
+    "settle_pass": true,
+    "settle_translation_delta_mm": 1.9281538901392699,
+    "settle_rotation_delta_deg": 0.5745727954267529,
+    "grasp_pass": false,
+    "grasp_height_fraction": null,
+    "grasp_yaw_deg": null,
+    "grasp_width_mm": null,
+    "override_quat": null,
+    "dropped": false,
+    "notes": []
+  },
+  "Black_Elderberry_Syrup_54_oz_Gaia_Herbs": {
+    "settle_pass": true,
+    "settle_translation_delta_mm": 1.9056773436593837,
+    "settle_rotation_delta_deg": 0.60287143951437,
+    "grasp_pass": false,
+    "grasp_height_fraction": null,
+    "grasp_yaw_deg": null,
+    "grasp_width_mm": null,
+    "override_quat": null,
+    "dropped": false,
+    "notes": []
+  },
+  "Nestle_Raisinets_Milk_Chocolate_35_oz_992_g": {
+    "settle_pass": true,
+    "settle_translation_delta_mm": 5.079655930227817,
+    "settle_rotation_delta_deg": 2.8708982378855294,
+    "grasp_pass": false,
+    "grasp_height_fraction": null,
+    "grasp_yaw_deg": null,
+    "grasp_width_mm": null,
+    "override_quat": null,
+    "dropped": false,
+    "notes": []
+  }
+}

--- a/src/so101_nexus/mesh_assets.py
+++ b/src/so101_nexus/mesh_assets.py
@@ -1,0 +1,447 @@
+"""Source-agnostic convex-hull collision pipeline shared by scanned-mesh datasets.
+
+``so101_nexus.ycb_assets`` and ``so101_nexus.gso_assets`` each own a dataset's
+download step (YCB ships GLB scans that need conversion and embedded-texture
+extraction; GSO ships ready-to-use OBJ + PNG), but both feed the result into
+the same decompose/cache/manifest pipeline defined here: measure the convex
+hull's surface error against the scan, keep the hull when it fits, otherwise
+run CoACD under an audited configuration and cache the parts with a manifest
+that records the source hash and generator inputs for invalidation.
+
+Every symbol here is a private implementation detail shared by the two asset
+modules; it is not part of the public API.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import json
+import logging
+import math
+import os
+from collections.abc import Callable, Iterator, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol, TypedDict, cast
+
+if TYPE_CHECKING:
+    import numpy as np
+
+logger = logging.getLogger(__name__)
+
+_COLLISION_SUBDIR = "collision_v3"
+"""Cache subdirectory for collision parts built with a measured surface-error gate."""
+
+_MANIFEST_NAME = "manifest.json"
+
+_FALLBACK_DECOMPOSER = "convex_hull"
+"""Manifest marker for a hull built without the ``decomp`` extra."""
+
+_HULL_DECOMPOSER = "none (hull kept)"
+"""Manifest marker for a measured hull that does not need decomposition."""
+
+_HULL_GAP_SAMPLES = 20_000
+_HULL_GAP_SEED = 0
+_HULL_GAP_GATE_M = 0.003
+_HULL_GAP_MAX_GATE_M = 0.010
+
+
+class _CoacdSettings(TypedDict):
+    threshold: float
+    max_convex_hull: int
+    preprocess_mode: str
+    preprocess_resolution: int
+    resolution: int
+    mcts_nodes: int
+    mcts_iterations: int
+    mcts_max_depth: int
+    pca: bool
+    merge: bool
+    decimate: bool
+    max_ch_vertex: int
+    seed: int
+
+
+_COACD_SETTINGS: _CoacdSettings = {
+    "threshold": 0.03,
+    "max_convex_hull": -1,
+    "preprocess_mode": "auto",
+    "preprocess_resolution": 50,
+    "resolution": 2000,
+    "mcts_nodes": 20,
+    "mcts_iterations": 150,
+    "mcts_max_depth": 3,
+    "pca": False,
+    "merge": True,
+    "decimate": True,
+    "max_ch_vertex": 128,
+    "seed": 0,
+}
+"""Audited CoACD configuration for the supported YCB and GSO scans."""
+
+
+class _ExportableMesh(Protocol):
+    vertices: np.ndarray
+    faces: np.ndarray
+
+    @property
+    def volume(self) -> float: ...
+
+    def export(self, file_obj: str, file_type: str | None = None) -> object: ...
+
+    @property
+    def convex_hull(self) -> _ExportableMesh: ...
+
+
+class _TextureImage(Protocol):
+    def save(self, fp: str, format: str | None = None) -> object: ...
+
+
+@dataclass(frozen=True, slots=True)
+class MeshCollisionPart:
+    """One convex part of a scanned mesh's collision decomposition.
+
+    Attributes
+    ----------
+    path:
+        OBJ file holding the convex part.
+    mass_fraction:
+        Share of the object's mass carried by this part, proportional to its
+        volume. A model's fractions sum to 1, so the body's total mass does not
+        depend on how many parts the decomposition produced.
+    """
+
+    path: Path
+    mass_fraction: float
+
+
+@dataclass(frozen=True, slots=True)
+class _CollisionBuild:
+    """Collision parts and the inputs that produced them."""
+
+    parts: tuple[_ExportableMesh, ...]
+    decomposer: str
+    decomposed: bool
+    settings: Mapping[str, object] | None
+    hull_gap_p95_m: float | None
+    hull_gap_max_m: float | None
+
+
+def _load_exportable_mesh(mesh_path: Path) -> _ExportableMesh:
+    """Load a mesh file as one object with ``export`` and ``convex_hull``."""
+    import trimesh
+
+    scene_or_mesh = trimesh.load(str(mesh_path), force="mesh")
+    if isinstance(scene_or_mesh, trimesh.Scene):
+        return cast("_ExportableMesh", scene_or_mesh.dump(concatenate=True))
+    return cast("_ExportableMesh", scene_or_mesh)
+
+
+def _decomposer_id() -> str:
+    """Identify the installed generator for cache keying."""
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        for package in ("threadpoolctl", "rtree"):
+            version(package)
+        return f"coacd {version('coacd')}"
+    except (ImportError, PackageNotFoundError):
+        return _FALLBACK_DECOMPOSER
+
+
+def _hull_surface_gap(
+    hull: _ExportableMesh,
+    mesh: _ExportableMesh,
+) -> tuple[float, float]:
+    """Return the p95 and maximum distances from a hull surface to a scan."""
+    import numpy as np
+    import trimesh
+
+    points, _ = trimesh.sample.sample_surface(
+        hull,
+        _HULL_GAP_SAMPLES,
+        seed=_HULL_GAP_SEED,
+    )
+    scan = trimesh.Trimesh(vertices=mesh.vertices, faces=mesh.faces, process=False)
+    scan.update_faces(scan.nondegenerate_faces())
+    distances = np.asarray(trimesh.proximity.closest_point(scan, points)[1], dtype=np.float64)
+    if distances.size == 0 or not np.isfinite(distances).all():
+        raise ValueError("The hull surface distance contains no finite samples.")
+    return float(np.percentile(distances, 95)), float(distances.max())
+
+
+def _build_collision_geometry(mesh: _ExportableMesh) -> _CollisionBuild:
+    """Build a measured hull or a collision-aware convex decomposition."""
+    hull = mesh.convex_hull
+    try:
+        import coacd
+        import trimesh
+        from threadpoolctl import threadpool_limits
+
+        importlib.import_module("rtree")
+    except ImportError as exc:
+        logger.warning(
+            "%s is not installed: collision geometry stays a single convex hull. "
+            "Install so101-nexus[decomp] for measured multi-hull geometry.",
+            exc.name or "a decomposition dependency",
+        )
+        return _CollisionBuild(
+            parts=(hull,),
+            decomposer=_FALLBACK_DECOMPOSER,
+            decomposed=False,
+            settings=None,
+            hull_gap_p95_m=None,
+            hull_gap_max_m=None,
+        )
+
+    hull_gap_p95_m, hull_gap_max_m = _hull_surface_gap(hull, mesh)
+    logger.debug(
+        "hull surface gap: p95=%.6f m, max=%.6f m",
+        hull_gap_p95_m,
+        hull_gap_max_m,
+    )
+    if hull_gap_p95_m <= _HULL_GAP_GATE_M and hull_gap_max_m <= _HULL_GAP_MAX_GATE_M:
+        return _CollisionBuild(
+            parts=(hull,),
+            decomposer=_HULL_DECOMPOSER,
+            decomposed=False,
+            settings=None,
+            hull_gap_p95_m=hull_gap_p95_m,
+            hull_gap_max_m=hull_gap_max_m,
+        )
+
+    coacd.set_log_level("error")
+    with threadpool_limits(limits=1, user_api="openmp"):
+        pieces = coacd.run_coacd(
+            coacd.Mesh(mesh.vertices, mesh.faces),
+            **_COACD_SETTINGS,
+        )
+    parts = tuple(
+        cast("_ExportableMesh", trimesh.Trimesh(vertices, faces)) for vertices, faces in pieces
+    )
+    parts = tuple(part for part in parts if abs(part.volume) > 0.0)
+    if not parts:
+        raise RuntimeError("CoACD produced no positive-volume collision parts.")
+    max_vertices = int(_COACD_SETTINGS["max_ch_vertex"])
+    if any(len(part.vertices) > max_vertices for part in parts):
+        raise RuntimeError(
+            f"CoACD produced a collision part with more than {max_vertices} vertices."
+        )
+    return _CollisionBuild(
+        parts=parts,
+        decomposer=_decomposer_id(),
+        decomposed=True,
+        settings=_COACD_SETTINGS,
+        hull_gap_p95_m=hull_gap_p95_m,
+        hull_gap_max_m=hull_gap_max_m,
+    )
+
+
+def _sha256(path: Path) -> str:
+    """Return the SHA-256 digest of a file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _write_collision_parts(
+    mesh: _ExportableMesh,
+    out_dir: Path,
+    *,
+    model_id: str,
+    source_path: Path,
+) -> None:
+    """Export collision parts and their generation manifest into ``out_dir``."""
+    build = _build_collision_geometry(mesh)
+    volumes = [abs(part.volume) for part in build.parts]
+    total = sum(volumes)
+    fractions = [volume / total for volume in volumes]
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = out_dir / _MANIFEST_NAME
+    manifest_path.unlink(missing_ok=True)
+    for stale in out_dir.glob("collision_*.obj"):
+        stale.unlink()
+    entries = []
+    for index, (part, volume, fraction) in enumerate(
+        zip(build.parts, volumes, fractions, strict=True)
+    ):
+        name = f"collision_{index:03d}.obj"
+        part.export(str(out_dir / name), file_type="obj")
+        entries.append(
+            {
+                "file": name,
+                "mass_fraction": fraction,
+                "volume_m3": volume,
+                "n_vertices": len(part.vertices),
+            }
+        )
+    manifest = {
+        "model_id": model_id,
+        "source": source_path.name,
+        "source_sha256": _sha256(source_path),
+        "decomposer": build.decomposer,
+        "settings": dict(build.settings) if build.settings is not None else None,
+        "hull_gap_p95_m": build.hull_gap_p95_m,
+        "hull_gap_max_m": build.hull_gap_max_m,
+        "hull_gap_gate_m": _HULL_GAP_GATE_M,
+        "hull_gap_max_gate_m": _HULL_GAP_MAX_GATE_M,
+        "decomposed": build.decomposed,
+        "mass_split": "part volume / total part volume",
+        "parts": entries,
+    }
+    pending = manifest_path.with_suffix(".json.pending")
+    pending.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    os.replace(pending, manifest_path)
+
+
+def _texture_image_from_material(material: object) -> _TextureImage | None:
+    for attr in ("image", "baseColorTexture"):
+        value = getattr(material, attr, None)
+        if value is None:
+            continue
+        image = getattr(value, "image", value)
+        if image is not None:
+            return cast("_TextureImage", image)
+    return None
+
+
+def _iter_texture_meshes(scene_or_mesh: object, scene_type: type) -> Iterator[object]:
+    if isinstance(scene_or_mesh, scene_type):
+        geometry = getattr(scene_or_mesh, "geometry", None)
+        if isinstance(geometry, Mapping):
+            yield from geometry.values()
+        to_geometry = getattr(scene_or_mesh, "to_geometry", None)
+        if callable(to_geometry):
+            yield to_geometry()
+        elif callable(dump := getattr(scene_or_mesh, "dump", None)):
+            yield dump(concatenate=True)
+    else:
+        yield scene_or_mesh
+
+
+def _manifest_part_is_usable(part: object) -> bool:
+    if not isinstance(part, Mapping):
+        return False
+    part = cast("Mapping[str, object]", part)
+    name = part.get("file")
+    fraction_value = part.get("mass_fraction")
+    if not isinstance(name, str) or Path(name).name != name:
+        return False
+    if isinstance(fraction_value, bool) or not isinstance(fraction_value, (int, float)):
+        return False
+    fraction = float(fraction_value)
+    return math.isfinite(fraction) and fraction >= 0.0
+
+
+def _read_manifest(collision_dir: Path) -> dict | None:
+    """Return a usable collision manifest, or ``None``."""
+    try:
+        manifest = json.loads((collision_dir / _MANIFEST_NAME).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(manifest, dict) or not isinstance(manifest.get("parts"), list):
+        return None
+    parts = manifest["parts"]
+    if not parts or not all(_manifest_part_is_usable(part) for part in parts):
+        return None
+    return manifest
+
+
+def _manifest_source_matches(collision_dir: Path, manifest: Mapping[str, object]) -> bool:
+    source = collision_dir.parent / str(manifest.get("source", ""))
+    try:
+        return manifest.get("source_sha256") == _sha256(source)
+    except OSError:
+        return False
+
+
+def _manifest_generator_matches(manifest: Mapping[str, object]) -> bool:
+    current = _decomposer_id()
+    if current == _FALLBACK_DECOMPOSER:
+        return True
+    gates_match = (
+        manifest.get("hull_gap_gate_m") == _HULL_GAP_GATE_M
+        and manifest.get("hull_gap_max_gate_m") == _HULL_GAP_MAX_GATE_M
+    )
+    if not gates_match:
+        return False
+    if manifest.get("decomposed"):
+        return manifest.get("decomposer") == current and manifest.get("settings") == _COACD_SETTINGS
+    return (
+        manifest.get("decomposer") == _HULL_DECOMPOSER
+        and manifest.get("settings") is None
+        and manifest.get("hull_gap_p95_m") is not None
+        and manifest.get("hull_gap_max_m") is not None
+    )
+
+
+def _collision_parts_are_current(collision_dir: Path) -> bool:
+    """Return true when all cached parts match the scan and generator inputs."""
+    manifest = _read_manifest(collision_dir)
+    if manifest is None:
+        return False
+    parts_exist = all((collision_dir / part["file"]).is_file() for part in manifest["parts"])
+    return (
+        parts_exist
+        and _manifest_source_matches(collision_dir, manifest)
+        and _manifest_generator_matches(manifest)
+    )
+
+
+def read_collision_parts(collision_dir: Path, error_hint: str) -> list[MeshCollisionPart]:
+    """Return the cached convex collision parts of a model, in export order.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the model has not been prepared yet; ``error_hint`` names the
+        ``ensure_*_assets`` call that prepares it.
+    """
+    manifest = _read_manifest(collision_dir)
+    if manifest is None:
+        raise FileNotFoundError(
+            f"No usable collision decomposition cached at {collision_dir}; call {error_hint} first."
+        )
+    return [
+        MeshCollisionPart(collision_dir / entry["file"], float(entry["mass_fraction"]))
+        for entry in manifest["parts"]
+    ]
+
+
+def ensure_scanned_mesh_assets(
+    *,
+    model_id: str,
+    mesh_dir: Path,
+    collision_dir: Path,
+    visual_path: Path,
+    texture_path: Path,
+    fetch: Callable[[], None],
+    ensure_texture: Callable[[], None],
+) -> Path:
+    """Run the shared cache-check/download/decompose orchestration for one model.
+
+    ``fetch`` and ``ensure_texture`` are source-specific hooks that a caller
+    (``so101_nexus.ycb_assets`` or ``so101_nexus.gso_assets``) defines: ``fetch``
+    downloads the raw scan on a full cache miss and writes ``visual_path`` (and
+    ``texture_path`` on a best-effort basis); ``ensure_texture`` recovers a
+    missing texture on an otherwise-current cache hit, more cheaply than a full
+    re-fetch. Every other step - the cache-freshness check, the CoACD/hull
+    decomposition, and the manifest write - is identical for every source.
+    """
+    if _collision_parts_are_current(collision_dir) and visual_path.exists():
+        if not texture_path.exists():
+            ensure_texture()
+        return mesh_dir
+
+    fetch()
+    _write_collision_parts(
+        _load_exportable_mesh(visual_path),
+        collision_dir,
+        model_id=model_id,
+        source_path=visual_path,
+    )
+    return mesh_dir

--- a/src/so101_nexus/mujoco/pick_and_place.py
+++ b/src/so101_nexus/mujoco/pick_and_place.py
@@ -3,7 +3,8 @@
 The carried object is chosen per episode from a compiled object pool (shared with
 the unified pick env via ``so101_nexus.object_slots``); the goal is a visible,
 non-colliding disc whose colour is randomized per episode. Supported carried
-objects: ``CubeObject``, ``YCBObject``, ``MeshObject``.
+objects: ``CubeObject``, ``ScannedMeshObject`` (``YCBObject``, ``GSOObject``),
+``MeshObject``.
 
 When ``PickAndPlaceConfig.n_distractors > 0``, one freejoint slot per entry in
 ``PickAndPlaceConfig.distractors`` is compiled after the carried pool; each reset
@@ -23,7 +24,6 @@ import mujoco
 import numpy as np
 
 from so101_nexus import (
-    ensure_ycb_assets,
     get_so101_mujoco_model_dir,
     get_so101_mujoco_model_path,
 )
@@ -40,8 +40,13 @@ from so101_nexus.mujoco.spawn_utils import (
     place_freejoint_slot,
     set_slot_contacts,
 )
-from so101_nexus.object_slots import ObjectSlot, build_object_scene_xml, extract_object_slots
-from so101_nexus.objects import CubeObject, SceneObject, YCBObject
+from so101_nexus.object_slots import (
+    ObjectSlot,
+    build_object_scene_xml,
+    ensure_scanned_mesh_assets,
+    extract_object_slots,
+)
+from so101_nexus.objects import CubeObject, ScannedMeshObject, SceneObject
 from so101_nexus.rewards import (
     object_static_ok,
     place_grasp_potential,
@@ -98,8 +103,8 @@ class PickAndPlaceEnv(SO101NexusMuJoCoBaseEnv):
         distractor_pool = list(config.distractors) if config.n_distractors else []
         scene_objects += distractor_pool
         for obj in scene_objects:
-            if isinstance(obj, YCBObject):
-                ensure_ycb_assets(obj.model_id)
+            if isinstance(obj, ScannedMeshObject):
+                ensure_scanned_mesh_assets(obj)
         slot_names = [f"pick_slot_{i}" for i in range(n_carried)] + [
             f"distractor_slot_{i}" for i in range(len(distractor_pool))
         ]

--- a/src/so101_nexus/mujoco/pick_env.py
+++ b/src/so101_nexus/mujoco/pick_env.py
@@ -6,7 +6,8 @@ backed by a MuJoCo scene built dynamically from a ``PickConfig`` object list.
 The shared object-slot machinery (XML builders, ``ObjectSlot`` metadata) lives
 in ``so101_nexus.object_slots``.
 
-Supported object types: ``CubeObject``, ``YCBObject``, ``MeshObject``.
+Supported object types: ``CubeObject``, ``ScannedMeshObject`` (``YCBObject``,
+``GSOObject``), ``MeshObject``.
 """
 
 from __future__ import annotations
@@ -18,7 +19,6 @@ import mujoco
 import numpy as np
 
 from so101_nexus import (
-    ensure_ycb_assets,
     get_so101_mujoco_model_dir,
     get_so101_mujoco_model_path,
 )
@@ -38,9 +38,10 @@ from so101_nexus.mujoco.spawn_utils import (
 from so101_nexus.object_slots import (
     ObjectSlot,
     build_object_scene_xml,
+    ensure_scanned_mesh_assets,
     extract_object_slots,
 )
-from so101_nexus.objects import SceneObject, YCBObject
+from so101_nexus.objects import ScannedMeshObject, SceneObject
 from so101_nexus.rewards import reach_progress
 from so101_nexus.scene import MUJOCO_SCENE_OPTION_XML
 
@@ -51,7 +52,8 @@ _SO101_XML = get_so101_mujoco_model_path()
 class PickEnv(SO101NexusMuJoCoBaseEnv):
     """Shared base for the MuJoCo pick environments (not directly registered).
 
-    Handles ``CubeObject``, ``YCBObject``, and ``MeshObject`` from
+    Handles ``CubeObject``, ``ScannedMeshObject`` (``YCBObject``, ``GSOObject``),
+    and ``MeshObject`` from
     ``PickConfig.objects``. One object is randomly chosen as the target per
     episode; ``config.n_distractors`` others are placed as distractors.
 
@@ -85,10 +87,10 @@ class PickEnv(SO101NexusMuJoCoBaseEnv):
         n_pool = len(scene_objects)
         n_slots = 1 + self._n_distractors
 
-        # Ensure YCB assets are on disk before building XML
+        # Ensure scanned-mesh assets (YCB, GSO) are on disk before building XML
         for obj in scene_objects:
-            if isinstance(obj, YCBObject):
-                ensure_ycb_assets(obj.model_id)
+            if isinstance(obj, ScannedMeshObject):
+                ensure_scanned_mesh_assets(obj)
 
         # Body slot names: one per pool object (not just active slots).
         # Slots beyond n_slots will be hidden off-world at reset time.

--- a/src/so101_nexus/mujoco/stack_cube.py
+++ b/src/so101_nexus/mujoco/stack_cube.py
@@ -21,7 +21,6 @@ import mujoco
 import numpy as np
 
 from so101_nexus import (
-    ensure_ycb_assets,
     get_so101_mujoco_model_dir,
     get_so101_mujoco_model_path,
 )
@@ -33,8 +32,13 @@ from so101_nexus.mujoco.spawn_utils import (
     place_freejoint_slot,
     sample_separated_positions,
 )
-from so101_nexus.object_slots import ObjectSlot, build_object_scene_xml, extract_object_slots
-from so101_nexus.objects import CubeObject, SceneObject, YCBObject
+from so101_nexus.object_slots import (
+    ObjectSlot,
+    build_object_scene_xml,
+    ensure_scanned_mesh_assets,
+    extract_object_slots,
+)
+from so101_nexus.objects import CubeObject, ScannedMeshObject, SceneObject
 from so101_nexus.rewards import (
     cube_stack_offset_ok,
     object_static_ok,
@@ -112,8 +116,8 @@ class StackCubeEnv(SO101NexusMuJoCoBaseEnv):
         # two-cube scene stays identical.
         distractor_pool = list(config.distractors) if config.n_distractors else []
         for obj in distractor_pool:
-            if isinstance(obj, YCBObject):
-                ensure_ycb_assets(obj.model_id)
+            if isinstance(obj, ScannedMeshObject):
+                ensure_scanned_mesh_assets(obj)
         scene_objects: list[SceneObject] = [cube_a_obj, cube_b_obj, *distractor_pool]
         slot_names = ["cube_a", "cube_b"] + [
             f"distractor_slot_{i}" for i in range(len(distractor_pool))

--- a/src/so101_nexus/object_slots.py
+++ b/src/so101_nexus/object_slots.py
@@ -5,7 +5,8 @@ of freejoint object bodies ("slots") into one compiled ``MjModel`` and select
 which slot is the active target (and which are distractors) per episode. This
 module holds the backend-neutral pieces of that machinery:
 
-- MJCF fragment builders for ``CubeObject``, ``YCBObject``, and ``MeshObject``.
+- MJCF fragment builders for ``CubeObject``, ``ScannedMeshObject`` (``YCBObject``,
+  ``GSOObject``), and ``MeshObject``.
 - The full scene builder ``build_object_scene_xml`` parameterized by the
   ``<option>`` preset and robot model path, so MuJoCo and Warp emit identical
   bodies and assets while differing only in the integrator/solver preset.
@@ -18,15 +19,30 @@ import this module without triggering MuJoCo env registration. No torch import.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import mujoco
 import numpy as np
 
-from so101_nexus.constants import COLOR_MAP
-from so101_nexus.objects import CubeObject, MeshObject, SceneObject, YCBObject
+from so101_nexus.constants import COLOR_MAP, GSO_MASSES
+from so101_nexus.gso_assets import (
+    ensure_gso_assets,
+    get_gso_collision_parts,
+    get_gso_texture_file,
+    get_gso_visual_mesh,
+)
+from so101_nexus.objects import (
+    CubeObject,
+    GSOObject,
+    MeshObject,
+    ScannedMeshObject,
+    SceneObject,
+    YCBObject,
+)
 from so101_nexus.scene import SCENE_LIGHTS_XML, SCENE_VISUAL_XML
 from so101_nexus.ycb_assets import (
+    ensure_ycb_assets,
     get_ycb_collision_parts,
     get_ycb_texture_file,
     get_ycb_visual_mesh,
@@ -34,13 +50,68 @@ from so101_nexus.ycb_assets import (
 from so101_nexus.ycb_geometry import get_mujoco_ycb_rest_pose
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
+    from pathlib import Path
+
+    from so101_nexus.mesh_assets import MeshCollisionPart
 
 # Default bounding radius used when an object exposes no geometry to measure.
 DEFAULT_BOUNDING_RADIUS = 0.025
 
-# Default per-object mass (kg) for YCB objects without a mass override.
+# Default per-object mass (kg) for YCB objects without a mass override. YCB
+# ships no per-object masses either, so every model uses this flat default;
+# GSO's hand-estimated per-model masses live in ``GSO_MASSES``.
 _DEFAULT_YCB_MASS = 0.01
+
+
+@dataclass(frozen=True, slots=True)
+class _ScannedMeshAccessors:
+    """Per-source functions ``build_object_scene_xml`` needs for a scanned mesh."""
+
+    ensure_assets: Callable[[str], Path]
+    collision_parts: Callable[[str], list[MeshCollisionPart]]
+    visual_mesh: Callable[[str], Path]
+    texture_file: Callable[[str], Path]
+    default_mass: Callable[[str], float]
+
+
+_SCANNED_MESH_ACCESSORS: dict[type[ScannedMeshObject], _ScannedMeshAccessors] = {
+    # Lambdas (not direct function refs) so a test's ``monkeypatch.setattr(
+    # object_slots, "get_ycb_collision_parts", ...)`` is honored: each call
+    # re-resolves the name from this module's globals instead of the binding
+    # captured when this dict literal ran.
+    YCBObject: _ScannedMeshAccessors(
+        ensure_assets=lambda model_id: ensure_ycb_assets(model_id),  # noqa: PLW0108
+        collision_parts=lambda model_id: get_ycb_collision_parts(model_id),  # noqa: PLW0108
+        visual_mesh=lambda model_id: get_ycb_visual_mesh(model_id),  # noqa: PLW0108
+        texture_file=lambda model_id: get_ycb_texture_file(model_id),  # noqa: PLW0108
+        default_mass=lambda _model_id: _DEFAULT_YCB_MASS,
+    ),
+    GSOObject: _ScannedMeshAccessors(
+        ensure_assets=lambda model_id: ensure_gso_assets(model_id),  # noqa: PLW0108
+        collision_parts=lambda model_id: get_gso_collision_parts(model_id),  # noqa: PLW0108
+        visual_mesh=lambda model_id: get_gso_visual_mesh(model_id),  # noqa: PLW0108
+        texture_file=lambda model_id: get_gso_texture_file(model_id),  # noqa: PLW0108
+        default_mass=lambda model_id: GSO_MASSES[model_id],
+    ),
+}
+
+
+def _accessors_for(obj: ScannedMeshObject) -> _ScannedMeshAccessors:
+    """Resolve the per-source accessors for a scanned-mesh object.
+
+    Uses ``isinstance`` (not an exact-type dict lookup) so a subclass of a
+    registered scanned-mesh type still resolves to its source's accessors.
+    """
+    for cls, accessors in _SCANNED_MESH_ACCESSORS.items():
+        if isinstance(obj, cls):
+            return accessors
+    raise KeyError(f"No scanned-mesh accessors registered for {type(obj)!r}")
+
+
+def ensure_scanned_mesh_assets(obj: ScannedMeshObject) -> None:
+    """Prefetch a scanned-mesh object's assets for its dataset source."""
+    _accessors_for(obj).ensure_assets(obj.model_id)
 
 
 def cube_bounding_radius(obj: CubeObject) -> float:
@@ -155,16 +226,17 @@ def build_object_scene_xml(
     body_entries = ""
 
     for i, (obj, slot) in enumerate(zip(objects, slot_names, strict=True)):
-        if isinstance(obj, YCBObject):
-            parts = get_ycb_collision_parts(obj.model_id)
+        if isinstance(obj, ScannedMeshObject):
+            accessors = _accessors_for(obj)
+            parts = accessors.collision_parts(obj.model_id)
             for k, part in enumerate(parts):
                 asset_entries += (
                     f'    <mesh name="pick_coll_{i}_{k}" file="{part.path.as_posix()}"/>\n'
                 )
-            visual_path = get_ycb_visual_mesh(obj.model_id).as_posix()
+            visual_path = accessors.visual_mesh(obj.model_id).as_posix()
             asset_entries += f'    <mesh name="pick_vis_{i}" file="{visual_path}"/>\n'
             material_name = None
-            texture_path = get_ycb_texture_file(obj.model_id)
+            texture_path = accessors.texture_file(obj.model_id)
             if texture_path.exists():
                 texture_name = f"pick_tex_{i}"
                 material_name = f"pick_mat_{i}"
@@ -176,7 +248,11 @@ def build_object_scene_xml(
                     f'    <material name="{material_name}" texture="{texture_name}" '
                     'texuniform="false"/>\n'
                 )
-            mass = obj.mass_override if obj.mass_override is not None else _DEFAULT_YCB_MASS
+            mass = (
+                obj.mass_override
+                if obj.mass_override is not None
+                else accessors.default_mass(obj.model_id)
+            )
             body_entries += mesh_xml_body(
                 slot,
                 i,
@@ -324,9 +400,10 @@ def extract_object_slots(
         qpos_addr = int(mjm.jnt_qposadr[joint_id])
         dof_addr = int(mjm.jnt_dofadr[joint_id])
 
-        if isinstance(obj, (YCBObject, MeshObject)):
+        if isinstance(obj, (ScannedMeshObject, MeshObject)):
             verts = _body_frame_collision_verts(mjm, geom_ids)
-            rest_quat, spawn_z = get_mujoco_ycb_rest_pose(verts)
+            model_id = obj.model_id if isinstance(obj, ScannedMeshObject) else None
+            rest_quat, spawn_z = get_mujoco_ycb_rest_pose(verts, model_id=model_id)
             # Footprint is measured in the resting orientation: the stable rest
             # pose can rotate a thin X/Y axis up, changing the horizontal extent
             # that the spawn separation samplers rely on.

--- a/src/so101_nexus/objects.py
+++ b/src/so101_nexus/objects.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
-from so101_nexus.constants import COLOR_MAP, YCB_OBJECTS, ColorName
+from so101_nexus.constants import COLOR_MAP, GSO_OBJECTS, YCB_OBJECTS, ColorName
 
 
 class SceneObject(ABC):
@@ -64,7 +64,35 @@ class CubeObject(SceneObject):
         return f"{self.color} cube"
 
 
-class YCBObject(SceneObject):
+class ScannedMeshObject(SceneObject):
+    """Shared base for dataset-scanned mesh objects (``YCBObject``, ``GSOObject``).
+
+    Both datasets feed the same convex-hull collision pipeline (see
+    ``so101_nexus.mesh_assets``): the visual mesh is the original scan, the
+    collision geometry is a measured convex decomposition of it, and a
+    surface-error gate keeps a single hull when that hull already matches the
+    scan. Backend builders dispatch on this base type rather than repeating
+    per-source ``isinstance`` checks.
+
+    Parameters
+    ----------
+    model_id : str
+        Dataset identifier. Must be a key in the subclass's object map.
+    mass_override : float, optional
+        Mass in kg to override the default mesh mass.
+    """
+
+    model_id: str
+    mass_override: float | None
+
+    def __init__(self, model_id: str, mass_override: float | None = None) -> None:
+        if mass_override is not None and mass_override <= 0:
+            raise ValueError(f"mass_override must be positive, got {mass_override}")
+        self.model_id = model_id
+        self.mass_override = mass_override
+
+
+class YCBObject(ScannedMeshObject):
     """YCB dataset object identified by ``model_id``.
 
     The visual mesh is the original YCB scan. The collision geometry is a
@@ -99,13 +127,45 @@ class YCBObject(SceneObject):
     ) -> None:
         if model_id not in YCB_OBJECTS:
             raise ValueError(f"model_id must be one of {list(YCB_OBJECTS)}, got {model_id!r}")
-        if mass_override is not None and mass_override <= 0:
-            raise ValueError(f"mass_override must be positive, got {mass_override}")
-        self.model_id = model_id
-        self.mass_override = mass_override
+        super().__init__(model_id, mass_override)
 
     def __repr__(self) -> str:  # noqa: D105
         return YCB_OBJECTS[self.model_id]
+
+
+class GSOObject(ScannedMeshObject):
+    """Google Scanned Objects (GSO) dataset object identified by ``model_id``.
+
+    Shares the ``YCBObject`` convex-hull collision pipeline (see
+    ``so101_nexus.mesh_assets``); the visual mesh is the mirrored GSO scan
+    (real-world scale, no rescale needed) and the collision geometry is a
+    measured convex decomposition of it, gated the same way as YCB's.
+
+    GSO ships no benchmark masses (unlike YCB, which has measured masses from
+    its physical objects), so the default mass for each ``model_id`` is a
+    hand-estimated volume-from-hull x assumed-density figure (see
+    ``GSO_MASSES`` in ``so101_nexus.constants``); pass ``mass_override`` to
+    replace it with a measured value.
+
+    Parameters
+    ----------
+    model_id : str
+        GSO dataset identifier. Must be a key in GSO_OBJECTS.
+    mass_override : float, optional
+        Mass in kg to override the default (hand-estimated) mesh mass.
+    """
+
+    def __init__(
+        self,
+        model_id: str,
+        mass_override: float | None = None,
+    ) -> None:
+        if model_id not in GSO_OBJECTS:
+            raise ValueError(f"model_id must be one of {list(GSO_OBJECTS)}, got {model_id!r}")
+        super().__init__(model_id, mass_override)
+
+    def __repr__(self) -> str:  # noqa: D105
+        return GSO_OBJECTS[self.model_id]
 
 
 class MeshObject(SceneObject):

--- a/src/so101_nexus/teleop/app.py
+++ b/src/so101_nexus/teleop/app.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, cast
 
 from so101_nexus.constants import COLOR_MAP, CUBE_COLOR_MAP, ColorName
 from so101_nexus.env_ids import Backend, env_ids_for_backend
-from so101_nexus.objects import CubeObject, SceneObject, YCBObject
+from so101_nexus.objects import CubeObject, GSOObject, SceneObject, YCBObject
 from so101_nexus.teleop.config_customization import (
     TeleopConfigOverrides,
     color_tuple_from_names,
@@ -177,6 +177,8 @@ def _object_spec_from_scene_object(obj: SceneObject) -> str | None:
         return f"cube:{obj.color}"
     if isinstance(obj, YCBObject):
         return f"ycb:{obj.model_id}"
+    if isinstance(obj, GSOObject):
+        return f"gso:{obj.model_id}"
     return None
 
 

--- a/src/so101_nexus/teleop/config_customization.py
+++ b/src/so101_nexus/teleop/config_customization.py
@@ -19,11 +19,12 @@ from typing import Any, cast
 from so101_nexus.constants import (
     COLOR_MAP,
     CUBE_COLOR_MAP,
+    GSO_OBJECTS,
     YCB_OBJECTS,
     ColorConfig,
     ColorName,
 )
-from so101_nexus.objects import CubeObject, MeshObject, SceneObject, YCBObject
+from so101_nexus.objects import CubeObject, GSOObject, MeshObject, SceneObject, YCBObject
 
 ConfigFactory = Callable[[str, object | None], object | dict[str, Any]]
 
@@ -80,9 +81,11 @@ def default_cube_color_choices() -> list[str]:
 
 def default_object_choices() -> list[str]:
     """Return built-in object spec strings for teleop UI controls."""
-    return [f"cube:{color}" for color in COLOR_MAP] + [
-        f"ycb:{model_id}" for model_id in YCB_OBJECTS
-    ]
+    return (
+        [f"cube:{color}" for color in COLOR_MAP]
+        + [f"ycb:{model_id}" for model_id in YCB_OBJECTS]
+        + [f"gso:{model_id}" for model_id in GSO_OBJECTS]
+    )
 
 
 def color_tuple_from_names(
@@ -107,9 +110,13 @@ def object_from_spec(spec: str) -> SceneObject:
         return CubeObject(color=_validate_color(parts[0], field_name="cube color"))
     if kind == "ycb" and len(parts) == 1:
         return YCBObject(model_id=parts[0])
+    if kind == "gso" and len(parts) == 1:
+        return GSOObject(model_id=parts[0])
     if kind == "mesh":
         raise ValueError("mesh objects must use mapping syntax to avoid ambiguous path parsing")
-    raise ValueError(f"object spec {spec!r} must be cube:<color> or ycb:<model_id>")
+    raise ValueError(
+        f"object spec {spec!r} must be cube:<color>, ycb:<model_id>, or gso:<model_id>"
+    )
 
 
 def object_from_mapping(raw: Mapping[str, Any]) -> SceneObject:
@@ -121,6 +128,8 @@ def object_from_mapping(raw: Mapping[str, Any]) -> SceneObject:
         )
     if kind == "ycb":
         return YCBObject(model_id=str(_required(raw, "model_id")))
+    if kind == "gso":
+        return GSOObject(model_id=str(_required(raw, "model_id")))
     if kind == "mesh":
         return MeshObject(
             collision_mesh_path=str(_required(raw, "collision_mesh_path")),
@@ -254,6 +263,8 @@ def object_to_mapping(obj: SceneObject) -> dict[str, Any]:
         }  # ponytail: schema drops mass, see object_from_mapping
     if isinstance(obj, YCBObject):
         return {"type": "ycb", "model_id": obj.model_id}
+    if isinstance(obj, GSOObject):
+        return {"type": "gso", "model_id": obj.model_id}
     if isinstance(obj, MeshObject):
         return {
             "type": "mesh",

--- a/src/so101_nexus/warp/pick_env.py
+++ b/src/so101_nexus/warp/pick_env.py
@@ -20,14 +20,17 @@ import numpy as np
 import torch
 
 from so101_nexus import (
-    ensure_ycb_assets,
     get_so101_mujoco_model_dir,
     get_so101_mujoco_model_path,
 )
 from so101_nexus.config import ControlMode, PickConfig, describe_pick_target
 from so101_nexus.constants import sample_color
-from so101_nexus.object_slots import build_object_scene_xml, extract_object_slots
-from so101_nexus.objects import SceneObject, YCBObject
+from so101_nexus.object_slots import (
+    build_object_scene_xml,
+    ensure_scanned_mesh_assets,
+    extract_object_slots,
+)
+from so101_nexus.objects import ScannedMeshObject, SceneObject
 from so101_nexus.observations import (
     GazeDirection,
     GazeState,
@@ -147,8 +150,8 @@ class WarpPickLiftVectorEnv(SO101NexusWarpVectorEnv):
             them ``pick_slot_{i}``.
         """
         for obj in scene_objects:
-            if isinstance(obj, YCBObject):
-                ensure_ycb_assets(obj.model_id)
+            if isinstance(obj, ScannedMeshObject):
+                ensure_scanned_mesh_assets(obj)
         self._n_total_slots = len(scene_objects)
         # ``_n_pool`` is the carried/distractor boundary: ``_select_active_slots``
         # draws from ``[0, _n_pool)`` and ``_parse_target_index`` range-checks a

--- a/src/so101_nexus/warp/stack_cube.py
+++ b/src/so101_nexus/warp/stack_cube.py
@@ -24,14 +24,17 @@ import numpy as np
 import torch
 
 from so101_nexus import (
-    ensure_ycb_assets,
     get_so101_mujoco_model_dir,
     get_so101_mujoco_model_path,
 )
 from so101_nexus.config import ControlMode, StackCubeConfig, describe_stack_target
 from so101_nexus.constants import COLOR_MAP, ColorName
-from so101_nexus.object_slots import build_object_scene_xml, extract_object_slots
-from so101_nexus.objects import CubeObject, SceneObject, YCBObject
+from so101_nexus.object_slots import (
+    build_object_scene_xml,
+    ensure_scanned_mesh_assets,
+    extract_object_slots,
+)
+from so101_nexus.objects import CubeObject, ScannedMeshObject, SceneObject
 from so101_nexus.observations import (
     GazeDirection,
     GazeState,
@@ -129,8 +132,8 @@ class WarpStackCubeVectorEnv(SO101NexusWarpVectorEnv):
         self._n_distractors = config.n_distractors
         distractor_pool = list(config.distractors) if self._n_distractors else []
         for obj in distractor_pool:
-            if isinstance(obj, YCBObject):
-                ensure_ycb_assets(obj.model_id)
+            if isinstance(obj, ScannedMeshObject):
+                ensure_scanned_mesh_assets(obj)
         self._d_pool = len(distractor_pool)
         self._d_offset = self._a_pool + self._b_pool
         scene_objects: list[SceneObject] = [

--- a/src/so101_nexus/ycb_assets.py
+++ b/src/so101_nexus/ycb_assets.py
@@ -1,124 +1,49 @@
-"""YCB mesh asset management - downloads from HuggingFace on demand."""
+"""YCB mesh asset management - downloads from HuggingFace on demand.
+
+The cache-check/download/decompose/manifest orchestration is source-agnostic
+and lives in ``so101_nexus.mesh_assets`` as ``ensure_scanned_mesh_assets``,
+shared with ``so101_nexus.gso_assets``. This module supplies only what is
+specific to the ai-habitat/ycb layout: the repository id, the cache directory,
+and the ``fetch``/``ensure_texture`` hooks that download ``textured.glb``
+scans, convert them to OBJ, and extract the embedded texture.
+"""
 
 from __future__ import annotations
 
-import hashlib
-import importlib
-import json
 import logging
-import math
 import os
-from collections.abc import Iterator, Mapping
-from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol, TypedDict, cast
 
 from so101_nexus.constants import YCB_OBJECTS
-
-if TYPE_CHECKING:
-    import numpy as np
+from so101_nexus.mesh_assets import (
+    _COACD_SETTINGS,  # noqa: F401  (re-exported: patched by tests/core/test_ycb.py)
+    _FALLBACK_DECOMPOSER,  # noqa: F401  (re-exported: patched by tests/core/test_ycb.py)
+    _HULL_DECOMPOSER,  # noqa: F401  (re-exported: patched by tests/core/test_ycb.py)
+    _HULL_GAP_GATE_M,  # noqa: F401  (re-exported: patched by tests/core/test_ycb.py)
+    _HULL_GAP_MAX_GATE_M,  # noqa: F401  (re-exported: patched by tests/core/test_ycb.py)
+    _HULL_GAP_SAMPLES,  # noqa: F401  (re-exported: patched by tests/core/test_ycb.py)
+    MeshCollisionPart,
+    _build_collision_geometry,  # noqa: F401  (re-exported: patched by tests/core/test_ycb.py)
+    _collision_parts_are_current,  # noqa: F401  (re-exported: patched by tests/core/test_ycb.py)
+    _decomposer_id,  # noqa: F401  (re-exported: patched by tests/core/test_ycb.py)
+    _iter_texture_meshes,
+    _load_exportable_mesh,
+    _read_manifest,  # noqa: F401  (re-exported: patched by tests/core/test_ycb.py)
+    _sha256,  # noqa: F401  (re-exported: patched by tests/core/test_ycb.py)
+    _texture_image_from_material,
+    _write_collision_parts,  # noqa: F401  (re-exported: called directly by tests/core/test_ycb.py)
+    ensure_scanned_mesh_assets,
+    read_collision_parts,
+)
 
 logger = logging.getLogger(__name__)
 
 _HF_REPO_ID = os.environ.get("SO101_YCB_HF_REPO", "ai-habitat/ycb")
 _CACHE_DIR = Path.home() / ".cache" / "so101_nexus" / "ycb"
 
-_COLLISION_SUBDIR = "collision_v3"
-"""Cache subdirectory for collision parts built with a measured surface-error gate."""
-
-_MANIFEST_NAME = "manifest.json"
-
-_FALLBACK_DECOMPOSER = "convex_hull"
-"""Manifest marker for a hull built without the ``decomp`` extra."""
-
-_HULL_DECOMPOSER = "none (hull kept)"
-"""Manifest marker for a measured hull that does not need decomposition."""
-
-_HULL_GAP_SAMPLES = 20_000
-_HULL_GAP_SEED = 0
-_HULL_GAP_GATE_M = 0.003
-_HULL_GAP_MAX_GATE_M = 0.010
-
-
-class _CoacdSettings(TypedDict):
-    threshold: float
-    max_convex_hull: int
-    preprocess_mode: str
-    preprocess_resolution: int
-    resolution: int
-    mcts_nodes: int
-    mcts_iterations: int
-    mcts_max_depth: int
-    pca: bool
-    merge: bool
-    decimate: bool
-    max_ch_vertex: int
-    seed: int
-
-
-_COACD_SETTINGS: _CoacdSettings = {
-    "threshold": 0.03,
-    "max_convex_hull": -1,
-    "preprocess_mode": "auto",
-    "preprocess_resolution": 50,
-    "resolution": 2000,
-    "mcts_nodes": 20,
-    "mcts_iterations": 150,
-    "mcts_max_depth": 3,
-    "pca": False,
-    "merge": True,
-    "decimate": True,
-    "max_ch_vertex": 128,
-    "seed": 0,
-}
-"""Audited CoACD configuration for the ten supported YCB scans."""
-
-
-class _ExportableMesh(Protocol):
-    vertices: np.ndarray
-    faces: np.ndarray
-
-    @property
-    def volume(self) -> float: ...
-
-    def export(self, file_obj: str, file_type: str | None = None) -> object: ...
-
-    @property
-    def convex_hull(self) -> _ExportableMesh: ...
-
-
-class _TextureImage(Protocol):
-    def save(self, fp: str, format: str | None = None) -> object: ...
-
-
-@dataclass(frozen=True, slots=True)
-class YCBCollisionPart:
-    """One convex part of a YCB model's collision decomposition.
-
-    Attributes
-    ----------
-    path:
-        OBJ file holding the convex part.
-    mass_fraction:
-        Share of the object's mass carried by this part, proportional to its
-        volume. A model's fractions sum to 1, so the body's total mass does not
-        depend on how many parts the decomposition produced.
-    """
-
-    path: Path
-    mass_fraction: float
-
-
-@dataclass(frozen=True, slots=True)
-class _CollisionBuild:
-    """Collision parts and the inputs that produced them."""
-
-    parts: tuple[_ExportableMesh, ...]
-    decomposer: str
-    decomposed: bool
-    settings: Mapping[str, object] | None
-    hull_gap_p95_m: float | None
-    hull_gap_max_m: float | None
+# Backward-compatible public alias; the dataclass itself now lives in
+# ``mesh_assets`` so YCB and GSO share one type.
+YCBCollisionPart = MeshCollisionPart
 
 
 def _validate_model_id(model_id: str) -> None:
@@ -138,16 +63,6 @@ def get_ycb_texture_file(model_id: str) -> Path:
     return _CACHE_DIR / model_id / "texture.png"
 
 
-def _load_exportable_mesh(mesh_path: Path) -> _ExportableMesh:
-    """Load a mesh file as one object with ``export`` and ``convex_hull``."""
-    import trimesh
-
-    scene_or_mesh = trimesh.load(str(mesh_path), force="mesh")
-    if isinstance(scene_or_mesh, trimesh.Scene):
-        return cast("_ExportableMesh", scene_or_mesh.dump(concatenate=True))
-    return cast("_ExportableMesh", scene_or_mesh)
-
-
 def _convert_glb_to_obj(glb_path: Path, obj_path: Path) -> None:
     """Convert a GLB mesh to OBJ format using trimesh."""
     mesh = _load_exportable_mesh(glb_path)
@@ -156,192 +71,9 @@ def _convert_glb_to_obj(glb_path: Path, obj_path: Path) -> None:
 
 def _collision_dir(model_id: str) -> Path:
     """Return the versioned directory holding a model's convex collision parts."""
+    from so101_nexus.mesh_assets import _COLLISION_SUBDIR
+
     return _CACHE_DIR / model_id / _COLLISION_SUBDIR
-
-
-def _decomposer_id() -> str:
-    """Identify the installed generator for cache keying."""
-    try:
-        from importlib.metadata import PackageNotFoundError, version
-
-        for package in ("threadpoolctl", "rtree"):
-            version(package)
-        return f"coacd {version('coacd')}"
-    except (ImportError, PackageNotFoundError):
-        return _FALLBACK_DECOMPOSER
-
-
-def _hull_surface_gap(
-    hull: _ExportableMesh,
-    mesh: _ExportableMesh,
-) -> tuple[float, float]:
-    """Return the p95 and maximum distances from a hull surface to a scan."""
-    import numpy as np
-    import trimesh
-
-    points, _ = trimesh.sample.sample_surface(
-        hull,
-        _HULL_GAP_SAMPLES,
-        seed=_HULL_GAP_SEED,
-    )
-    scan = trimesh.Trimesh(vertices=mesh.vertices, faces=mesh.faces, process=False)
-    scan.update_faces(scan.nondegenerate_faces())
-    distances = np.asarray(trimesh.proximity.closest_point(scan, points)[1], dtype=np.float64)
-    if distances.size == 0 or not np.isfinite(distances).all():
-        raise ValueError("The hull surface distance contains no finite samples.")
-    return float(np.percentile(distances, 95)), float(distances.max())
-
-
-def _build_collision_geometry(mesh: _ExportableMesh) -> _CollisionBuild:
-    """Build a measured hull or a collision-aware convex decomposition."""
-    hull = mesh.convex_hull
-    try:
-        import coacd
-        import trimesh
-        from threadpoolctl import threadpool_limits
-
-        importlib.import_module("rtree")
-    except ImportError as exc:
-        logger.warning(
-            "%s is not installed: collision geometry stays a single convex hull. "
-            "Install so101-nexus[decomp] for measured multi-hull geometry.",
-            exc.name or "a decomposition dependency",
-        )
-        return _CollisionBuild(
-            parts=(hull,),
-            decomposer=_FALLBACK_DECOMPOSER,
-            decomposed=False,
-            settings=None,
-            hull_gap_p95_m=None,
-            hull_gap_max_m=None,
-        )
-
-    hull_gap_p95_m, hull_gap_max_m = _hull_surface_gap(hull, mesh)
-    logger.debug(
-        "hull surface gap: p95=%.6f m, max=%.6f m",
-        hull_gap_p95_m,
-        hull_gap_max_m,
-    )
-    if hull_gap_p95_m <= _HULL_GAP_GATE_M and hull_gap_max_m <= _HULL_GAP_MAX_GATE_M:
-        return _CollisionBuild(
-            parts=(hull,),
-            decomposer=_HULL_DECOMPOSER,
-            decomposed=False,
-            settings=None,
-            hull_gap_p95_m=hull_gap_p95_m,
-            hull_gap_max_m=hull_gap_max_m,
-        )
-
-    coacd.set_log_level("error")
-    with threadpool_limits(limits=1, user_api="openmp"):
-        pieces = coacd.run_coacd(
-            coacd.Mesh(mesh.vertices, mesh.faces),
-            **_COACD_SETTINGS,
-        )
-    parts = tuple(
-        cast("_ExportableMesh", trimesh.Trimesh(vertices, faces)) for vertices, faces in pieces
-    )
-    parts = tuple(part for part in parts if abs(part.volume) > 0.0)
-    if not parts:
-        raise RuntimeError("CoACD produced no positive-volume collision parts.")
-    max_vertices = int(_COACD_SETTINGS["max_ch_vertex"])
-    if any(len(part.vertices) > max_vertices for part in parts):
-        raise RuntimeError(
-            f"CoACD produced a collision part with more than {max_vertices} vertices."
-        )
-    return _CollisionBuild(
-        parts=parts,
-        decomposer=_decomposer_id(),
-        decomposed=True,
-        settings=_COACD_SETTINGS,
-        hull_gap_p95_m=hull_gap_p95_m,
-        hull_gap_max_m=hull_gap_max_m,
-    )
-
-
-def _sha256(path: Path) -> str:
-    """Return the SHA-256 digest of a file."""
-    digest = hashlib.sha256()
-    with path.open("rb") as stream:
-        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def _write_collision_parts(
-    mesh: _ExportableMesh,
-    out_dir: Path,
-    *,
-    model_id: str,
-    source_path: Path,
-) -> None:
-    """Export collision parts and their generation manifest into ``out_dir``."""
-    build = _build_collision_geometry(mesh)
-    volumes = [abs(part.volume) for part in build.parts]
-    total = sum(volumes)
-    fractions = [volume / total for volume in volumes]
-
-    out_dir.mkdir(parents=True, exist_ok=True)
-    manifest_path = out_dir / _MANIFEST_NAME
-    manifest_path.unlink(missing_ok=True)
-    for stale in out_dir.glob("collision_*.obj"):
-        stale.unlink()
-    entries = []
-    for index, (part, volume, fraction) in enumerate(
-        zip(build.parts, volumes, fractions, strict=True)
-    ):
-        name = f"collision_{index:03d}.obj"
-        part.export(str(out_dir / name), file_type="obj")
-        entries.append(
-            {
-                "file": name,
-                "mass_fraction": fraction,
-                "volume_m3": volume,
-                "n_vertices": len(part.vertices),
-            }
-        )
-    manifest = {
-        "model_id": model_id,
-        "source": source_path.name,
-        "source_sha256": _sha256(source_path),
-        "decomposer": build.decomposer,
-        "settings": dict(build.settings) if build.settings is not None else None,
-        "hull_gap_p95_m": build.hull_gap_p95_m,
-        "hull_gap_max_m": build.hull_gap_max_m,
-        "hull_gap_gate_m": _HULL_GAP_GATE_M,
-        "hull_gap_max_gate_m": _HULL_GAP_MAX_GATE_M,
-        "decomposed": build.decomposed,
-        "mass_split": "part volume / total part volume",
-        "parts": entries,
-    }
-    pending = manifest_path.with_suffix(".json.pending")
-    pending.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
-    os.replace(pending, manifest_path)
-
-
-def _texture_image_from_material(material: object) -> _TextureImage | None:
-    for attr in ("image", "baseColorTexture"):
-        value = getattr(material, attr, None)
-        if value is None:
-            continue
-        image = getattr(value, "image", value)
-        if image is not None:
-            return cast("_TextureImage", image)
-    return None
-
-
-def _iter_texture_meshes(scene_or_mesh: object, scene_type: type) -> Iterator[object]:
-    if isinstance(scene_or_mesh, scene_type):
-        geometry = getattr(scene_or_mesh, "geometry", None)
-        if isinstance(geometry, Mapping):
-            yield from geometry.values()
-        to_geometry = getattr(scene_or_mesh, "to_geometry", None)
-        if callable(to_geometry):
-            yield to_geometry()
-        elif callable(dump := getattr(scene_or_mesh, "dump", None)):
-            yield dump(concatenate=True)
-    else:
-        yield scene_or_mesh
 
 
 def _extract_glb_texture(glb_path: Path, texture_path: Path) -> bool:
@@ -381,72 +113,12 @@ def _texture_glb_path(model_id: str) -> Path:
     return orig if orig.exists() else base / "textured.glb"
 
 
-def _manifest_part_is_usable(part: object) -> bool:
-    if not isinstance(part, Mapping):
-        return False
-    part = cast("Mapping[str, object]", part)
-    name = part.get("file")
-    fraction_value = part.get("mass_fraction")
-    if not isinstance(name, str) or Path(name).name != name:
-        return False
-    if isinstance(fraction_value, bool) or not isinstance(fraction_value, (int, float)):
-        return False
-    fraction = float(fraction_value)
-    return math.isfinite(fraction) and fraction >= 0.0
-
-
-def _read_manifest(collision_dir: Path) -> dict | None:
-    """Return a usable collision manifest, or ``None``."""
-    try:
-        manifest = json.loads((collision_dir / _MANIFEST_NAME).read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        return None
-    if not isinstance(manifest, dict) or not isinstance(manifest.get("parts"), list):
-        return None
-    parts = manifest["parts"]
-    if not parts or not all(_manifest_part_is_usable(part) for part in parts):
-        return None
-    return manifest
-
-
-def _manifest_source_matches(collision_dir: Path, manifest: Mapping[str, object]) -> bool:
-    source = collision_dir.parent / str(manifest.get("source", ""))
-    try:
-        return manifest.get("source_sha256") == _sha256(source)
-    except OSError:
-        return False
-
-
-def _manifest_generator_matches(manifest: Mapping[str, object]) -> bool:
-    current = _decomposer_id()
-    if current == _FALLBACK_DECOMPOSER:
-        return True
-    gates_match = (
-        manifest.get("hull_gap_gate_m") == _HULL_GAP_GATE_M
-        and manifest.get("hull_gap_max_gate_m") == _HULL_GAP_MAX_GATE_M
-    )
-    if not gates_match:
-        return False
-    if manifest.get("decomposed"):
-        return manifest.get("decomposer") == current and manifest.get("settings") == _COACD_SETTINGS
-    return (
-        manifest.get("decomposer") == _HULL_DECOMPOSER
-        and manifest.get("settings") is None
-        and manifest.get("hull_gap_p95_m") is not None
-        and manifest.get("hull_gap_max_m") is not None
-    )
-
-
-def _collision_parts_are_current(collision_dir: Path) -> bool:
-    """Return true when all cached parts match the scan and generator inputs."""
-    manifest = _read_manifest(collision_dir)
-    if manifest is None:
-        return False
-    parts_exist = all((collision_dir / part["file"]).is_file() for part in manifest["parts"])
-    return (
-        parts_exist
-        and _manifest_source_matches(collision_dir, manifest)
-        and _manifest_generator_matches(manifest)
+def _warn_texture_extraction_failed(model_id: str, glb_path: Path) -> None:
+    logger.warning(
+        "Failed to extract texture for YCB %r from %s; "
+        "object will render in MuJoCo's default gray.",
+        model_id,
+        glb_path,
     )
 
 
@@ -465,70 +137,51 @@ def ensure_ycb_assets(model_id: str) -> Path:
     """
     _validate_model_id(model_id)
     mesh_dir = _CACHE_DIR / model_id
-
     collision_dir = _collision_dir(model_id)
     visual_path = mesh_dir / "visual.obj"
     texture_path = mesh_dir / "texture.png"
     glb_path = _CACHE_DIR / "meshes" / model_id / "google_16k" / "textured.glb"
     orig_path = glb_path.with_suffix(".glb.orig")
 
-    if _collision_parts_are_current(collision_dir) and visual_path.exists():
-        if not texture_path.exists():
-            if not glb_path.exists() or not orig_path.exists():
-                from huggingface_hub import snapshot_download
+    def _snapshot_download() -> None:
+        from huggingface_hub import snapshot_download
 
-                snapshot_download(
-                    repo_id=_HF_REPO_ID,
-                    repo_type="dataset",
-                    allow_patterns=[f"meshes/{model_id}/*"],
-                    local_dir=str(_CACHE_DIR),
-                )
-            preferred_glb = _texture_glb_path(model_id)
-            if preferred_glb.exists():
-                extracted = _extract_glb_texture(preferred_glb, texture_path)
-                if not extracted:
-                    logger.warning(
-                        "Failed to extract texture for YCB %r from %s; "
-                        "object will render in MuJoCo's default gray.",
-                        model_id,
-                        preferred_glb,
-                    )
-        return mesh_dir
-
-    from huggingface_hub import snapshot_download
-
-    snapshot_download(
-        repo_id=_HF_REPO_ID,
-        repo_type="dataset",
-        allow_patterns=[f"meshes/{model_id}/*"],
-        local_dir=str(_CACHE_DIR),
-    )
-
-    mesh_dir.mkdir(parents=True, exist_ok=True)
-    _convert_glb_to_obj(glb_path, visual_path)
-
-    _write_collision_parts(
-        _load_exportable_mesh(visual_path),
-        collision_dir,
-        model_id=model_id,
-        source_path=visual_path,
-    )
-    # Single-hull cache from a release before the decomposition; nothing reads it.
-    (mesh_dir / "collision.obj").unlink(missing_ok=True)
-    preferred_glb = _texture_glb_path(model_id)
-    extracted = _extract_glb_texture(preferred_glb, texture_path)
-    if not extracted:
-        logger.warning(
-            "Failed to extract texture for YCB %r from %s; "
-            "object will render in MuJoCo's default gray.",
-            model_id,
-            preferred_glb,
+        snapshot_download(
+            repo_id=_HF_REPO_ID,
+            repo_type="dataset",
+            allow_patterns=[f"meshes/{model_id}/*"],
+            local_dir=str(_CACHE_DIR),
         )
 
-    return mesh_dir
+    def _ensure_texture() -> None:
+        if not glb_path.exists() or not orig_path.exists():
+            _snapshot_download()
+        preferred_glb = _texture_glb_path(model_id)
+        if preferred_glb.exists() and not _extract_glb_texture(preferred_glb, texture_path):
+            _warn_texture_extraction_failed(model_id, preferred_glb)
+
+    def _fetch() -> None:
+        _snapshot_download()
+        mesh_dir.mkdir(parents=True, exist_ok=True)
+        _convert_glb_to_obj(glb_path, visual_path)
+        # Single-hull cache from a release before the decomposition; nothing reads it.
+        (mesh_dir / "collision.obj").unlink(missing_ok=True)
+        preferred_glb = _texture_glb_path(model_id)
+        if not _extract_glb_texture(preferred_glb, texture_path):
+            _warn_texture_extraction_failed(model_id, preferred_glb)
+
+    return ensure_scanned_mesh_assets(
+        model_id=model_id,
+        mesh_dir=mesh_dir,
+        collision_dir=collision_dir,
+        visual_path=visual_path,
+        texture_path=texture_path,
+        fetch=_fetch,
+        ensure_texture=_ensure_texture,
+    )
 
 
-def get_ycb_collision_parts(model_id: str) -> list[YCBCollisionPart]:
+def get_ycb_collision_parts(model_id: str) -> list[MeshCollisionPart]:
     """Return the cached convex collision parts of a YCB model, in export order.
 
     Raises
@@ -538,17 +191,7 @@ def get_ycb_collision_parts(model_id: str) -> list[YCBCollisionPart]:
         :func:`ensure_ycb_assets` first.
     """
     _validate_model_id(model_id)
-    manifest = _read_manifest(_collision_dir(model_id))
-    if manifest is None:
-        raise FileNotFoundError(
-            f"No usable collision decomposition cached for {model_id!r}; "
-            f"call ensure_ycb_assets({model_id!r}) first."
-        )
-    parts_dir = _collision_dir(model_id)
-    return [
-        YCBCollisionPart(parts_dir / entry["file"], float(entry["mass_fraction"]))
-        for entry in manifest["parts"]
-    ]
+    return read_collision_parts(_collision_dir(model_id), f"ensure_ycb_assets({model_id!r})")
 
 
 def get_ycb_collision_meshes(model_id: str) -> list[Path]:

--- a/src/so101_nexus/ycb_geometry.py
+++ b/src/so101_nexus/ycb_geometry.py
@@ -4,37 +4,117 @@ from __future__ import annotations
 
 import numpy as np
 
+# ``get_mujoco_ycb_rest_pose``'s AABB heuristic is a guess, not a physics
+# result. ``scripts/validate_object_rest_poses.py`` settle-tests every
+# supported model and records a corrected quaternion here when the
+# heuristic pose is not settle-stable. It also runs a non-gating grasp
+# screen (advisory only - see its module docstring for methodology and
+# limits); ``GRASP_ADVISORY`` names objects whose narrowest sampled
+# cross-section exceeds the gripper's full mechanical opening at every
+# tested pose. Full results: src/so101_nexus/gso_pose_validation_results.json.
+_TOO_WIDE = "no sampled slice fits the gripper's opening at any height/yaw; too wide to grasp."
+GRASP_ADVISORY: dict[str, str] = {
+    "037_scissors": _TOO_WIDE,
+    "Shurtape_Gaffers_Tape_Silver_2_x_60_yd": _TOO_WIDE,
+    "Big_O_Sponges_Assorted_Cellulose_12_pack": _TOO_WIDE,
+    "Nestle_Raisinets_Milk_Chocolate_35_oz_992_g": _TOO_WIDE,
+}
 
-def get_mujoco_ycb_rest_pose(verts: np.ndarray, margin: float = 0.002) -> tuple[np.ndarray, float]:
+POSE_OVERRIDES: dict[str, tuple[float, float, float, float]] = {
+    "030_fork": (
+        0.9487688362649201,
+        0.05192379329375049,
+        0.015387636719621154,
+        0.3112954154154558,
+    ),
+    "032_knife": (
+        0.9370767109522925,
+        0.3489106280209861,
+        0.010219865920332777,
+        -0.006645734376632088,
+    ),
+    "040_large_marker": (
+        0.9868061963150316,
+        -0.0036756068674924118,
+        0.1618641914243856,
+        6.605258629754342e-05,
+    ),
+    "043_phillips_screwdriver": (
+        0.9869994957430818,
+        0.02660164354705449,
+        0.02117028873260648,
+        0.1570864947679341,
+    ),
+    "Pony_C_Clamp_1440": (
+        0.7252865768758933,
+        -0.2984139667764899,
+        0.36029176430034454,
+        -0.5050725991515618,
+    ),
+    "OXO_Soft_Works_Can_Opener_SnapLock": (
+        0.9124123190985273,
+        -0.0022104422621626748,
+        -0.005014702029669815,
+        0.40923553934843887,
+    ),
+    "Shurtape_Gaffers_Tape_Silver_2_x_60_yd": (
+        0.700240155426634,
+        -0.01148416578855433,
+        0.7137190536397818,
+        -0.01170261234763929,
+    ),
+}
+
+
+def _quat_to_rotmat(quat: np.ndarray) -> np.ndarray:
+    """Return the 3x3 rotation matrix for a wxyz quaternion."""
+    w, x, y, z = quat
+    return np.array(
+        [
+            [1 - 2 * (y * y + z * z), 2 * (x * y - z * w), 2 * (x * z + y * w)],
+            [2 * (x * y + z * w), 1 - 2 * (x * x + z * z), 2 * (y * z - x * w)],
+            [2 * (x * z - y * w), 2 * (y * z + x * w), 1 - 2 * (x * x + y * y)],
+        ]
+    )
+
+
+def get_mujoco_ycb_rest_pose(
+    verts: np.ndarray, margin: float = 0.002, model_id: str | None = None
+) -> tuple[np.ndarray, float]:
     """Return a stable object rest quaternion and spawn Z from mesh vertices.
 
-    Objects are rotated so their thinnest axis points up (Z), producing a
-    flat, stable rest pose. The quaternion uses the convention (w, x, y, z).
-    ``verts`` are read in the body frame, so ``spawn_z`` is the height the body
-    origin needs for the rotated mesh to clear the floor by ``margin``; vertices
+    ``model_id`` looks up ``POSE_OVERRIDES`` first: a settle-test-validated
+    correction for objects whose thin-axis-up heuristic proved unstable.
+    Without a match (``model_id=None`` or not in the table), objects are
+    rotated so their thinnest axis points up (Z), producing a flat, guessed
+    rest pose. The quaternion uses the convention (w, x, y, z). ``verts`` are
+    read in the body frame, so ``spawn_z`` is the height the body origin
+    needs for the rotated mesh to clear the floor by ``margin``; vertices
     that are not centered on the origin are handled.
     """
+    if model_id is not None and model_id in POSE_OVERRIDES:
+        quat = np.array(POSE_OVERRIDES[model_id])
+        rotated = verts @ _quat_to_rotmat(quat).T
+        spawn_z = float(-np.min(rotated[:, 2])) + margin
+        return quat, spawn_z
+
     extents = np.ptp(verts, axis=0)
     thin_axis = int(np.argmin(extents))
 
-    # sqrt(2)/2 ≈ 0.7071068 - the quaternion component for a 90-degree rotation.
+    # sqrt(2)/2 - the quaternion component for a 90-degree rotation.
     _SQRT_HALF = 0.7071068
 
     if thin_axis == 2:
-        # Thin axis is already Z - no rotation needed.
         quat = np.array([1.0, 0.0, 0.0, 0.0])
         spawn_z = float(-np.min(verts[:, 2])) + margin
     elif thin_axis == 0:
-        # Thin axis is X - rotate 90 degrees around Y to bring X to Z, which maps
-        # (x, y, z) to (z, y, -x). Negating any column other than the new Z would
-        # invert the measured height, which cancels only for centered vertices.
+        # X up: rotate 90 deg around Y, mapping (x, y, z) -> (z, y, -x).
         quat = np.array([_SQRT_HALF, 0.0, _SQRT_HALF, 0.0])
         rotated = verts[:, [2, 1, 0]].copy()
         rotated[:, 2] *= -1
         spawn_z = float(-np.min(rotated[:, 2])) + margin
     else:
-        # Thin axis is Y - rotate 90 degrees around X to bring Y to Z, which maps
-        # (x, y, z) to (x, -z, y).
+        # Y up: rotate 90 deg around X, mapping (x, y, z) -> (x, -z, y).
         quat = np.array([_SQRT_HALF, _SQRT_HALF, 0.0, 0.0])
         rotated = verts[:, [0, 2, 1]].copy()
         rotated[:, 1] *= -1

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1168,22 +1168,22 @@ class TestPickAndPlaceObjectPool:
     def test_explicit_object_pool(self):
         from so101_nexus.objects import YCBObject
 
-        cfg = PickAndPlaceConfig(objects=[YCBObject("011_banana")])
+        cfg = PickAndPlaceConfig(objects=[YCBObject("009_gelatin_box")])
         pool = cfg.object_pool()
         assert len(pool) == 1
         assert isinstance(pool[0], YCBObject)
-        assert cfg.task_description == "Pick up the banana and place it on the blue circle."
+        assert cfg.task_description == "Pick up the gelatin box and place it on the blue circle."
 
     def test_objects_with_non_default_cube_sugar_raises(self):
         from so101_nexus.objects import YCBObject
 
         with pytest.raises(ValueError, match="object pool and non-default cube sugar"):
-            PickAndPlaceConfig(objects=[YCBObject("011_banana")], cube_colors="green")
+            PickAndPlaceConfig(objects=[YCBObject("009_gelatin_box")], cube_colors="green")
 
     def test_objects_with_default_cube_sugar_ok(self):
         from so101_nexus.objects import YCBObject
 
-        cfg = PickAndPlaceConfig(objects=[YCBObject("011_banana")])
+        cfg = PickAndPlaceConfig(objects=[YCBObject("009_gelatin_box")])
         assert cfg.cube_colors == "red"
 
     def test_min_object_target_separation_alias(self):

--- a/tests/core/test_gso.py
+++ b/tests/core/test_gso.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import json
+import types
+from pathlib import Path
+
+import pytest
+
+from so101_nexus import gso_assets, mesh_assets
+from so101_nexus.constants import GSO_MASSES, GSO_OBJECTS
+from so101_nexus.gso_assets import get_gso_mesh_dir
+
+EXPECTED_MODEL_IDS = list(GSO_OBJECTS)
+
+
+class TestGSOConstants:
+    def test_gso_objects_values_are_strings(self):
+        for model_id, name in GSO_OBJECTS.items():
+            assert isinstance(name, str), f"{model_id} name is not a string"
+            assert len(name) > 0, f"{model_id} name is empty"
+
+    def test_every_object_has_a_mass(self):
+        assert set(GSO_MASSES) == set(GSO_OBJECTS)
+        for model_id, mass in GSO_MASSES.items():
+            assert mass > 0, f"{model_id} mass is not positive"
+
+
+class TestGSOAssets:
+    def test_get_gso_mesh_dir_returns_path(self):
+        result = get_gso_mesh_dir("Pony_C_Clamp_1440")
+        assert isinstance(result, Path)
+
+    def test_get_gso_mesh_dir_invalid_model_raises(self):
+        with pytest.raises(ValueError, match="model_id"):
+            get_gso_mesh_dir("invalid_model")
+
+    def test_get_gso_mesh_dir_contains_model_id(self):
+        for model_id in EXPECTED_MODEL_IDS:
+            path = get_gso_mesh_dir(model_id)
+            assert model_id in str(path)
+
+
+def _patch_module(monkeypatch: pytest.MonkeyPatch, name: str, module: object) -> None:
+    import sys
+
+    monkeypatch.setitem(sys.modules, name, module)
+
+
+def test_get_gso_texture_file_returns_cache_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr(gso_assets, "_CACHE_DIR", tmp_path)
+
+    assert gso_assets.get_gso_texture_file("CoQ10") == tmp_path / "CoQ10" / "texture.png"
+
+
+def _write_cached_parts(mesh_dir: Path, files: tuple[str, ...] = ("collision_000.obj",)) -> Path:
+    """Write a collision-v3 cache entry and return its directory."""
+    mesh_dir.mkdir(parents=True, exist_ok=True)
+    source = mesh_dir / "visual.obj"
+    source.write_text("v", encoding="utf-8")
+    parts_dir = mesh_dir / "collision_v3"
+    parts_dir.mkdir(parents=True, exist_ok=True)
+    for name in files:
+        (parts_dir / name).write_text("c", encoding="utf-8")
+    manifest = {
+        "model_id": mesh_dir.name,
+        "source": source.name,
+        "source_sha256": mesh_assets._sha256(source),
+        "decomposer": mesh_assets._HULL_DECOMPOSER,
+        "settings": None,
+        "hull_gap_p95_m": 0.0,
+        "hull_gap_max_m": 0.0,
+        "hull_gap_gate_m": mesh_assets._HULL_GAP_GATE_M,
+        "hull_gap_max_gate_m": mesh_assets._HULL_GAP_MAX_GATE_M,
+        "decomposed": False,
+        "parts": [{"file": name, "mass_fraction": 1.0 / len(files)} for name in files],
+    }
+    (parts_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return parts_dir
+
+
+def test_ensure_gso_assets_cache_hit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr(gso_assets, "_CACHE_DIR", tmp_path)
+    model_id = "Pony_C_Clamp_1440"
+    mesh_dir = tmp_path / model_id
+    mesh_dir.mkdir(parents=True)
+    _write_cached_parts(mesh_dir)
+    (mesh_dir / "visual.obj").write_text("v", encoding="utf-8")
+    (mesh_dir / "texture.png").write_text("t", encoding="utf-8")
+
+    def _unexpected_snapshot_download(**_kwargs):
+        raise AssertionError("snapshot_download should not be called on cache hit")
+
+    _patch_module(
+        monkeypatch,
+        "huggingface_hub",
+        types.SimpleNamespace(snapshot_download=_unexpected_snapshot_download),
+    )
+
+    assert gso_assets.ensure_gso_assets(model_id) == mesh_dir
+
+
+def test_ensure_gso_assets_cache_hit_copies_missing_texture(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    monkeypatch.setattr(gso_assets, "_CACHE_DIR", tmp_path)
+    model_id = "Pony_C_Clamp_1440"
+    mesh_dir = tmp_path / model_id
+    mesh_dir.mkdir(parents=True)
+    _write_cached_parts(mesh_dir)
+    (mesh_dir / "visual.obj").write_text("v", encoding="utf-8")
+    downloaded_texture = tmp_path / "meshes" / model_id / "texture.png"
+    downloaded_texture.parent.mkdir(parents=True)
+    downloaded_texture.write_text("texture-bytes", encoding="utf-8")
+
+    def _unexpected_snapshot_download(**_kwargs):
+        raise AssertionError("a cached mirror texture should not trigger a download")
+
+    _patch_module(
+        monkeypatch,
+        "huggingface_hub",
+        types.SimpleNamespace(snapshot_download=_unexpected_snapshot_download),
+    )
+
+    result = gso_assets.ensure_gso_assets(model_id)
+
+    assert result == mesh_dir
+    assert (mesh_dir / "texture.png").read_text(encoding="utf-8") == "texture-bytes"
+
+
+class _FakeMesh:
+    """Stands in for a trimesh mesh; convex by construction, so no decomposition."""
+
+    volume = 1.0
+    vertices = ((0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0))
+    faces = ((0, 1, 2), (0, 1, 3), (0, 2, 3), (1, 2, 3))
+
+    def __init__(self):
+        self.exports: list[tuple[str, str | None]] = []
+        self.convex_hull = self
+
+    def export(self, file_obj: str, file_type: str | None = None):
+        self.exports.append((file_obj, file_type))
+        Path(file_obj).write_text("hull", encoding="utf-8")
+
+
+def _fake_trimesh(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_module(
+        monkeypatch,
+        "trimesh",
+        types.SimpleNamespace(
+            Scene=type("_FakeScene", (), {}),
+            load=lambda *_a, **_k: _FakeMesh(),
+        ),
+    )
+
+
+def test_ensure_gso_assets_warns_without_a_mirrored_texture(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+):
+    import logging
+
+    model_id = "Pony_C_Clamp_1440"
+    monkeypatch.setattr(gso_assets, "_CACHE_DIR", tmp_path)
+
+    def _snapshot_download(**_kwargs):
+        obj_dir = tmp_path / "meshes" / model_id
+        obj_dir.mkdir(parents=True, exist_ok=True)
+        (obj_dir / "model.obj").write_text("v", encoding="utf-8")
+
+    _patch_module(
+        monkeypatch,
+        "huggingface_hub",
+        types.SimpleNamespace(snapshot_download=_snapshot_download),
+    )
+    _fake_coacd(monkeypatch, [])
+    _fake_trimesh(monkeypatch)
+    monkeypatch.setattr(mesh_assets, "_hull_surface_gap", lambda _h, _m: (0.0, 0.0))
+
+    with caplog.at_level(logging.WARNING, logger="so101_nexus.gso_assets"):
+        mesh_dir = gso_assets.ensure_gso_assets(model_id)
+
+    assert mesh_dir == tmp_path / model_id
+    assert not (mesh_dir / "texture.png").exists()
+    assert any(model_id in r.getMessage() for r in caplog.records if r.levelno == logging.WARNING)
+
+
+def _fake_coacd(monkeypatch: pytest.MonkeyPatch, events: list[tuple]) -> None:
+    """Install fake ``coacd``/``threadpoolctl``/``rtree`` modules recording their use."""
+    import contextlib
+
+    def _run_coacd(mesh, **kwargs):
+        events.append(("run_coacd", kwargs))
+        return [("v0", "f0"), ("v1", "f1")]
+
+    @contextlib.contextmanager
+    def _threadpool_limits(limits=None, user_api=None):
+        events.append(("enter_limits", limits, user_api))
+        yield
+        events.append(("exit_limits",))
+
+    _patch_module(
+        monkeypatch,
+        "coacd",
+        types.SimpleNamespace(
+            Mesh=lambda vertices, faces: (vertices, faces),
+            run_coacd=_run_coacd,
+            set_log_level=lambda _level: None,
+        ),
+    )
+    _patch_module(
+        monkeypatch, "threadpoolctl", types.SimpleNamespace(threadpool_limits=_threadpool_limits)
+    )
+    _patch_module(monkeypatch, "rtree", types.SimpleNamespace())
+
+
+def test_ensure_gso_assets_download_copies_obj_directly(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """GSO ships ready-to-use OBJ + PNG, unlike YCB's GLB conversion path."""
+    model_id = "Pony_C_Clamp_1440"
+    monkeypatch.setattr(gso_assets, "_CACHE_DIR", tmp_path)
+
+    def _snapshot_download(**kwargs):
+        assert kwargs["allow_patterns"] == [f"meshes/{model_id}/*"]
+        obj_dir = tmp_path / "meshes" / model_id
+        obj_dir.mkdir(parents=True, exist_ok=True)
+        (obj_dir / "model.obj").write_text("real-world-scale obj", encoding="utf-8")
+        (obj_dir / "texture.png").write_text("texture-bytes", encoding="utf-8")
+
+    _patch_module(
+        monkeypatch,
+        "huggingface_hub",
+        types.SimpleNamespace(snapshot_download=_snapshot_download),
+    )
+    _fake_coacd(monkeypatch, [])
+    _fake_trimesh(monkeypatch)
+    monkeypatch.setattr(mesh_assets, "_hull_surface_gap", lambda _h, _m: (0.0, 0.0))
+
+    mesh_dir = gso_assets.ensure_gso_assets(model_id)
+
+    assert mesh_dir == tmp_path / model_id
+    assert (mesh_dir / "visual.obj").read_text(encoding="utf-8") == "real-world-scale obj"
+    assert (mesh_dir / "texture.png").read_text(encoding="utf-8") == "texture-bytes"
+
+
+def test_collision_and_visual_mesh_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr(gso_assets, "_CACHE_DIR", tmp_path)
+    model_id = "CoQ10"
+    parts_dir = _write_cached_parts(tmp_path / model_id, ("collision_000.obj", "collision_001.obj"))
+
+    assert gso_assets.get_gso_collision_meshes(model_id) == [
+        parts_dir / "collision_000.obj",
+        parts_dir / "collision_001.obj",
+    ]
+    assert gso_assets.get_gso_collision_mesh(model_id) == parts_dir / "collision_000.obj"
+    assert gso_assets.get_gso_visual_mesh(model_id) == tmp_path / model_id / "visual.obj"
+
+
+def test_collision_parts_require_prepared_assets(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr(gso_assets, "_CACHE_DIR", tmp_path)
+    with pytest.raises(FileNotFoundError, match="ensure_gso_assets"):
+        gso_assets.get_gso_collision_parts("CoQ10")
+
+
+def test_source_repo_env_override(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("SO101_GSO_HF_REPO", "your-org/your-gso-repo")
+    import importlib
+
+    reloaded = importlib.reload(gso_assets)
+    try:
+        assert reloaded._HF_REPO_ID == "your-org/your-gso-repo"
+    finally:
+        monkeypatch.delenv("SO101_GSO_HF_REPO", raising=False)
+        importlib.reload(gso_assets)

--- a/tests/core/test_object_slots.py
+++ b/tests/core/test_object_slots.py
@@ -22,7 +22,7 @@ from so101_nexus.object_slots import (
     mesh_xml_body,
     object_bounding_radius,
 )
-from so101_nexus.objects import CubeObject, MeshObject, YCBObject
+from so101_nexus.objects import CubeObject, GSOObject, MeshObject, YCBObject
 from so101_nexus.scene import MUJOCO_SCENE_OPTION_XML
 from so101_nexus.ycb_assets import YCBCollisionPart
 
@@ -72,9 +72,11 @@ class TestXmlBuilders:
 
     def test_collision_geom_name(self):
         assert collision_geom_name("pick_slot_0", CubeObject()) == "pick_slot_0_geom"
-        banana = YCBObject("011_banana")
-        assert collision_geom_name("pick_slot_1", banana) == "pick_slot_1_collision_0"
-        assert collision_geom_name("pick_slot_1", banana, part=2) == "pick_slot_1_collision_2"
+        gelatin_box = YCBObject("009_gelatin_box")
+        assert collision_geom_name("pick_slot_1", gelatin_box) == "pick_slot_1_collision_0"
+        assert collision_geom_name("pick_slot_1", gelatin_box, part=2) == "pick_slot_1_collision_2"
+        clamp = GSOObject("Pony_C_Clamp_1440")
+        assert collision_geom_name("pick_slot_2", clamp) == "pick_slot_2_collision_0"
 
     def test_cube_bounding_radius(self):
         assert cube_bounding_radius(CubeObject(half_size=0.0125)) == pytest.approx(
@@ -125,7 +127,7 @@ class TestXmlBuilders:
         monkeypatch.setattr(object_slots, "get_ycb_texture_file", lambda _m: texture_path)
 
         xml = build_object_scene_xml(
-            [YCBObject(model_id="011_banana")],
+            [YCBObject(model_id="009_gelatin_box")],
             ["pick_slot_0"],
             [0.1, 0.2, 0.3, 1.0],
             option_xml=MUJOCO_SCENE_OPTION_XML,
@@ -164,7 +166,7 @@ class TestXmlBuilders:
         monkeypatch.setattr(object_slots, "get_ycb_texture_file", lambda _m: texture_path)
 
         xml = build_object_scene_xml(
-            [YCBObject(model_id="011_banana")],
+            [YCBObject(model_id="009_gelatin_box")],
             ["pick_slot_0"],
             [0.1, 0.2, 0.3, 1.0],
             option_xml=MUJOCO_SCENE_OPTION_XML,
@@ -174,6 +176,32 @@ class TestXmlBuilders:
         assert 'file="C:/cache/ycb/visual.obj"' in xml
         assert 'file="C:/cache/ycb/texture.png"' in xml
         assert r"C:\cache\ycb" not in xml
+
+    def test_gso_scene_xml_binds_cached_texture(self, monkeypatch, tmp_path):
+        from so101_nexus import object_slots
+
+        collision_path = tmp_path / "collision.obj"
+        visual_path = tmp_path / "visual.obj"
+        texture_path = tmp_path / "texture.png"
+        texture_path.write_text("texture", encoding="utf-8")
+        monkeypatch.setattr(
+            object_slots,
+            "get_gso_collision_parts",
+            lambda _m: [YCBCollisionPart(collision_path, 1.0)],
+        )
+        monkeypatch.setattr(object_slots, "get_gso_visual_mesh", lambda _m: visual_path)
+        monkeypatch.setattr(object_slots, "get_gso_texture_file", lambda _m: texture_path)
+
+        xml = build_object_scene_xml(
+            [GSOObject(model_id="CoQ10")],
+            ["pick_slot_0"],
+            [0.1, 0.2, 0.3, 1.0],
+            option_xml=MUJOCO_SCENE_OPTION_XML,
+            robot_xml_path=_ROBOT_XML,
+        )
+        assert f'<texture name="pick_tex_0" type="2d" file="{texture_path}"/>' in xml
+        assert '<material name="pick_mat_0" texture="pick_tex_0" texuniform="false"/>' in xml
+        assert 'material="pick_mat_0"' in xml
 
 
 class TestSlotExtraction:
@@ -245,6 +273,36 @@ class TestSlotExtraction:
         assert slot.bounding_radius == pytest.approx(rotated_radius, abs=1e-6)
         assert slot.bounding_radius != pytest.approx(naive_radius, abs=1e-6)
 
+    def test_extract_gso_slot_applies_its_pose_override(self, monkeypatch, tmp_path):
+        """Pony_C_Clamp_1440 has a POSE_OVERRIDES entry; the compiled slot's
+        rest_quat must be that override, not the thin-axis-up heuristic guess -
+        proving object_slots wires ``model_id`` through to the rest-pose lookup."""
+        from so101_nexus import object_slots
+        from so101_nexus.ycb_geometry import POSE_OVERRIDES
+
+        model_id = "Pony_C_Clamp_1440"
+        override_quat = np.array(POSE_OVERRIDES[model_id])
+        visual = _write_box_obj(tmp_path / "visual.obj", (-0.02, -0.03, -0.01), (0.02, 0.03, 0.01))
+        monkeypatch.setattr(
+            object_slots, "get_gso_collision_parts", lambda _m: [YCBCollisionPart(visual, 1.0)]
+        )
+        monkeypatch.setattr(object_slots, "get_gso_visual_mesh", lambda _m: visual)
+        monkeypatch.setattr(object_slots, "get_gso_texture_file", lambda _m: tmp_path / "none.png")
+
+        obj = GSOObject(model_id=model_id, mass_override=0.35)
+        xml, slot_names = _cube_scene([obj])
+        so_dir = get_so101_mujoco_model_path().parent
+        with tempfile.NamedTemporaryFile("w", suffix=".xml", dir=so_dir, delete=True) as f:
+            f.write(xml)
+            f.flush()
+            mjm = mujoco.MjModel.from_xml_path(f.name)
+        slot = extract_object_slots(mjm, slot_names, [obj])[0]
+
+        assert slot.geom_id >= 0
+        body_id = int(mjm.geom_bodyid[slot.geom_id])
+        assert float(mjm.body_mass[body_id]) == pytest.approx(0.35, rel=1e-9)
+        np.testing.assert_allclose(slot.rest_quat, override_quat)
+
 
 def _write_box_obj(path, lo, hi):
     """Write an axis-aligned box OBJ spanning ``lo`` to ``hi``."""
@@ -285,6 +343,7 @@ class TestMultiPartCollision:
 
     def _compile(self, monkeypatch, tmp_path, parts):
         from so101_nexus import object_slots
+        from so101_nexus.ycb_geometry import POSE_OVERRIDES
 
         visual = _write_box_obj(
             tmp_path / "visual.obj",
@@ -294,8 +353,12 @@ class TestMultiPartCollision:
         monkeypatch.setattr(object_slots, "get_ycb_collision_parts", lambda _m: parts)
         monkeypatch.setattr(object_slots, "get_ycb_visual_mesh", lambda _m: visual)
         monkeypatch.setattr(object_slots, "get_ycb_texture_file", lambda _m: tmp_path / "none.png")
+        # This fixture probes the thin-axis-up heuristic in isolation, so
+        # suspend the settle-validated pose correction for this model_id: the
+        # synthetic slab is not that object's real mesh.
+        monkeypatch.delitem(POSE_OVERRIDES, "009_gelatin_box", raising=False)
 
-        obj = YCBObject(model_id="011_banana", mass_override=self.MASS)
+        obj = YCBObject(model_id="009_gelatin_box", mass_override=self.MASS)
         xml, slot_names = _cube_scene([obj])
         so_dir = get_so101_mujoco_model_path().parent
         with tempfile.NamedTemporaryFile("w", suffix=".xml", dir=so_dir, delete=True) as f:

--- a/tests/core/test_objects.py
+++ b/tests/core/test_objects.py
@@ -1,6 +1,13 @@
 import pytest
 
-from so101_nexus.objects import CubeObject, MeshObject, SceneObject, YCBObject
+from so101_nexus.objects import (
+    CubeObject,
+    GSOObject,
+    MeshObject,
+    ScannedMeshObject,
+    SceneObject,
+    YCBObject,
+)
 
 
 class TestSceneObjectBase:
@@ -9,6 +16,11 @@ class TestSceneObjectBase:
 
     def test_ycb_is_scene_object(self):
         assert isinstance(YCBObject(model_id="009_gelatin_box"), SceneObject)
+        assert isinstance(YCBObject(model_id="009_gelatin_box"), ScannedMeshObject)
+
+    def test_gso_is_scene_object(self):
+        assert isinstance(GSOObject(model_id="CoQ10"), SceneObject)
+        assert isinstance(GSOObject(model_id="CoQ10"), ScannedMeshObject)
 
     def test_mesh_is_scene_object(self):
         obj = MeshObject(
@@ -23,7 +35,8 @@ class TestSceneObjectBase:
     def test_all_have_repr(self):
         objects: list[SceneObject] = [
             CubeObject(),
-            YCBObject(model_id="011_banana"),
+            YCBObject(model_id="009_gelatin_box"),
+            GSOObject(model_id="CoQ10"),
             MeshObject(
                 collision_mesh_path="/a.obj", visual_mesh_path="/b.obj", mass=0.1, name="widget"
             ),
@@ -63,11 +76,45 @@ class TestYCBObject:
 
     def test_repr_human_readable(self):
         assert repr(YCBObject(model_id="009_gelatin_box")) == "gelatin box"
-        assert repr(YCBObject(model_id="011_banana")) == "banana"
+        assert repr(YCBObject(model_id="030_fork")) == "fork"
 
     def test_invalid_model_id(self):
         with pytest.raises(ValueError, match="model_id must be one of"):
             YCBObject(model_id="999_unknown")
+
+    def test_invalid_mass_override(self):
+        with pytest.raises(ValueError, match="mass_override must be positive"):
+            YCBObject(model_id="009_gelatin_box", mass_override=-1.0)
+
+    def test_valid_mass_override(self):
+        obj = YCBObject(model_id="009_gelatin_box", mass_override=0.25)
+        assert obj.mass_override == 0.25
+
+
+class TestGSOObject:
+    def test_requires_model_id(self):
+        with pytest.raises(TypeError):
+            GSOObject()
+
+    def test_valid(self):
+        obj = GSOObject(model_id="CoQ10")
+        assert obj.model_id == "CoQ10"
+
+    def test_repr_human_readable(self):
+        assert repr(GSOObject(model_id="CoQ10")) == "supplement bottle"
+        assert repr(GSOObject(model_id="Pony_C_Clamp_1440")) == "C-clamp"
+
+    def test_invalid_model_id(self):
+        with pytest.raises(ValueError, match="model_id must be one of"):
+            GSOObject(model_id="Unknown_Model")
+
+    def test_invalid_mass_override(self):
+        with pytest.raises(ValueError, match="mass_override must be positive"):
+            GSOObject(model_id="CoQ10", mass_override=-1.0)
+
+    def test_valid_mass_override(self):
+        obj = GSOObject(model_id="CoQ10", mass_override=0.25)
+        assert obj.mass_override == 0.25
 
 
 class TestMeshObject:

--- a/tests/core/test_teleop_app_helpers.py
+++ b/tests/core/test_teleop_app_helpers.py
@@ -483,7 +483,7 @@ def test_normalized_init_config_includes_env_overrides() -> None:
         -90,
         [],
         True,
-        ["cube:green", "ycb:011_banana"],
+        ["cube:green", "ycb:009_gelatin_box"],
         1,
         ["white"],
         ["yellow", "orange"],
@@ -498,7 +498,7 @@ def test_normalized_init_config_includes_env_overrides() -> None:
     )
 
     overrides = config["env_overrides"]
-    assert overrides.object_specs == ("cube:green", "ycb:011_banana")
+    assert overrides.object_specs == ("cube:green", "ycb:009_gelatin_box")
     assert overrides.n_distractors == 1
     assert overrides.ground_colors == ("white",)
     assert overrides.robot_colors == ("yellow", "orange")
@@ -624,7 +624,7 @@ def test_normalized_init_config_includes_success_hold_seconds() -> None:
 def test_customization_ui_state_for_pick_config_uses_base_config_defaults() -> None:
     state = teleop_app._customization_ui_state_from_config(
         PickConfig(
-            objects=[CubeObject(color="green"), YCBObject(model_id="011_banana")],
+            objects=[CubeObject(color="green"), YCBObject(model_id="009_gelatin_box")],
             n_distractors=1,
             ground_colors=["white"],
             robot_colors="yellow",
@@ -640,7 +640,7 @@ def test_customization_ui_state_for_pick_config_uses_base_config_defaults() -> N
     assert state.common_visible is True
     assert state.pick_visible is True
     assert state.pick_and_place_visible is False
-    assert state.object_specs == ["cube:green", "ycb:011_banana"]
+    assert state.object_specs == ["cube:green", "ycb:009_gelatin_box"]
     assert state.n_distractors == 1
     assert state.ground_colors == ["white"]
     assert state.robot_colors == ["yellow"]

--- a/tests/core/test_teleop_config_customization.py
+++ b/tests/core/test_teleop_config_customization.py
@@ -28,10 +28,10 @@ def test_object_from_spec_parses_cube() -> None:
 
 
 def test_object_from_spec_parses_ycb() -> None:
-    obj = object_from_spec("ycb:011_banana")
+    obj = object_from_spec("ycb:009_gelatin_box")
 
     assert isinstance(obj, YCBObject)
-    assert obj.model_id == "011_banana"
+    assert obj.model_id == "009_gelatin_box"
 
 
 def test_object_from_mapping_parses_mesh() -> None:
@@ -70,7 +70,7 @@ def test_object_from_spec_rejects_mesh_string_specs() -> None:
 def test_apply_config_overrides_updates_pick_objects_and_distractors() -> None:
     cfg = apply_config_overrides(
         PickConfig(),
-        TeleopConfigOverrides(object_specs=("cube:green", "ycb:011_banana"), n_distractors=1),
+        TeleopConfigOverrides(object_specs=("cube:green", "ycb:009_gelatin_box"), n_distractors=1),
     )
 
     assert isinstance(cfg, PickConfig)
@@ -78,7 +78,7 @@ def test_apply_config_overrides_updates_pick_objects_and_distractors() -> None:
     assert isinstance(cfg.objects[0], CubeObject)
     assert cfg.objects[0].color == "green"
     assert isinstance(cfg.objects[1], YCBObject)
-    assert cfg.objects[1].model_id == "011_banana"
+    assert cfg.objects[1].model_id == "009_gelatin_box"
 
 
 def test_apply_config_overrides_updates_stack_cube_distractors() -> None:
@@ -138,7 +138,7 @@ def test_apply_config_overrides_ignores_pick_specific_options_for_non_pick_confi
 
     cfg = apply_config_overrides(
         base,
-        TeleopConfigOverrides(object_specs=("ycb:011_banana",), n_distractors=1),
+        TeleopConfigOverrides(object_specs=("ycb:009_gelatin_box",), n_distractors=1),
     )
 
     assert isinstance(cfg, MoveConfig)
@@ -186,7 +186,7 @@ def test_load_profile_json_merges_common_task_and_env_sections(tmp_path) -> None
     path.write_text(
         '{"common":{"ground_colors":["white"]},'
         '"pick":{"objects":[{"type":"cube","color":"green"},'
-        '{"type":"ycb","model_id":"011_banana"}],"n_distractors":1},'
+        '{"type":"ycb","model_id":"009_gelatin_box"}],"n_distractors":1},'
         '"envs":{"MuJoCoPickLift-v1":{"spawn_max_radius":0.22}}}',
         encoding="utf-8",
     )
@@ -198,7 +198,7 @@ def test_load_profile_json_merges_common_task_and_env_sections(tmp_path) -> None
     assert isinstance(overrides.objects[0], CubeObject)
     assert overrides.objects[0].color == "green"
     assert isinstance(overrides.objects[1], YCBObject)
-    assert overrides.objects[1].model_id == "011_banana"
+    assert overrides.objects[1].model_id == "009_gelatin_box"
     assert overrides.n_distractors == 1
     assert overrides.spawn_max_radius == 0.22
 
@@ -328,7 +328,7 @@ def test_overrides_to_mapping_round_trips_through_from_mapping() -> None:
     import json
 
     overrides = TeleopConfigOverrides(
-        objects=(CubeObject(color="blue"), YCBObject(model_id="011_banana")),
+        objects=(CubeObject(color="blue"), YCBObject(model_id="009_gelatin_box")),
         n_distractors=2,
         ground_colors=("red", "green"),
         spawn_max_radius=0.3,

--- a/tests/core/test_teleop_session.py
+++ b/tests/core/test_teleop_session.py
@@ -217,7 +217,7 @@ def test_build_recording_config_applies_overrides_before_camera_wiring() -> None
         (320, 240),
         (640, 480),
         overrides=TeleopConfigOverrides(
-            object_specs=("cube:green", "ycb:011_banana"),
+            object_specs=("cube:green", "ycb:009_gelatin_box"),
             n_distractors=1,
             reset_settle_frames=4,
         ),
@@ -229,7 +229,7 @@ def test_build_recording_config_applies_overrides_before_camera_wiring() -> None
     assert isinstance(cfg.objects[0], CubeObject)
     assert cfg.objects[0].color == "green"
     assert isinstance(cfg.objects[1], YCBObject)
-    assert cfg.objects[1].model_id == "011_banana"
+    assert cfg.objects[1].model_id == "009_gelatin_box"
     assert any(isinstance(o, WristCamera) for o in cfg.observations)
     assert any(isinstance(o, OverheadCamera) for o in cfg.observations)
 
@@ -270,7 +270,7 @@ def test_recording_env_kwargs_applies_overrides_to_registered_config_kwargs(monk
         (320, 240),
         (640, 480),
         overrides=TeleopConfigOverrides(
-            object_specs=("cube:green", "ycb:011_banana"),
+            object_specs=("cube:green", "ycb:009_gelatin_box"),
             n_distractors=1,
         ),
     )

--- a/tests/core/test_validate_object_rest_poses.py
+++ b/tests/core/test_validate_object_rest_poses.py
@@ -1,0 +1,125 @@
+"""Regression tests for validate_object_rest_poses.py's advisory-only grasp policy.
+
+``validate_one`` gates pose-override acceptance on the settle test alone; the
+grasp screen is recorded on the report but never drops an object or blocks an
+override. These tests exercise that policy directly against ``validate_one``,
+with ``run_settle_test``/``run_grasp_check``/``_settle_from_quat`` monkeypatched
+so no real MuJoCo physics or asset downloads are needed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+
+def _load_script():
+    """Import scripts/validate_object_rest_poses.py as a module (not on sys.path)."""
+    path = Path(__file__).resolve().parents[2] / "scripts" / "validate_object_rest_poses.py"
+    spec = importlib.util.spec_from_file_location("validate_object_rest_poses", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+v = _load_script()
+
+
+def _settle(model_id: str, quat: np.ndarray, *, passed: bool) -> v.SettleResult:
+    delta_m = 0.001 if passed else 0.05
+    delta_deg = 1.0 if passed else 30.0
+    return v.SettleResult(
+        model_id=model_id,
+        predicted_quat=quat,
+        predicted_spawn_z=0.01,
+        settled_pos=np.array([0.15, 0.0, 0.01]),
+        settled_quat=quat,
+        translation_delta_m=delta_m,
+        rotation_delta_deg=delta_deg,
+    )
+
+
+def _grasp(model_id: str, *, passed: bool) -> v.GraspResult:
+    if passed:
+        return v.GraspResult(
+            model_id=model_id, passed=True, height_fraction=0.5, yaw_deg=0.0, width_mm=20.0
+        )
+    return v.GraspResult(model_id=model_id, passed=False, detail="no slice fits")
+
+
+class _FakeObj:
+    """Stands in for a SceneObject; validate_one never inspects it directly."""
+
+
+@pytest.fixture(autouse=True)
+def _no_spawn_z_lookup(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(v, "_spawn_z_for_quat", lambda _obj, _quat: 0.01)
+
+
+def test_settle_pass_grasp_fail_is_not_dropped_and_needs_no_override(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The core policy under test: a settle-stable, grasp-advisory-failing object ships as-is."""
+    model_id = "test_model"
+    quat = np.array([1.0, 0.0, 0.0, 0.0])
+    monkeypatch.setattr(
+        v, "run_settle_test", lambda _obj, _mid: _settle(model_id, quat, passed=True)
+    )
+    monkeypatch.setattr(v, "run_grasp_check", lambda _obj, _mid, _q: _grasp(model_id, passed=False))
+
+    report = v.validate_one(_FakeObj(), model_id)
+
+    assert report.settle.passed is True
+    assert report.grasp.passed is False
+    assert report.override_quat is None
+    assert report.dropped is False
+
+
+def test_settle_fail_finds_a_settle_only_override_regardless_of_grasp(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """An unstable heuristic pose gets corrected by the first candidate that settles,
+    even when that candidate also fails the (advisory) grasp screen."""
+    model_id = "test_model"
+    bad_quat = np.array([1.0, 0.0, 0.0, 0.0])
+    good_quat = np.array([0.7071068, 0.0, 0.7071068, 0.0])
+    monkeypatch.setattr(
+        v, "run_settle_test", lambda _obj, _mid: _settle(model_id, bad_quat, passed=False)
+    )
+    monkeypatch.setattr(v, "run_grasp_check", lambda _obj, _mid, _q: _grasp(model_id, passed=False))
+
+    def _settle_from_quat(_obj, _mid, quat, _spawn_z):
+        passed = bool(np.allclose(quat, good_quat))
+        return _settle(model_id, quat if not passed else good_quat, passed=passed)
+
+    monkeypatch.setattr(v, "_settle_from_quat", _settle_from_quat)
+
+    report = v.validate_one(_FakeObj(), model_id)
+
+    assert report.override_quat is not None
+    np.testing.assert_allclose(report.override_quat, good_quat)
+    assert report.settle.passed is True
+    assert report.grasp.passed is False
+    assert report.dropped is False
+
+
+def test_no_candidate_settles_drops_the_object(monkeypatch: pytest.MonkeyPatch):
+    model_id = "test_model"
+    bad_quat = np.array([1.0, 0.0, 0.0, 0.0])
+    monkeypatch.setattr(
+        v, "run_settle_test", lambda _obj, _mid: _settle(model_id, bad_quat, passed=False)
+    )
+    monkeypatch.setattr(v, "run_grasp_check", lambda _obj, _mid, _q: _grasp(model_id, passed=False))
+    monkeypatch.setattr(
+        v, "_settle_from_quat", lambda _obj, _mid, quat, _sz: _settle(model_id, quat, passed=False)
+    )
+
+    report = v.validate_one(_FakeObj(), model_id)
+
+    assert report.dropped is True
+    assert report.override_quat is None

--- a/tests/core/test_ycb.py
+++ b/tests/core/test_ycb.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from so101_nexus import ycb_assets
+from so101_nexus import mesh_assets, ycb_assets
 from so101_nexus.constants import YCB_OBJECTS
 from so101_nexus.ycb_assets import get_ycb_mesh_dir
 
@@ -133,10 +133,7 @@ def test_convert_glb_to_obj_handles_mesh(monkeypatch: pytest.MonkeyPatch, tmp_pa
 def test_get_ycb_texture_file_returns_cache_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     monkeypatch.setattr(ycb_assets, "_CACHE_DIR", tmp_path)
 
-    assert (
-        ycb_assets.get_ycb_texture_file("058_golf_ball")
-        == tmp_path / "058_golf_ball" / "texture.png"
-    )
+    assert ycb_assets.get_ycb_texture_file("032_knife") == tmp_path / "032_knife" / "texture.png"
 
 
 def test_extract_glb_texture_saves_material_image(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
@@ -274,7 +271,7 @@ def test_ensure_ycb_assets_returns_when_texture_extract_finds_nothing(
     fake_trimesh = types.SimpleNamespace(Scene=_FakeScene, load=lambda *_a, **_k: _FakeMesh())
     _patch_module(monkeypatch, "trimesh", fake_trimesh)
     _fake_coacd(monkeypatch, [])
-    monkeypatch.setattr(ycb_assets, "_hull_surface_gap", lambda _h, _m: (0.0, 0.0))
+    monkeypatch.setattr(mesh_assets, "_hull_surface_gap", lambda _h, _m: (0.0, 0.0))
 
     mesh_dir = ycb_assets.ensure_ycb_assets(model_id)
 
@@ -310,7 +307,7 @@ def test_ensure_ycb_assets_download_and_decomposition(
     )
     monkeypatch.setattr(ycb_assets, "_convert_glb_to_obj", _convert_glb_to_obj)
     _fake_coacd(monkeypatch, [])
-    monkeypatch.setattr(ycb_assets, "_hull_surface_gap", lambda _h, _m: (0.0, 0.0))
+    monkeypatch.setattr(mesh_assets, "_hull_surface_gap", lambda _h, _m: (0.0, 0.0))
 
     mesh_dir = ycb_assets.ensure_ycb_assets(model_id)
     assert mesh_dir == tmp_path / model_id
@@ -355,7 +352,7 @@ def test_ensure_ycb_assets_scene_path_for_hull(monkeypatch: pytest.MonkeyPatch, 
     )
     monkeypatch.setattr(ycb_assets, "_convert_glb_to_obj", lambda _g, p: p.write_text("v"))
     _fake_coacd(monkeypatch, [])
-    monkeypatch.setattr(ycb_assets, "_hull_surface_gap", lambda _h, _m: (0.0, 0.0))
+    monkeypatch.setattr(mesh_assets, "_hull_surface_gap", lambda _h, _m: (0.0, 0.0))
 
     ycb_assets.ensure_ycb_assets(model_id)
     assert mesh.exports[-1] == (
@@ -366,7 +363,7 @@ def test_ensure_ycb_assets_scene_path_for_hull(monkeypatch: pytest.MonkeyPatch, 
 
 def test_collision_and_visual_mesh_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     monkeypatch.setattr(ycb_assets, "_CACHE_DIR", tmp_path)
-    model_id = "058_golf_ball"
+    model_id = "032_knife"
     parts_dir = _write_cached_parts(tmp_path / model_id, ("collision_000.obj", "collision_001.obj"))
     assert ycb_assets.get_ycb_collision_meshes(model_id) == [
         parts_dir / "collision_000.obj",
@@ -379,7 +376,7 @@ def test_collision_and_visual_mesh_paths(monkeypatch: pytest.MonkeyPatch, tmp_pa
 def test_collision_parts_require_prepared_assets(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     monkeypatch.setattr(ycb_assets, "_CACHE_DIR", tmp_path)
     with pytest.raises(FileNotFoundError, match="ensure_ycb_assets"):
-        ycb_assets.get_ycb_collision_parts("058_golf_ball")
+        ycb_assets.get_ycb_collision_parts("032_knife")
 
 
 def test_collision_parts_reject_a_truncated_manifest(
@@ -387,7 +384,7 @@ def test_collision_parts_reject_a_truncated_manifest(
 ):
     """A half-written manifest must read as absent, not wedge the cache forever."""
     monkeypatch.setattr(ycb_assets, "_CACHE_DIR", tmp_path)
-    model_id = "058_golf_ball"
+    model_id = "032_knife"
     parts_dir = _write_cached_parts(tmp_path / model_id)
     (parts_dir / "manifest.json").write_text('{"parts": [{"file":', encoding="utf-8")
 
@@ -405,11 +402,11 @@ def test_cached_parts_from_another_decomposer_are_rebuilt(
     rather than overwriting it with a coarse hull.
     """
     monkeypatch.setattr(ycb_assets, "_CACHE_DIR", tmp_path)
-    parts_dir = _write_cached_parts(tmp_path / "058_golf_ball", decomposer="coacd 0.0.1")
-    monkeypatch.setattr(ycb_assets, "_decomposer_id", lambda: "coacd 9.9.9")
+    parts_dir = _write_cached_parts(tmp_path / "032_knife", decomposer="coacd 0.0.1")
+    monkeypatch.setattr(mesh_assets, "_decomposer_id", lambda: "coacd 9.9.9")
     assert not ycb_assets._collision_parts_are_current(parts_dir)
 
-    monkeypatch.setattr(ycb_assets, "_decomposer_id", lambda: ycb_assets._FALLBACK_DECOMPOSER)
+    monkeypatch.setattr(mesh_assets, "_decomposer_id", lambda: ycb_assets._FALLBACK_DECOMPOSER)
     assert ycb_assets._collision_parts_are_current(parts_dir)
 
 
@@ -419,7 +416,7 @@ def test_cached_parts_are_rebuilt_when_the_visual_scan_changes(
 ):
     """The source hash must prevent parts from another scan from reaching physics."""
     monkeypatch.setattr(ycb_assets, "_CACHE_DIR", tmp_path)
-    mesh_dir = tmp_path / "058_golf_ball"
+    mesh_dir = tmp_path / "032_knife"
     parts_dir = _write_cached_parts(mesh_dir)
     assert ycb_assets._collision_parts_are_current(parts_dir)
 
@@ -458,7 +455,7 @@ def test_extract_glb_texture_accepts_orig_extension(
 def test_texture_glb_path_prefers_orig(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     """When both textured.glb.orig and textured.glb exist, the .orig wins."""
     monkeypatch.setattr(ycb_assets, "_CACHE_DIR", tmp_path)
-    model_id = "011_banana"
+    model_id = "009_gelatin_box"
     base = tmp_path / "meshes" / model_id / "google_16k"
     base.mkdir(parents=True)
     glb = base / "textured.glb"
@@ -472,7 +469,7 @@ def test_texture_glb_path_prefers_orig(monkeypatch: pytest.MonkeyPatch, tmp_path
 def test_texture_glb_path_falls_back_to_glb(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     """When only textured.glb exists, _texture_glb_path returns it."""
     monkeypatch.setattr(ycb_assets, "_CACHE_DIR", tmp_path)
-    model_id = "011_banana"
+    model_id = "009_gelatin_box"
     base = tmp_path / "meshes" / model_id / "google_16k"
     base.mkdir(parents=True)
     glb = base / "textured.glb"
@@ -486,7 +483,7 @@ def test_ensure_ycb_assets_downloads_orig_when_partial_cache_lacks_it(
 ):
     """Partial caches with only textured.glb must pull .orig before extraction."""
     monkeypatch.setattr(ycb_assets, "_CACHE_DIR", tmp_path)
-    model_id = "011_banana"
+    model_id = "009_gelatin_box"
 
     mesh_dir = tmp_path / model_id
     mesh_dir.mkdir(parents=True)
@@ -535,7 +532,7 @@ def test_ensure_ycb_assets_logs_warning_when_extraction_fails(
     import logging
 
     monkeypatch.setattr(ycb_assets, "_CACHE_DIR", tmp_path)
-    model_id = "011_banana"
+    model_id = "009_gelatin_box"
 
     mesh_dir = tmp_path / model_id
     mesh_dir.mkdir(parents=True)
@@ -622,7 +619,7 @@ def test_collision_build_keeps_an_accurate_single_hull(monkeypatch: pytest.Monke
     events: list[tuple] = []
     _fake_coacd(monkeypatch, events)
     monkeypatch.setattr(
-        ycb_assets,
+        mesh_assets,
         "_hull_surface_gap",
         lambda _hull, _mesh: (
             ycb_assets._HULL_GAP_GATE_M,
@@ -647,7 +644,7 @@ def test_collision_build_uses_the_audited_coacd_configuration(
     _fake_coacd(monkeypatch, events)
     _fake_trimesh_with_hulls(monkeypatch, [1.0, 3.0])
     monkeypatch.setattr(
-        ycb_assets,
+        mesh_assets,
         "_hull_surface_gap",
         lambda _hull, _mesh: (ycb_assets._HULL_GAP_GATE_M + 0.001, 0.0),
     )
@@ -673,7 +670,7 @@ def test_collision_build_falls_back_to_single_hull_without_the_extra(
     _patch_module(monkeypatch, missing, None)
     mesh = _ConcaveMesh()
 
-    with caplog.at_level(logging.WARNING, logger="so101_nexus.ycb_assets"):
+    with caplog.at_level(logging.WARNING, logger="so101_nexus.mesh_assets"):
         build = ycb_assets._build_collision_geometry(mesh)
 
     assert build.parts == (mesh.convex_hull,)
@@ -687,7 +684,7 @@ def test_write_collision_parts_records_provenance_and_mass(
     events: list[tuple] = []
     _fake_coacd(monkeypatch, events)
     _fake_trimesh_with_hulls(monkeypatch, [1.0, 3.0])
-    monkeypatch.setattr(ycb_assets, "_hull_surface_gap", lambda _h, _m: (0.004, 0.012))
+    monkeypatch.setattr(mesh_assets, "_hull_surface_gap", lambda _h, _m: (0.004, 0.012))
     source = tmp_path / "visual.obj"
     source.write_text("visual", encoding="utf-8")
     out_dir = tmp_path / "collision_v3"
@@ -695,14 +692,14 @@ def test_write_collision_parts_records_provenance_and_mass(
     ycb_assets._write_collision_parts(
         _ConcaveMesh(),
         out_dir,
-        model_id="037_scissors",
+        model_id="031_spoon",
         source_path=source,
     )
 
     manifest = json.loads((out_dir / "manifest.json").read_text(encoding="utf-8"))
     assert [part["mass_fraction"] for part in manifest["parts"]] == [0.25, 0.75]
     assert sum(part["mass_fraction"] for part in manifest["parts"]) == 1.0
-    assert manifest["model_id"] == "037_scissors"
+    assert manifest["model_id"] == "031_spoon"
     assert manifest["source_sha256"] == ycb_assets._sha256(source)
     assert manifest["settings"] == ycb_assets._COACD_SETTINGS
     assert [part["n_vertices"] for part in manifest["parts"]] == [4, 4]
@@ -718,12 +715,12 @@ def test_write_collision_parts_drops_stale_parts(monkeypatch: pytest.MonkeyPatch
     source = tmp_path / "visual.obj"
     source.write_text("visual", encoding="utf-8")
     _fake_coacd(monkeypatch, [])
-    monkeypatch.setattr(ycb_assets, "_hull_surface_gap", lambda _h, _m: (0.0, 0.0))
+    monkeypatch.setattr(mesh_assets, "_hull_surface_gap", lambda _h, _m: (0.0, 0.0))
 
     ycb_assets._write_collision_parts(
         _FakeMesh(),
         tmp_path,
-        model_id="058_golf_ball",
+        model_id="032_knife",
         source_path=source,
     )
 

--- a/tests/mujoco/test_envs.py
+++ b/tests/mujoco/test_envs.py
@@ -382,9 +382,9 @@ def test_pick_multiple_cubes_with_distractors():
 
 def test_pick_mixed_pool_with_distractors():
     objects = [
-        YCBObject(model_id="011_banana"),
+        YCBObject(model_id="009_gelatin_box"),
         CubeObject(color="blue"),
-        YCBObject(model_id="058_golf_ball"),
+        YCBObject(model_id="032_knife"),
     ]
     config = PickConfig(objects=objects, n_distractors=2)
     env = gym.make("MuJoCoPickLift-v1", config=config)
@@ -396,7 +396,7 @@ def test_pick_mixed_pool_with_distractors():
         env.close()
 
 
-@pytest.mark.parametrize("model_id", ["011_banana", "030_fork", "031_spoon", "032_knife"])
+@pytest.mark.parametrize("model_id", ["030_fork", "031_spoon", "032_knife"])
 def test_pick_ycb_collision_geom_starts_above_floor(model_id):
     pytest.importorskip("coacd", reason="multi-hull collision needs the decomp extra")
     from so101_nexus.mujoco.spawn_utils import slot_world_min_z
@@ -1621,9 +1621,9 @@ def test_pick_hidden_slot_collisions_restore_when_slot_becomes_target():
 def test_pick_hidden_ycb_slots_are_inert_below_floor():
     """Same fix must hold for YCB pools with collision and visual geoms."""
     objects = [
-        YCBObject(model_id="011_banana"),
+        YCBObject(model_id="009_gelatin_box"),
         YCBObject(model_id="030_fork"),
-        YCBObject(model_id="058_golf_ball"),
+        YCBObject(model_id="032_knife"),
     ]
     config = PickConfig(objects=objects, n_distractors=0)
     env = gym.make("MuJoCoPickLift-v1", config=config)
@@ -1709,12 +1709,12 @@ def test_pick_and_place_color_reproducible_by_seed():
 
 def test_pick_and_place_ycb_object_task_description():
     """An explicit object pool names the carried object in the task description."""
-    config = PickAndPlaceConfig(objects=[YCBObject(model_id="011_banana")])
+    config = PickAndPlaceConfig(objects=[YCBObject(model_id="009_gelatin_box")])
     env = gym.make("MuJoCoPickAndPlace-v1", config=config)
     try:
         env.reset(seed=0)
         desc = env.unwrapped.task_description  # type: ignore[attr-defined]
-        assert "banana" in desc
+        assert "gelatin box" in desc
         assert "circle" in desc
         _run_episode(env)
     finally:
@@ -1737,7 +1737,7 @@ def test_pick_and_place_object_pose_tracks_selected_slot():
 
 def test_pick_and_place_info_keys_with_object_pool():
     """Placement info keys stay stable for a non-cube carried object."""
-    config = PickAndPlaceConfig(objects=[YCBObject(model_id="011_banana")])
+    config = PickAndPlaceConfig(objects=[YCBObject(model_id="009_gelatin_box")])
     env = gym.make("MuJoCoPickAndPlace-v1", config=config)
     expected = {
         "obj_to_target_dist",

--- a/tests/mujoco/test_envs.py
+++ b/tests/mujoco/test_envs.py
@@ -32,10 +32,10 @@ from so101_nexus.config import (
     StackCubeConfig,
     TouchConfig,
 )
-from so101_nexus.constants import CUBE_COLOR_MAP, YCB_OBJECTS
+from so101_nexus.constants import CUBE_COLOR_MAP, GSO_OBJECTS, YCB_OBJECTS
 from so101_nexus.kinematics import EE_ACTION_DIM
 from so101_nexus.mujoco.base_env import SO101NexusMuJoCoBaseEnv
-from so101_nexus.objects import CubeObject, YCBObject
+from so101_nexus.objects import CubeObject, GSOObject, YCBObject
 from so101_nexus.observations import (
     EndEffectorPose,
     GazeDirection,
@@ -75,6 +75,7 @@ REWARD_RANGE_OVERRIDES: dict[str, tuple[float, float]] = {
 
 CUBE_COLORS = list(CUBE_COLOR_MAP.keys())
 YCB_MODEL_IDS = list(YCB_OBJECTS.keys())
+GSO_MODEL_IDS = list(GSO_OBJECTS.keys())
 MOVE_DIRECTIONS = ["up", "down", "left", "right", "forward", "backward"]
 # Control-mode families come from so101_nexus.config so this suite cannot drift
 # from the ControlMode literal when a new mode lands. Joint modes command the six
@@ -363,6 +364,18 @@ def test_pick_ycb_object(model_id):
         env.close()
 
 
+@pytest.mark.parametrize("model_id", GSO_MODEL_IDS)
+def test_pick_gso_object(model_id):
+    config = PickConfig(objects=[GSOObject(model_id=model_id)])
+    env = gym.make("MuJoCoPickLift-v1", config=config)
+    try:
+        env.reset()
+        assert GSO_OBJECTS[model_id] in env.unwrapped.task_description  # type: ignore[attr-defined]
+        _run_episode(env)
+    finally:
+        env.close()
+
+
 def test_pick_multiple_cubes_with_distractors():
     """PickLift with a homogeneous cube pool and distractors spawns correctly."""
     objects: list[CubeObject] = [
@@ -385,6 +398,7 @@ def test_pick_mixed_pool_with_distractors():
         YCBObject(model_id="009_gelatin_box"),
         CubeObject(color="blue"),
         YCBObject(model_id="032_knife"),
+        GSOObject(model_id="CoQ10"),
     ]
     config = PickConfig(objects=objects, n_distractors=2)
     env = gym.make("MuJoCoPickLift-v1", config=config)

--- a/tests/mujoco/test_pick_and_place_config.py
+++ b/tests/mujoco/test_pick_and_place_config.py
@@ -106,7 +106,7 @@ class TestDistractorValidation:
         assert len(recwarn) == 0
 
     def test_non_cube_distractors_never_warn(self, recwarn):
-        PickAndPlaceConfig(distractors=[YCBObject("011_banana")], n_distractors=1)
+        PickAndPlaceConfig(distractors=[YCBObject("009_gelatin_box")], n_distractors=1)
         assert len(recwarn) == 0
 
 

--- a/tests/mujoco/test_teleop_env_kwargs.py
+++ b/tests/mujoco/test_teleop_env_kwargs.py
@@ -55,7 +55,7 @@ def test_recording_env_kwargs_applies_pick_overrides() -> None:
         (320, 240),
         (640, 480),
         overrides=TeleopConfigOverrides(
-            object_specs=("cube:green", "ycb:011_banana"),
+            object_specs=("cube:green", "ycb:009_gelatin_box"),
             n_distractors=1,
         ),
     )
@@ -64,7 +64,7 @@ def test_recording_env_kwargs_applies_pick_overrides() -> None:
     assert isinstance(kwargs["config"].objects[0], CubeObject)
     assert kwargs["config"].objects[0].color == "green"
     assert isinstance(kwargs["config"].objects[1], YCBObject)
-    assert kwargs["config"].objects[1].model_id == "011_banana"
+    assert kwargs["config"].objects[1].model_id == "009_gelatin_box"
 
 
 def test_recording_env_kwargs_applies_stack_cube_overrides() -> None:

--- a/tests/visual/test_mujoco_visual.py
+++ b/tests/visual/test_mujoco_visual.py
@@ -63,8 +63,6 @@ def _env_kwargs(env_id: str) -> dict:
         }
     # YCB-based envs: extract model_id from env_id name
     _YCB_ENV_TO_MODEL: dict[str, str] = {
-        "MuJoCoPickBananaLift-v1": "011_banana",
-        "MuJoCoPickGolfBallLift-v1": "058_golf_ball",
         "MuJoCoPickForkLift-v1": "030_fork",
     }
     model_id = _YCB_ENV_TO_MODEL.get(env_id)

--- a/tests/warp/test_warp_envs.py
+++ b/tests/warp/test_warp_envs.py
@@ -342,7 +342,7 @@ def test_pick_supports_heterogeneous_pool():
     import torch
 
     from so101_nexus.config import PickConfig
-    from so101_nexus.objects import CubeObject, YCBObject
+    from so101_nexus.objects import CubeObject, GSOObject, YCBObject
     from so101_nexus.warp.pick_env import WarpPickLiftVectorEnv
 
     # Single YCB object: constructs, resets, steps with finite observations.
@@ -355,9 +355,24 @@ def test_pick_supports_heterogeneous_pool():
     assert torch.isfinite(obs).all()
     assert torch.isfinite(reward).all()
 
+    # Single GSO object: constructs, resets, steps with finite observations.
+    env_gso = WarpPickLiftVectorEnv(
+        num_envs=2, config=PickConfig(objects=GSOObject("CoQ10")), device="cpu", seed=0
+    )
+    obs_gso, _ = env_gso.reset(seed=0)
+    assert torch.isfinite(obs_gso).all()
+    obs_gso, reward_gso, _, _, _ = env_gso.step(torch.zeros((2, 6)))
+    assert torch.isfinite(obs_gso).all()
+    assert torch.isfinite(reward_gso).all()
+
     # Mixed pool with a decomposed model: every world's target mask is exactly
     # the compiled mask of its selected slot, parts included.
-    pool = [CubeObject(color="red"), CubeObject(color="blue"), YCBObject("009_gelatin_box")]
+    pool = [
+        CubeObject(color="red"),
+        CubeObject(color="blue"),
+        YCBObject("009_gelatin_box"),
+        GSOObject("CoQ10"),
+    ]
     env2 = WarpPickLiftVectorEnv(
         num_envs=8, config=PickConfig(objects=pool, n_distractors=1), device="cpu", seed=1
     )

--- a/tests/warp/test_warp_envs.py
+++ b/tests/warp/test_warp_envs.py
@@ -311,7 +311,7 @@ def test_pick_object_pose_obs_tracks_cube():
     assert torch.allclose(obs[:, :3], env._target_pos(), atol=1e-5)
 
 
-@pytest.mark.parametrize("objects", [None, "033_spatula"])
+@pytest.mark.parametrize("objects", [None, "043_phillips_screwdriver"])
 def test_pick_contact_budget_headroom_and_grasp_range(objects):
     """The default budget must cover a decomposed pool, not just a single cube."""
     import torch
@@ -347,7 +347,7 @@ def test_pick_supports_heterogeneous_pool():
 
     # Single YCB object: constructs, resets, steps with finite observations.
     env = WarpPickLiftVectorEnv(
-        num_envs=2, config=PickConfig(objects=YCBObject("011_banana")), device="cpu", seed=0
+        num_envs=2, config=PickConfig(objects=YCBObject("009_gelatin_box")), device="cpu", seed=0
     )
     obs, _ = env.reset(seed=0)
     assert torch.isfinite(obs).all()
@@ -357,7 +357,7 @@ def test_pick_supports_heterogeneous_pool():
 
     # Mixed pool with a decomposed model: every world's target mask is exactly
     # the compiled mask of its selected slot, parts included.
-    pool = [CubeObject(color="red"), CubeObject(color="blue"), YCBObject("011_banana")]
+    pool = [CubeObject(color="red"), CubeObject(color="blue"), YCBObject("009_gelatin_box")]
     env2 = WarpPickLiftVectorEnv(
         num_envs=8, config=PickConfig(objects=pool, n_distractors=1), device="cpu", seed=1
     )

--- a/tests/warp/test_warp_heterogeneous.py
+++ b/tests/warp/test_warp_heterogeneous.py
@@ -40,6 +40,24 @@ def test_pnp_ycb_object_target_offset_and_finite_reward():
     assert "obj_to_target_dist" in info
 
 
+def test_pnp_gso_object_target_offset_and_finite_reward():
+    import torch
+
+    from so101_nexus.config import PickAndPlaceConfig
+    from so101_nexus.objects import GSOObject
+    from so101_nexus.warp.pick_and_place import WarpPickAndPlaceVectorEnv
+
+    config = PickAndPlaceConfig(objects=[GSOObject("CoQ10")])
+    env = WarpPickAndPlaceVectorEnv(num_envs=4, config=config, device="cpu", seed=0)
+    obs, _ = env.reset(seed=0)
+    assert torch.isfinite(obs).all()
+    expected = env._target_disc_pos() - env._target_pos()
+    assert torch.allclose(obs[:, -3:], expected, atol=1e-5)
+    _, reward, _, _, info = env.step(torch.zeros((4, 6)))
+    assert torch.isfinite(reward).all()
+    assert "obj_to_target_dist" in info
+
+
 def test_autoreset_preserves_per_world_target_metadata():
     import torch
 

--- a/tests/warp/test_warp_heterogeneous.py
+++ b/tests/warp/test_warp_heterogeneous.py
@@ -12,7 +12,7 @@ def test_touch_threshold_vector_matches_selected_bounding_radius():
     from so101_nexus.objects import CubeObject, YCBObject
     from so101_nexus.warp.touch_env import WarpTouchVectorEnv
 
-    pool = [CubeObject(half_size=0.02, color="red"), YCBObject("011_banana")]
+    pool = [CubeObject(half_size=0.02, color="red"), YCBObject("009_gelatin_box")]
     env = WarpTouchVectorEnv(num_envs=16, config=TouchConfig(objects=pool), device="cpu", seed=0)
     env.reset(seed=0)
     radius = env._target_bounding_radius()
@@ -28,7 +28,7 @@ def test_pnp_ycb_object_target_offset_and_finite_reward():
     from so101_nexus.objects import YCBObject
     from so101_nexus.warp.pick_and_place import WarpPickAndPlaceVectorEnv
 
-    config = PickAndPlaceConfig(objects=[YCBObject("011_banana")])
+    config = PickAndPlaceConfig(objects=[YCBObject("009_gelatin_box")])
     env = WarpPickAndPlaceVectorEnv(num_envs=4, config=config, device="cpu", seed=0)
     obs, _ = env.reset(seed=0)
     assert torch.isfinite(obs).all()
@@ -71,7 +71,7 @@ def test_per_world_task_descriptions_and_reducer():
     from so101_nexus.objects import CubeObject, YCBObject
     from so101_nexus.warp.pick_env import WarpPickLiftVectorEnv
 
-    pool = [CubeObject(color="red"), YCBObject("011_banana")]
+    pool = [CubeObject(color="red"), YCBObject("009_gelatin_box")]
     env = WarpPickLiftVectorEnv(num_envs=8, config=PickConfig(objects=pool), device="cpu", seed=0)
     _, info = env.reset(seed=0)
     assert len(env.task_descriptions) == 8


### PR DESCRIPTION
## Summary
- Adds `GSOObject` and 12 curated Google Scanned Objects (`GSO_OBJECTS`), alongside the existing 10 `YCBObject` items, sharing the same convex-hull collision pipeline. Assets download on demand from a Hugging Face mirror (`SO101_GSO_HF_REPO` env override), cached at `~/.cache/so101_nexus/gso/{model_id}/`.
- Extracts `so101_nexus.mesh_assets`: the source-parameterized download/decompose/cache engine `ycb_assets.py` and the new `gso_assets.py` both build on.
- Adds `so101_nexus.ycb_geometry.POSE_OVERRIDES`: settle-test-validated rest-pose corrections for objects whose default "thinnest axis up" heuristic tips over under real physics.
- Adds `so101_nexus.ycb_geometry.GRASP_ADVISORY`: an informational note on objects whose cross-section exceeds the SO-101 gripper's opening at every sampled pose.
- Adds `scripts/validate_object_rest_poses.py`, the settle-test and grasp-screen audit script; findings recorded in `src/so101_nexus/gso_pose_validation_results.json`.
- Updates docs (`api/objects`, `concepts/customization`, `workflow/teleoperation`, `getting-started/quickstart`, `api/configs`) for the new GSO object type.

## Review fixes applied before commit
- `object_slots._SCANNED_MESH_ACCESSORS` lookup switched from exact-type dict indexing to `isinstance`-based resolution, so subclasses of `YCBObject`/`GSOObject` resolve correctly.
- Corrected stale "Six YCB models ship" doc copy to "Ten" (`YCB_OBJECTS` has 10 entries).
- Moved `gso_pose_validation_results.json` out of the gitignored `docs/superpowers/` tree into `src/so101_nexus/` so the file referenced by CHANGELOG.md, `GSO_PROVENANCE.md`, and `ycb_geometry.py` is actually committed and reviewable.

## Validation
- `make format lint typecheck` - clean.
- `uv run pytest tests/core/test_gso.py tests/core/test_validate_object_rest_poses.py tests/core/test_ycb.py tests/core/test_objects.py tests/core/test_object_slots.py tests/core/test_config.py tests/core/test_teleop_config_customization.py -q` - 314 passed.
- `make test` (full suite) - 1590 passed, 2 skipped (visual tests require a configured VLM), 92.66% coverage (gate 84%).

## Open questions / risks
- Teleop profile serialization (`config_customization.object_from_mapping`/`object_to_mapping`) does not round-trip `mass_override` for `GSOObject` or `YCBObject`. This is pre-existing behavior unchanged by this PR (YCB never supported it either); flagging for a follow-up if profile-level mass overrides are wanted.