### PR TITLE
chore(release): 0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ for the public-API and deprecation policy.
 
 ## [Unreleased]
 
+## [0.5.3] - 2026-08-27
+
 ### Added
 
 - `CylinderObject`, `SphereObject`, and `PyramidObject` add solid-color
@@ -555,7 +557,8 @@ for the public-API and deprecation policy.
 
 - Initial release: SO-101 MuJoCo simulation with cameras, GitHub Actions CI, and the core project structure.
 
-[Unreleased]: https://github.com/johnsutor/so101-nexus/compare/0.5.2...HEAD
+[Unreleased]: https://github.com/johnsutor/so101-nexus/compare/0.5.3...HEAD
+[0.5.3]: https://github.com/johnsutor/so101-nexus/compare/0.5.2...0.5.3
 [0.5.2]: https://github.com/johnsutor/so101-nexus/compare/0.5.1...0.5.2
 [0.5.1]: https://github.com/johnsutor/so101-nexus/compare/0.5.0...0.5.1
 [0.5.0]: https://github.com/johnsutor/so101-nexus/compare/0.4.13...0.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "so101-nexus"
-version = "0.5.2"
+version = "0.5.3"
 description = "End-to-end simulation and training stack for the SO-101 arm: record demonstrations, clone behavior, and reinforce with GPU-parallel MuJoCo / MuJoCo Warp environments, built on LeRobot"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -3534,7 +3534,7 @@ wheels = [
 
 [[package]]
 name = "so101-nexus"
-version = "0.5.2"
+version = "0.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "gymnasium" },


### PR DESCRIPTION
## What changed

- Bumped the package metadata to `0.5.3`.
- Promoted the unreleased geometric primitives and GSO asset entries to `0.5.3`.
- Updated the lockfile and changelog comparison links.

## Why

- Prepare the `0.5.3` patch release from `main`.

## Validation

- `make format lint typecheck`
- `uv run pytest tests/test_docs_consistency.py -q` (15 passed)
- `make test` (1,631 passed, 2 skipped)
- `uv build --out-dir /tmp/so101-nexus-0.5.3-dist`

## Checklist

- [ ] Tests added or updated (metadata-only change).
- [x] `make format lint typecheck` and the relevant tests pass locally.
- [x] Documentation updated if the public API or behavior changed.
- [x] `CHANGELOG.md` `## [Unreleased]` entry added for any user-facing change.
- [x] No em dashes or emoji in prose, docs, or comments.