### PR TITLE
feat: add geometric scene primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ for the public-API and deprecation policy.
 
 ### Added
 
+- `CylinderObject`, `SphereObject`, and `PyramidObject` add solid-color
+  geometric primitives to dynamic MuJoCo and MuJoCo Warp scenes. Each uses the
+  same `half_size`, `mass`, and `color` contract as `CubeObject`, and fills the
+  same bounding cube.
 - `GSOObject` and 12 curated [Google Scanned Objects](https://research.google/blog/scanned-objects-by-google-research-a-dataset-of-3d-scanned-common-household-items/)
   (`GSO_OBJECTS`), alongside the existing 10 `YCBObject` items, sharing the
   same convex-hull collision pipeline. Assets download on demand from a

--- a/docs/content/docs/api/objects.mdx
+++ b/docs/content/docs/api/objects.mdx
@@ -1,15 +1,23 @@
 ---
 title: Scene Objects and Assets
-description: Constructor reference for cubes, YCB objects, and meshes, plus the YCB download cache and bundled simulation asset helpers.
+description: Constructor reference for geometric primitives, YCB objects, and meshes, plus the YCB download cache and bundled simulation asset helpers.
 ---
 
 Scene objects define what the robot interacts with. All object types live in `so101_nexus` and share the abstract `SceneObject` base class.
 
 ```python
-from so101_nexus import CubeObject, GSOObject, MeshObject, YCBObject
+from so101_nexus import (
+    CubeObject,
+    CylinderObject,
+    GSOObject,
+    MeshObject,
+    PyramidObject,
+    SphereObject,
+    YCBObject,
+)
 ```
 
-All four concrete object types work on the MuJoCo and MuJoCo Warp backends, which build their scenes through the same `so101_nexus.object_slots.build_object_scene_xml`.
+All concrete object types work on the MuJoCo and MuJoCo Warp backends. Both backends build dynamic-object scenes through `so101_nexus.object_slots.build_object_scene_xml`.
 
 ## SceneObject (abstract)
 
@@ -33,6 +41,25 @@ repr(cube)  # "blue cube"
 | `color` | `ColorName` | `"red"` | Color of the cube. Must be a valid `ColorName`. |
 
 `__repr__()` returns `"{color} cube"`, for example `"red cube"`.
+
+## CylinderObject, SphereObject, and PyramidObject
+
+These solid-color primitives use the same `half_size`, `mass`, and `color`
+parameters as `CubeObject`. Each primitive fills the cube with side length
+`2 * half_size`: cylinders have that diameter and height, spheres have that
+diameter, and square pyramids have that base width and height.
+
+```python
+from so101_nexus import CylinderObject, PyramidObject, SphereObject
+
+cylinder = CylinderObject(half_size=0.02, color="blue")
+sphere = SphereObject(half_size=0.02, color="green")
+pyramid = PyramidObject(half_size=0.02, color="yellow")
+```
+
+`__repr__()` returns `"{color} cylinder"`, `"{color} sphere"`, or
+`"{color} pyramid"`. The valid colors are the same `ColorName` values that
+`CubeObject` accepts.
 
 ## YCBObject
 

--- a/src/so101_nexus/__init__.py
+++ b/src/so101_nexus/__init__.py
@@ -76,10 +76,14 @@ from so101_nexus.lerobot_dataset import (
 )
 from so101_nexus.objects import (
     CubeObject,
+    CylinderObject,
     GSOObject,
     MeshObject,
+    PrimitiveObject,
+    PyramidObject,
     ScannedMeshObject,
     SceneObject,
+    SphereObject,
     YCBObject,
 )
 from so101_nexus.observations import (
@@ -219,6 +223,7 @@ __all__ = [
     "ColorName",
     "ControlMode",
     "CubeObject",
+    "CylinderObject",
     "EndEffectorPose",
     "EnvironmentConfig",
     "GSOCollisionPart",
@@ -244,12 +249,15 @@ __all__ = [
     "PickAndPlaceConfig",
     "PickConfig",
     "Pose",
+    "PrimitiveObject",
+    "PyramidObject",
     "RenderConfig",
     "RewardConfig",
     "RobotCameraPreset",
     "RobotConfig",
     "ScannedMeshObject",
     "SceneObject",
+    "SphereObject",
     "StackCubeConfig",
     "TargetOffset",
     "TargetPosition",

--- a/src/so101_nexus/config.py
+++ b/src/so101_nexus/config.py
@@ -23,7 +23,7 @@ from so101_nexus.kinematics import (
     EE_DELTA_ACTION_SCALE,
     EE_ORIENTATION_WEIGHT,
 )
-from so101_nexus.objects import CubeObject, SceneObject
+from so101_nexus.objects import CubeObject, PrimitiveObject, SceneObject
 from so101_nexus.observations import (
     EndEffectorPose,
     GazeDirection,
@@ -1495,7 +1495,7 @@ class LookAtConfig(EnvironmentConfig):
     objects : list[SceneObject] or SceneObject, optional
         Object(s) to sample as the look-at target. Accepts a single
         SceneObject, a list, or None (defaults to [CubeObject()]).
-        Only CubeObject targets are currently supported.
+        Only solid-color geometric primitives are supported.
     fov_deg : float or None
         Vertical field of view (degrees) of the wrist camera used for the gaze
         axis. The task succeeds when the target lies within the camera's field
@@ -1531,9 +1531,9 @@ class LookAtConfig(EnvironmentConfig):
                 GazeState(),
             ]
         for obj in self.objects:
-            if not isinstance(obj, CubeObject):
+            if not isinstance(obj, PrimitiveObject):
                 raise TypeError(
-                    f"LookAtConfig only supports CubeObject targets, got {type(obj).__name__}"
+                    f"LookAtConfig only supports PrimitiveObject targets, got {type(obj).__name__}"
                 )
 
     @property

--- a/src/so101_nexus/mujoco/look_at_env.py
+++ b/src/so101_nexus/mujoco/look_at_env.py
@@ -4,41 +4,31 @@ from __future__ import annotations
 
 import math
 import tempfile
-from typing import TYPE_CHECKING, ClassVar
+from typing import ClassVar
 
 import mujoco
 import numpy as np
 
 from so101_nexus import get_so101_mujoco_model_dir, get_so101_mujoco_model_path
 from so101_nexus.config import ControlMode, LookAtConfig
-from so101_nexus.constants import COLOR_MAP, sample_color
+from so101_nexus.constants import sample_color
 from so101_nexus.gaze import object_in_view
 from so101_nexus.mujoco.base_env import SO101NexusMuJoCoBaseEnv
+from so101_nexus.object_slots import primitive_visual_xml_geom, pyramid_xml_asset
+from so101_nexus.objects import PrimitiveObject, PyramidObject
 from so101_nexus.rewards import orientation_progress
 from so101_nexus.scene import MUJOCO_SCENE_OPTION_XML, SCENE_LIGHTS_XML, SCENE_VISUAL_XML
-
-if TYPE_CHECKING:
-    from so101_nexus.objects import CubeObject
 
 _SO101_DIR = get_so101_mujoco_model_dir()
 _SO101_XML = get_so101_mujoco_model_path()
 
 
-def _build_look_at_scene_xml(obj: CubeObject, ground_rgba: list[float]) -> str:
-    """Build MuJoCo XML string for the look-at scene (robot + floor + target object).
-
-    Only CubeObject is supported for the look-at target; the cube is placed as a
-    kinematic mocap body so the robot can orient toward it. Per the cross-backend
-    contract (body_type="kinematic"), the target is purely visual: collision is
-    disabled (contype=0 conaffinity=0) so the arm passes through it, and as a mocap
-    body it is unaffected by gravity or contact (its pose is driven via
-    data.mocap_pos/mocap_quat, set each reset). This prevents the arm from bumping
-    the reference frame, which a dynamic freejoint box previously allowed.
-    """
+def _build_look_at_scene_xml(obj: PrimitiveObject, ground_rgba: list[float]) -> str:
+    """Build a MuJoCo XML string with a kinematic visual target primitive."""
     robot_path = str(_SO101_XML)
     gr, gg, gb, ga = ground_rgba
-    hs = obj.half_size
-    cr, cg, cb, ca = COLOR_MAP[obj.color]
+    asset_entries = pyramid_xml_asset(0, obj) if isinstance(obj, PyramidObject) else ""
+    asset_section = f"  <asset>\n{asset_entries}  </asset>\n\n" if asset_entries else ""
     return f"""\
 <mujoco model="look_at_scene">
   <compiler angle="radian"/>
@@ -46,17 +36,14 @@ def _build_look_at_scene_xml(obj: CubeObject, ground_rgba: list[float]) -> str:
   <include file="{robot_path}"/>
   {MUJOCO_SCENE_OPTION_XML}
 
-{SCENE_VISUAL_XML}
+{asset_section}{SCENE_VISUAL_XML}
 
   <worldbody>
 {SCENE_LIGHTS_XML}
     <geom name="floor" type="plane" size="0 0 0.01" rgba="{gr} {gg} {gb} {ga}"
           pos="0 0 0" contype="1" conaffinity="1"/>
-    <body name="look_target" pos="0.15 0 {hs}" mocap="true">
-      <geom name="look_target_geom" type="box" size="{hs} {hs} {hs}"
-            rgba="{cr} {cg} {cb} {ca}"
-            contype="0" conaffinity="0"/>
-    </body>
+    <body name="look_target" pos="0.15 0 {obj.half_size}" mocap="true">
+{primitive_visual_xml_geom("look_target_geom", obj)}    </body>
   </worldbody>
 </mujoco>
 """
@@ -95,8 +82,8 @@ class LookAtEnv(SO101NexusMuJoCoBaseEnv):
             robot_init_qpos_noise=robot_init_qpos_noise,
         )
 
-        # Use the first (and typically only) target object from config.
-        self._target_obj: CubeObject = config.objects[0]  # type: ignore[assignment]
+        # Look-at targets are visual primitives on a kinematic mocap body.
+        self._target_obj: PrimitiveObject = config.objects[0]  # type: ignore[assignment]
 
         ground_rgba = sample_color(config.ground_colors)
         xml_string = _build_look_at_scene_xml(self._target_obj, ground_rgba)

--- a/src/so101_nexus/mujoco/spawn_utils.py
+++ b/src/so101_nexus/mujoco/spawn_utils.py
@@ -153,14 +153,14 @@ def place_freejoint_slot(
 ) -> None:
     """Place an active object slot at ``xy`` with random yaw, resting on the floor.
 
-    ``slot`` is an ``so101_nexus.object_slots.ObjectSlot``; cubes use the analytic
-    spawn height while mesh-backed objects clear the floor via their compiled
-    collision geom.
+    ``slot`` is an ``so101_nexus.object_slots.ObjectSlot``; geometric primitives
+    use analytic spawn heights while mesh-backed objects clear the floor via their
+    compiled collision geom.
     """
-    from so101_nexus.objects import CubeObject
+    from so101_nexus.objects import PrimitiveObject
 
     x, y = xy
-    if isinstance(slot.obj, CubeObject):
+    if isinstance(slot.obj, PrimitiveObject):
         data.qpos[slot.qpos_addr : slot.qpos_addr + 3] = [x, y, slot.spawn_z]
         data.qpos[slot.qpos_addr + 3 : slot.qpos_addr + 7] = random_yaw_quat(rng)
         return

--- a/src/so101_nexus/object_slots.py
+++ b/src/so101_nexus/object_slots.py
@@ -5,8 +5,8 @@ of freejoint object bodies ("slots") into one compiled ``MjModel`` and select
 which slot is the active target (and which are distractors) per episode. This
 module holds the backend-neutral pieces of that machinery:
 
-- MJCF fragment builders for ``CubeObject``, ``ScannedMeshObject`` (``YCBObject``,
-  ``GSOObject``), and ``MeshObject``.
+- MJCF fragment builders for geometric primitives, ``ScannedMeshObject``
+  (``YCBObject``, ``GSOObject``), and ``MeshObject``.
 - The full scene builder ``build_object_scene_xml`` parameterized by the
   ``<option>`` preset and robot model path, so MuJoCo and Warp emit identical
   bodies and assets while differing only in the integrator/solver preset.
@@ -34,10 +34,14 @@ from so101_nexus.gso_assets import (
 )
 from so101_nexus.objects import (
     CubeObject,
+    CylinderObject,
     GSOObject,
     MeshObject,
+    PrimitiveObject,
+    PyramidObject,
     ScannedMeshObject,
     SceneObject,
+    SphereObject,
     YCBObject,
 )
 from so101_nexus.scene import SCENE_LIGHTS_XML, SCENE_VISUAL_XML
@@ -119,13 +123,20 @@ def cube_bounding_radius(obj: CubeObject) -> float:
     return float(obj.half_size * np.sqrt(2))
 
 
+def primitive_bounding_radius(obj: PrimitiveObject) -> float:
+    """Return a primitive's horizontal bounding radius."""
+    if isinstance(obj, (CubeObject, PyramidObject)):
+        return float(obj.half_size * np.sqrt(2))
+    return obj.half_size
+
+
 def collision_geom_name(slot_name: str, obj: SceneObject, part: int = 0) -> str:
     """Return the name of a slot's collision/contact geom.
 
-    Mesh-backed slots (YCB, custom) carry one geom per convex part of their
-    collision decomposition, numbered from zero; cubes carry a single box geom.
+    Mesh-backed slots carry one geom per convex part of their collision
+    decomposition, numbered from zero. Geometric primitives carry one geom.
     """
-    if isinstance(obj, CubeObject):
+    if isinstance(obj, PrimitiveObject):
         return f"{slot_name}_geom"
     return _mesh_collision_geom_name(slot_name, part)
 
@@ -142,6 +153,61 @@ def cube_xml_body(slot_name: str, obj: CubeObject) -> str:
         f'    <body name="{slot_name}" pos="0.15 0 {hs}">\n'
         f'      <freejoint name="{slot_name}_joint"/>\n'
         f'      <geom name="{slot_name}_geom" type="box" size="{hs} {hs} {hs}"\n'
+        f'            rgba="{r} {g} {b} {a}" mass="{obj.mass}"\n'
+        f'            contype="1" conaffinity="1" condim="4" friction="1 0.05 0.001"\n'
+        f'            solref="0.01 1" solimp="0.95 0.99 0.001"/>\n'
+        f"    </body>\n"
+    )
+
+
+def pyramid_xml_asset(asset_index: int, obj: PyramidObject) -> str:
+    """Return the MJCF mesh asset for a square pyramid."""
+    hs = obj.half_size
+    vertices = (
+        (-hs, -hs, -hs),
+        (hs, -hs, -hs),
+        (hs, hs, -hs),
+        (-hs, hs, -hs),
+        (0.0, 0.0, hs),
+    )
+    faces = ((0, 2, 1), (0, 3, 2), (0, 1, 4), (1, 2, 4), (2, 3, 4), (3, 0, 4))
+    vertex_values = " ".join(str(value) for vertex in vertices for value in vertex)
+    face_values = " ".join(str(value) for face in faces for value in face)
+    return (
+        f'    <mesh name="primitive_pyramid_{asset_index}" vertex="{vertex_values}" '
+        f'face="{face_values}"/>\n'
+    )
+
+
+def _primitive_geom_spec(obj: PrimitiveObject, asset_index: int) -> str:
+    if isinstance(obj, CubeObject):
+        return f'type="box" size="{obj.half_size} {obj.half_size} {obj.half_size}"'
+    if isinstance(obj, CylinderObject):
+        return f'type="cylinder" size="{obj.half_size} {obj.half_size}"'
+    if isinstance(obj, SphereObject):
+        return f'type="sphere" size="{obj.half_size}"'
+    if isinstance(obj, PyramidObject):
+        return f'type="mesh" mesh="primitive_pyramid_{asset_index}"'
+    raise TypeError(f"Unsupported primitive type: {type(obj)}")
+
+
+def primitive_visual_xml_geom(geom_name: str, obj: PrimitiveObject, asset_index: int = 0) -> str:
+    """Return a non-colliding MJCF geom for a geometric primitive."""
+    r, g, b, a = COLOR_MAP[obj.color]
+    return (
+        f'      <geom name="{geom_name}" {_primitive_geom_spec(obj, asset_index)} '
+        f'rgba="{r} {g} {b} {a}" contype="0" conaffinity="0"/>\n'
+    )
+
+
+def primitive_xml_body(slot_name: str, obj: PrimitiveObject, asset_index: int) -> str:
+    """Return the MJCF ``<body>`` fragment for one freejoint primitive slot."""
+    hs = obj.half_size
+    r, g, b, a = COLOR_MAP[obj.color]
+    return (
+        f'    <body name="{slot_name}" pos="0.15 0 {hs}">\n'
+        f'      <freejoint name="{slot_name}_joint"/>\n'
+        f'      <geom name="{slot_name}_geom" {_primitive_geom_spec(obj, asset_index)}\n'
         f'            rgba="{r} {g} {b} {a}" mass="{obj.mass}"\n'
         f'            contype="1" conaffinity="1" condim="4" friction="1 0.05 0.001"\n'
         f'            solref="0.01 1" solimp="0.95 0.99 0.001"/>\n'
@@ -270,8 +336,11 @@ def build_object_scene_xml(
                 f' scale="{obj.scale} {obj.scale} {obj.scale}"/>\n'
             )
             body_entries += mesh_xml_body(slot, i, obj.mass)
-        elif isinstance(obj, CubeObject):
-            body_entries += cube_xml_body(slot, obj)
+        elif isinstance(obj, PyramidObject):
+            asset_entries += pyramid_xml_asset(i, obj)
+            body_entries += primitive_xml_body(slot, obj, i)
+        elif isinstance(obj, PrimitiveObject):
+            body_entries += primitive_xml_body(slot, obj, i)
         else:
             raise TypeError(f"Unsupported object type: {type(obj)}")
 
@@ -303,8 +372,8 @@ class ObjectSlot:
     layout and apply to a scalar ``MjData`` (MuJoCo) and a batched
     ``mjw.Data`` column (Warp) alike. ``rest_quat`` is a NumPy ``wxyz`` vector;
     backends convert to tensors as needed. ``geom_ids`` holds every collision
-    geom of the slot (one per convex part of a decomposed mesh, one for a cube),
-    which is what contact scans must aggregate over.
+    geom of the slot (one per convex part of a decomposed mesh, one for a
+    geometric primitive), which is what contact scans must aggregate over.
     """
 
     __slots__ = (
@@ -346,7 +415,7 @@ def _slot_collision_geom_ids(
 ) -> tuple[int, ...]:
     """Return every collision geom id of a slot body, in XML order."""
     geom_ids: list[int] = []
-    if isinstance(obj, CubeObject):
+    if isinstance(obj, PrimitiveObject):
         geom_id = int(mujoco.mj_name2id(mjm, mujoco.mjtObj.mjOBJ_GEOM, f"{slot_name}_geom"))
         geom_ids = [geom_id] if geom_id >= 0 else []
     else:
@@ -389,9 +458,9 @@ def extract_object_slots(
 ) -> list[ObjectSlot]:
     """Read per-slot runtime metadata from a compiled ``MjModel``.
 
-    For cubes the rest pose is identity and the spawn height is the half-size;
-    for mesh-backed objects (YCB, custom) the stable rest orientation and floor
-    clearance come from the union of the compiled collision-part vertices.
+    For geometric primitives the rest pose is identity and the spawn height is
+    the half-size. For mesh-backed objects (YCB, custom), the stable rest
+    orientation and floor clearance come from compiled collision-part vertices.
     """
     slots: list[ObjectSlot] = []
     for slot_name, obj in zip(slot_names, objects, strict=True):
@@ -412,10 +481,10 @@ def extract_object_slots(
             rotated_xy = (verts @ rot.reshape(3, 3).T)[:, :2]
             xy_extent = np.ptp(rotated_xy, axis=0)
             bounding_radius = float(np.linalg.norm(xy_extent) / 2)
-        elif isinstance(obj, CubeObject):
+        elif isinstance(obj, PrimitiveObject):
             rest_quat = np.array([1.0, 0.0, 0.0, 0.0])
             spawn_z = obj.half_size
-            bounding_radius = cube_bounding_radius(obj)
+            bounding_radius = primitive_bounding_radius(obj)
         else:
             raise TypeError(f"Unsupported object type: {type(obj)}")
 
@@ -440,8 +509,8 @@ def object_bounding_radius(obj: SceneObject, compiled_verts: np.ndarray | None =
     mesh vertices (pass ``compiled_verts``), falling back to
     ``DEFAULT_BOUNDING_RADIUS`` when unavailable.
     """
-    if isinstance(obj, CubeObject):
-        return cube_bounding_radius(obj)
+    if isinstance(obj, PrimitiveObject):
+        return primitive_bounding_radius(obj)
     if compiled_verts is not None:
         xy_extent = np.ptp(compiled_verts[:, :2], axis=0)
         return float(np.linalg.norm(xy_extent) / 2)

--- a/src/so101_nexus/objects.py
+++ b/src/so101_nexus/objects.py
@@ -10,6 +10,7 @@ environments use to auto-generate task description strings.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import ClassVar
 
 from so101_nexus.constants import COLOR_MAP, GSO_OBJECTS, YCB_OBJECTS, ColorName
 
@@ -31,18 +32,20 @@ class SceneObject(ABC):
         """Return a natural-language description of this object."""
 
 
-class CubeObject(SceneObject):
-    """Axis-aligned box for use in simulation scenes.
+class PrimitiveObject(SceneObject):
+    """Shared base class for solid-color geometric primitives.
 
     Parameters
     ----------
     half_size : float
-        Half-extent of each side in metres.
+        Half the side length of the cube that contains the primitive, in metres.
     mass : float
         Object mass in kg.
     color : ColorName
         Named color from COLOR_MAP (e.g. "red", "blue").
     """
+
+    shape_name: ClassVar[str]
 
     def __init__(
         self,
@@ -50,6 +53,8 @@ class CubeObject(SceneObject):
         mass: float = 0.01,
         color: ColorName = "red",
     ) -> None:
+        if type(self) is PrimitiveObject:
+            raise TypeError("PrimitiveObject is an abstract base class")
         if half_size <= 0:
             raise ValueError(f"half_size must be positive, got {half_size}")
         if mass <= 0:
@@ -61,7 +66,31 @@ class CubeObject(SceneObject):
         self.color = color
 
     def __repr__(self) -> str:  # noqa: D105
-        return f"{self.color} cube"
+        return f"{self.color} {self.shape_name}"
+
+
+class CubeObject(PrimitiveObject):
+    """Axis-aligned box for use in simulation scenes."""
+
+    shape_name = "cube"
+
+
+class CylinderObject(PrimitiveObject):
+    """Cylinder that fills the same cube as a :class:`CubeObject`."""
+
+    shape_name = "cylinder"
+
+
+class SphereObject(PrimitiveObject):
+    """Sphere that fills the same cube as a :class:`CubeObject`."""
+
+    shape_name = "sphere"
+
+
+class PyramidObject(PrimitiveObject):
+    """Square pyramid that fills the same cube as a :class:`CubeObject`."""
+
+    shape_name = "pyramid"
 
 
 class ScannedMeshObject(SceneObject):

--- a/src/so101_nexus/scene.py
+++ b/src/so101_nexus/scene.py
@@ -56,6 +56,7 @@ def build_robot_floor_scene_xml(
     option_xml: str,
     robot_xml_path: str,
     overhead_camera_xml: str = "",
+    extra_assets: str = "",
     extra_bodies: str = "",
 ) -> str:
     """Build a robot + floor MJCF with no in-scene target marker.
@@ -76,11 +77,14 @@ def build_robot_floor_scene_xml(
         Optional ``<camera>`` element injected into the worldbody, used when an
         ``OverheadCamera`` observation renders on the Warp backend. Empty by
         default (no overhead camera).
+    extra_assets : str
+        Optional ``<asset>`` entries used by ``extra_bodies``. Empty by default.
     extra_bodies : str
         Optional extra ``<worldbody>`` XML (for example a visual-only target
         marker geom rendered by the Warp camera path). Empty by default.
     """
     gr, gg, gb, ga = ground_rgba
+    asset_section = f"  <asset>\n{extra_assets}  </asset>\n\n" if extra_assets else ""
     return f"""\
 <mujoco model="robot_floor_scene">
   <compiler angle="radian"/>
@@ -88,7 +92,7 @@ def build_robot_floor_scene_xml(
   <include file="{robot_xml_path}"/>
   {option_xml}
 
-{SCENE_VISUAL_XML}
+{asset_section}{SCENE_VISUAL_XML}
 
   <worldbody>
 {SCENE_LIGHTS_XML}

--- a/src/so101_nexus/warp/look_at_env.py
+++ b/src/so101_nexus/warp/look_at_env.py
@@ -12,9 +12,10 @@ import warp as wp
 
 from so101_nexus import get_so101_mujoco_model_dir, get_so101_mujoco_model_path
 from so101_nexus.config import ControlMode, LookAtConfig
-from so101_nexus.constants import COLOR_MAP, sample_color
+from so101_nexus.constants import sample_color
 from so101_nexus.gaze import gaze_angle_rad, object_in_view
-from so101_nexus.objects import CubeObject
+from so101_nexus.object_slots import primitive_visual_xml_geom, pyramid_xml_asset
+from so101_nexus.objects import PrimitiveObject, PyramidObject
 from so101_nexus.observations import CameraObservation, GazeDirection, GazeState
 from so101_nexus.rewards import orientation_progress, simple_reward
 from so101_nexus.scene import WARP_SCENE_OPTION_XML, build_robot_floor_scene_xml
@@ -60,20 +61,17 @@ class WarpLookAtVectorEnv(SO101NexusWarpVectorEnv):
             config = LookAtConfig()
         ground_rgba = sample_color(config.ground_colors)
         target = config.objects[0]
-        assert isinstance(target, CubeObject)
+        assert isinstance(target, PrimitiveObject)
+        marker_assets = pyramid_xml_asset(0, target) if isinstance(target, PyramidObject) else ""
         marker_xml = ""
         if any(isinstance(c, CameraObservation) for c in (config.observations or [])):
-            cr, cg, cb, ca = COLOR_MAP[target.color]
-            hs = target.half_size
-            marker_xml = (
-                f'    <geom name="look_target" type="box" size="{hs} {hs} {hs}" '
-                f'rgba="{cr} {cg} {cb} {ca}" contype="0" conaffinity="0"/>\n'
-            )
+            marker_xml = primitive_visual_xml_geom("look_target", target)
         xml_string = build_robot_floor_scene_xml(
             ground_rgba,
             option_xml=WARP_SCENE_OPTION_XML,
             robot_xml_path=str(_SO101_XML),
             overhead_camera_xml=SO101NexusWarpVectorEnv._overhead_camera_xml(config),
+            extra_assets=marker_assets,
             extra_bodies=marker_xml,
         )
         with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", dir=_SO101_DIR, delete=True) as f:

--- a/tests/core/test_object_slots.py
+++ b/tests/core/test_object_slots.py
@@ -22,7 +22,15 @@ from so101_nexus.object_slots import (
     mesh_xml_body,
     object_bounding_radius,
 )
-from so101_nexus.objects import CubeObject, GSOObject, MeshObject, YCBObject
+from so101_nexus.objects import (
+    CubeObject,
+    CylinderObject,
+    GSOObject,
+    MeshObject,
+    PyramidObject,
+    SphereObject,
+    YCBObject,
+)
 from so101_nexus.scene import MUJOCO_SCENE_OPTION_XML
 from so101_nexus.ycb_assets import YCBCollisionPart
 
@@ -86,6 +94,24 @@ class TestXmlBuilders:
     def test_object_bounding_radius_cube(self):
         radius = object_bounding_radius(CubeObject(half_size=0.02))
         assert radius == pytest.approx(0.02 * np.sqrt(2))
+
+    @pytest.mark.parametrize(
+        ("obj", "geom_type", "geom_size"),
+        [
+            (CylinderObject(half_size=0.02, mass=0.03, color="blue"), "cylinder", "0.02 0.02"),
+            (SphereObject(half_size=0.02, mass=0.03, color="blue"), "sphere", "0.02"),
+            (PyramidObject(half_size=0.02, mass=0.03, color="blue"), "mesh", None),
+        ],
+    )
+    def test_primitive_scene_xml_fields(self, obj, geom_type, geom_size):
+        xml, _ = _cube_scene([obj])
+        assert f'type="{geom_type}"' in xml
+        assert 'mass="0.03"' in xml
+        assert "0.0 0.0 1.0 1.0" in xml  # blue rgba
+        if geom_size is not None:
+            assert f'size="{geom_size}' in xml
+        else:
+            assert '<mesh name="primitive_pyramid_0"' in xml
 
     def test_build_scene_xml_uses_warp_option(self):
         from so101_nexus.scene import WARP_SCENE_OPTION_XML
@@ -227,6 +253,29 @@ class TestSlotExtraction:
         np.testing.assert_allclose(slots[0].rest_quat, [1.0, 0.0, 0.0, 0.0])
         for slot in slots:
             assert slot.geom_id >= 0
+
+    def test_extract_equal_bounding_shape_slots(self):
+        half_size = 0.02
+        objects = [
+            CubeObject(half_size=half_size),
+            CylinderObject(half_size=half_size),
+            SphereObject(half_size=half_size),
+            PyramidObject(half_size=half_size),
+        ]
+        xml, slot_names = _cube_scene(objects)
+        so_dir = get_so101_mujoco_model_path().parent
+        with tempfile.NamedTemporaryFile("w", suffix=".xml", dir=so_dir, delete=True) as f:
+            f.write(xml)
+            f.flush()
+            mjm = mujoco.MjModel.from_xml_path(f.name)
+        slots = extract_object_slots(mjm, slot_names, objects)
+
+        assert [slot.spawn_z for slot in slots] == pytest.approx([half_size] * len(objects))
+        assert [object_bounding_radius(obj) for obj in objects] == pytest.approx(
+            [half_size * np.sqrt(2), half_size, half_size, half_size * np.sqrt(2)]
+        )
+        for slot in slots:
+            np.testing.assert_allclose(slot.rest_quat, [1.0, 0.0, 0.0, 0.0])
 
     def test_mesh_bounding_radius_uses_rotated_footprint(self, tmp_path):
         # A box thin in X: the stable rest pose rotates X up, so the horizontal

--- a/tests/core/test_objects.py
+++ b/tests/core/test_objects.py
@@ -2,10 +2,13 @@ import pytest
 
 from so101_nexus.objects import (
     CubeObject,
+    CylinderObject,
     GSOObject,
     MeshObject,
+    PyramidObject,
     ScannedMeshObject,
     SceneObject,
+    SphereObject,
     YCBObject,
 )
 
@@ -35,6 +38,9 @@ class TestSceneObjectBase:
     def test_all_have_repr(self):
         objects: list[SceneObject] = [
             CubeObject(),
+            CylinderObject(),
+            SphereObject(),
+            PyramidObject(),
             YCBObject(model_id="009_gelatin_box"),
             GSOObject(model_id="CoQ10"),
             MeshObject(
@@ -63,6 +69,33 @@ class TestCubeObject:
     def test_invalid_color(self):
         with pytest.raises(ValueError, match="color must be one of"):
             CubeObject(color="fuschia")
+
+
+@pytest.mark.parametrize(
+    ("object_type", "shape_name"),
+    [
+        (CylinderObject, "cylinder"),
+        (SphereObject, "sphere"),
+        (PyramidObject, "pyramid"),
+    ],
+)
+class TestShapeObjects:
+    def test_defaults(self, object_type, shape_name):
+        obj = object_type()
+        assert obj.half_size > 0
+        assert obj.mass > 0
+        assert repr(obj) == f"red {shape_name}"
+
+    def test_accepts_cube_colors(self, object_type, shape_name):
+        assert repr(object_type(color="green")) == f"green {shape_name}"
+
+    def test_rejects_invalid_size(self, object_type, shape_name):
+        with pytest.raises(ValueError, match="half_size must be positive"):
+            object_type(half_size=-0.01)
+
+    def test_rejects_invalid_color(self, object_type, shape_name):
+        with pytest.raises(ValueError, match="color must be one of"):
+            object_type(color="fuschia")
 
 
 class TestYCBObject:

--- a/tests/mujoco/test_envs.py
+++ b/tests/mujoco/test_envs.py
@@ -35,7 +35,14 @@ from so101_nexus.config import (
 from so101_nexus.constants import CUBE_COLOR_MAP, GSO_OBJECTS, YCB_OBJECTS
 from so101_nexus.kinematics import EE_ACTION_DIM
 from so101_nexus.mujoco.base_env import SO101NexusMuJoCoBaseEnv
-from so101_nexus.objects import CubeObject, GSOObject, YCBObject
+from so101_nexus.objects import (
+    CubeObject,
+    CylinderObject,
+    GSOObject,
+    PyramidObject,
+    SphereObject,
+    YCBObject,
+)
 from so101_nexus.observations import (
     EndEffectorPose,
     GazeDirection,
@@ -352,6 +359,25 @@ def test_pick_cube_color(color):
         env.close()
 
 
+@pytest.mark.parametrize(
+    ("object_type", "shape_name"),
+    [
+        (CylinderObject, "cylinder"),
+        (SphereObject, "sphere"),
+        (PyramidObject, "pyramid"),
+    ],
+)
+def test_pick_geometric_primitive(object_type, shape_name):
+    config = PickConfig(objects=[object_type(half_size=0.02, color="green")])
+    env = gym.make("MuJoCoPickLift-v1", config=config)
+    try:
+        env.reset(seed=0)
+        assert env.unwrapped.task_description == f"Pick up the green {shape_name}."  # type: ignore[attr-defined]
+        _run_episode(env)
+    finally:
+        env.close()
+
+
 @pytest.mark.parametrize("model_id", YCB_MODEL_IDS)
 def test_pick_ycb_object(model_id):
     config = PickConfig(objects=[YCBObject(model_id=model_id)])
@@ -436,6 +462,25 @@ def test_look_at_cube_color(color):
     try:
         env.reset()
         assert color in env.unwrapped.task_description  # type: ignore[attr-defined]
+        _run_episode(env)
+    finally:
+        env.close()
+
+
+@pytest.mark.parametrize(
+    ("object_type", "shape_name"),
+    [
+        (CylinderObject, "cylinder"),
+        (SphereObject, "sphere"),
+        (PyramidObject, "pyramid"),
+    ],
+)
+def test_look_at_geometric_primitive(object_type, shape_name):
+    config = LookAtConfig(objects=[object_type(half_size=0.02, color="blue")])
+    env = gym.make("MuJoCoLookAt-v1", config=config)
+    try:
+        env.reset(seed=0)
+        assert env.unwrapped.task_description == f"Look at the blue {shape_name}."  # type: ignore[attr-defined]
         _run_episode(env)
     finally:
         env.close()

--- a/tests/warp/test_warp_camera.py
+++ b/tests/warp/test_warp_camera.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from so101_nexus.objects import CubeObject, CylinderObject, PyramidObject, SphereObject
+
 pytestmark = pytest.mark.warp
 
 # Tiny resolutions keep the CPU ray-trace fast while still exercising H != W.
@@ -243,16 +245,16 @@ def test_camera_only_config_has_empty_state():
     assert obs["wrist_camera"].shape == (2, WRIST_H, WRIST_W, 3)
 
 
-def test_lookat_renders_target_marker():
+@pytest.mark.parametrize("object_type", [CubeObject, CylinderObject, SphereObject, PyramidObject])
+def test_lookat_renders_target_marker(object_type):
     import torch
 
     from so101_nexus.config import LookAtConfig
-    from so101_nexus.objects import CubeObject
     from so101_nexus.observations import JointPositions, OverheadCamera
     from so101_nexus.warp.look_at_env import WarpLookAtVectorEnv
 
     cfg = LookAtConfig(
-        objects=[CubeObject(color="blue", half_size=0.03)],
+        objects=[object_type(color="blue", half_size=0.03)],
         observations=[JointPositions(), OverheadCamera(width=48, height=48)],
     )
     env = WarpLookAtVectorEnv(num_envs=2, config=cfg, device="cpu", seed=0)

--- a/tests/warp/test_warp_heterogeneous.py
+++ b/tests/warp/test_warp_heterogeneous.py
@@ -21,6 +21,38 @@ def test_touch_threshold_vector_matches_selected_bounding_radius():
     assert radius.unique().numel() > 1
 
 
+@pytest.mark.parametrize(
+    ("object_type", "shape_name"),
+    [
+        ("CylinderObject", "cylinder"),
+        ("SphereObject", "sphere"),
+        ("PyramidObject", "pyramid"),
+    ],
+)
+def test_pick_geometric_primitive(object_type, shape_name):
+    import torch
+
+    from so101_nexus.config import PickConfig
+    from so101_nexus.objects import CylinderObject, PyramidObject, SphereObject
+    from so101_nexus.warp.pick_env import WarpPickLiftVectorEnv
+
+    objects = {
+        "CylinderObject": CylinderObject,
+        "SphereObject": SphereObject,
+        "PyramidObject": PyramidObject,
+    }
+    env = WarpPickLiftVectorEnv(
+        num_envs=2,
+        config=PickConfig(objects=[objects[object_type](half_size=0.02, color="green")]),
+        device="cpu",
+        seed=0,
+    )
+    obs, _ = env.reset(seed=0)
+
+    assert torch.isfinite(obs).all()
+    assert env.task_descriptions == [f"Pick up the green {shape_name}."] * 2
+
+
 def test_pnp_ycb_object_target_offset_and_finite_reward():
     import torch
 


### PR DESCRIPTION
## Summary
- Add cylinder, sphere, and pyramid scene objects with cube colors.
- Keep every primitive inside the same cube as CubeObject.
- Support Pick and LookAt scenes on MuJoCo and MuJoCo Warp.

## Validation
- make format && make lint && make typecheck
- make test

Full suite: 1631 passed, 2 skipped.