### PR TITLE
fix(warp): constrain published runtime dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ for the public-API and deprecation policy.
 
 ## [Unreleased]
 
+## [0.5.4] - 2026-08-27
+
+### Fixed
+
+- `so101-nexus[warp]` now constrains `warp-lang` to `>=1.14,<1.16` and
+  `torch` to `<2.10`. `mujoco-warp==3.9.0.1` leaves both dependencies
+  unconstrained. Pip selected `warp-lang==1.16.0`, which failed CPU Warp sensor
+  code generation, and a CUDA 13 Torch build, which rejected a CUDA 12.8 NVIDIA
+  driver. The package now resolves Warp 1.15.0 and Torch 2.9.1+cu128.
+
 ## [0.5.3] - 2026-08-27
 
 ### Added
@@ -557,7 +567,8 @@ for the public-API and deprecation policy.
 
 - Initial release: SO-101 MuJoCo simulation with cameras, GitHub Actions CI, and the core project structure.
 
-[Unreleased]: https://github.com/johnsutor/so101-nexus/compare/0.5.3...HEAD
+[Unreleased]: https://github.com/johnsutor/so101-nexus/compare/0.5.4...HEAD
+[0.5.4]: https://github.com/johnsutor/so101-nexus/compare/0.5.3...0.5.4
 [0.5.3]: https://github.com/johnsutor/so101-nexus/compare/0.5.2...0.5.3
 [0.5.2]: https://github.com/johnsutor/so101-nexus/compare/0.5.1...0.5.2
 [0.5.1]: https://github.com/johnsutor/so101-nexus/compare/0.5.0...0.5.1

--- a/docs/content/docs/api/stability.mdx
+++ b/docs/content/docs/api/stability.mdx
@@ -43,7 +43,7 @@ A name whose only safe behavior would be a breaking change, for example a path t
 
 - **Python**: 3.12 and 3.13, verified in continuous integration.
 - **Operating systems**: Linux and macOS are exercised in continuous integration for the MuJoCo backend.
-- **Backends**: the MuJoCo backend is stable. The MuJoCo Warp backend (`so101-nexus[warp]`) is experimental; its API and physics may change between minor releases, and it requires an NVIDIA GPU with CUDA >= 12.4 for GPU execution. Warp has no ROCm/AMD support.
+- **Backends**: the MuJoCo backend is stable. The MuJoCo Warp backend (`so101-nexus[warp]`) is experimental; its API and physics may change between minor releases, and it requires an NVIDIA GPU with CUDA >= 12.8 for GPU execution. Warp has no ROCm/AMD support.
 - **Accelerators**: `so101-nexus[rocm]` builds MuJoCo-backend training against AMD's ROCm 7.2 PyTorch index on Linux x86_64, with the resolution constraints covered in [Installation](/docs/getting-started/installation).
 
 ## Determinism

--- a/docs/content/docs/concepts/backends.mdx
+++ b/docs/content/docs/concepts/backends.mdx
@@ -33,7 +33,7 @@ Warp uses the implicit integrator without the noslip constraint, so policies may
 
 ## Installation and Hardware
 
-Install the backend with the `warp` extra, which needs an NVIDIA GPU and CUDA >= 12.4 for GPU execution. Warp has no ROCm/AMD support. To train on an AMD GPU you install the `rocm` extra instead, which affects only the MuJoCo backend's training loop; see [Installation](/docs/getting-started/installation).
+Install the backend with the `warp` extra, which needs an NVIDIA GPU and CUDA >= 12.8 for GPU execution. Warp has no ROCm/AMD support. To train on an AMD GPU you install the `rocm` extra instead, which affects only the MuJoCo backend's training loop; see [Installation](/docs/getting-started/installation).
 
 ## Objects
 

--- a/docs/content/docs/getting-started/installation.mdx
+++ b/docs/content/docs/getting-started/installation.mdx
@@ -44,7 +44,7 @@ The base install ships the MuJoCo backend and the environment API. Everything el
 | `teleop` | Gradio demonstration recorder: `lerobot[feetech]`, `gradio`, `plotly`, `opencv-python` | `pip install "so101-nexus[teleop]"` |
 | `decomp` | Measured convex decomposition of YCB collision meshes (`coacd`, `rtree`, `threadpoolctl`). Without it YCB collision geometry falls back to a single convex hull. The packages ship wheels for the supported platforms | `pip install "so101-nexus[decomp]"` |
 | `train` | Torch training dependencies for the PPO and BC examples | `pip install "so101-nexus[train]"` |
-| `warp` | GPU-parallel MuJoCo Warp backend. Needs an NVIDIA GPU and CUDA >= 12.4 | `pip install "so101-nexus[warp]"` |
+| `warp` | GPU-parallel MuJoCo Warp backend. Needs an NVIDIA GPU and CUDA >= 12.8 | `pip install "so101-nexus[warp]"` |
 | `rocm` | PyTorch from AMD's ROCm 7.2 wheel index. See below | `uv sync --extra train --extra rocm --no-default-groups` |
 
 Extras combine: `pip install "so101-nexus[teleop,train]"`.

--- a/docs/content/docs/getting-started/quickstart.mdx
+++ b/docs/content/docs/getting-started/quickstart.mdx
@@ -69,7 +69,7 @@ envs.close()
 ```
 
 <Callout type="warn">
-  The Warp backend is experimental. It needs an NVIDIA GPU with CUDA >= 12.4, and its physics differs from MuJoCo, so a policy may need re-tuning across backends. See [Backends](/docs/concepts/backends) and [Stability and versioning](/docs/api/stability).
+  The Warp backend is experimental. It needs an NVIDIA GPU with CUDA >= 12.8, and its physics differs from MuJoCo, so a policy may need re-tuning across backends. See [Backends](/docs/concepts/backends) and [Stability and versioning](/docs/api/stability).
 </Callout>
 
 `all_registered_env_ids()` reports the ids for whichever backends you imported, six per backend:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "so101-nexus"
-version = "0.5.3"
+version = "0.5.4"
 description = "End-to-end simulation and training stack for the SO-101 arm: record demonstrations, clone behavior, and reinforce with GPU-parallel MuJoCo / MuJoCo Warp environments, built on LeRobot"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -45,7 +45,8 @@ train = [
 ]
 warp = [
     "mujoco-warp>=3.9.0.1,<3.10",
-    "torch",
+    "torch<2.10",
+    "warp-lang>=1.14,<1.16",
 ]
 rocm = [
     "torch; sys_platform == 'linux' and platform_machine == 'x86_64'",
@@ -58,6 +59,7 @@ conflicts = [
     [{ extra = "rocm" }, { extra = "teleop" }],
     [{ extra = "rocm" }, { group = "test" }],
     [{ extra = "rocm" }, { group = "dev" }],
+    [{ extra = "rocm" }, { extra = "warp" }],
 ]
 
 [tool.uv.sources]
@@ -95,6 +97,8 @@ test = [
     "imageio[ffmpeg]",
     "Pillow",
     "lerobot[feetech]>=0.5.0,<0.6",
+    "torch<2.10",
+    "torchcodec<0.10",
 ]
 visual = ["litellm", "Pillow", "imageio[ffmpeg]"]
 

--- a/tests/test_rocm_extra.py
+++ b/tests/test_rocm_extra.py
@@ -25,11 +25,28 @@ def test_rocm_extra_declared() -> None:
 
 
 def test_default_extras_do_not_reference_rocm_index() -> None:
-    """``train``/``warp`` still declare bare ``torch``, unaffected by rocm."""
+    """``train`` and ``warp`` resolve torch from the default package index."""
     extras = PYPROJECT["project"]["optional-dependencies"]
     for extra in ("train", "warp"):
-        assert extras[extra].count("torch") == 1
-        assert "torch" in extras[extra]
+        torch_requirements = [
+            dependency for dependency in extras[extra] if dependency.startswith("torch")
+        ]
+        assert len(torch_requirements) == 1
+        assert all("rocm" not in dependency for dependency in torch_requirements)
+
+
+def test_warp_extra_pins_compatible_runtime_versions() -> None:
+    """The Warp runtime pins versions that its released package smoke test supports."""
+    warp = PYPROJECT["project"]["optional-dependencies"]["warp"]
+    assert "torch<2.10" in warp
+    assert "warp-lang>=1.14,<1.16" in warp
+
+
+def test_test_group_pins_compatible_torchcodec() -> None:
+    """The test suite uses a TorchCodec release compatible with the Warp Torch cap."""
+    test_dependencies = PYPROJECT["dependency-groups"]["test"]
+    assert "torch<2.10" in test_dependencies
+    assert "torchcodec<0.10" in test_dependencies
 
 
 def test_torch_sources_route_only_the_rocm_extra_to_the_rocm_index() -> None:
@@ -50,10 +67,11 @@ def test_rocm_index_is_explicit_and_points_at_rocm72() -> None:
 
 
 def test_rocm_conflicts_with_extras_and_groups_pinning_incompatible_torch() -> None:
-    """rocm (torch>=2.11) can never resolve alongside lerobot's torch<2.11 pin."""
+    """ROCm cannot combine with dependency sets that pin incompatible Torch versions."""
     conflicts = PYPROJECT["tool"]["uv"]["conflicts"]
     rocm_pairs = [{frozenset(m.items()) for m in pair} for pair in conflicts]
     assert frozenset({("extra", "rocm")}) in {p for pair in rocm_pairs for p in pair}
     assert {frozenset({("extra", "rocm")}), frozenset({("extra", "teleop")})} in rocm_pairs
     assert {frozenset({("extra", "rocm")}), frozenset({("group", "test")})} in rocm_pairs
     assert {frozenset({("extra", "rocm")}), frozenset({("group", "dev")})} in rocm_pairs
+    assert {frozenset({("extra", "rocm")}), frozenset({("extra", "warp")})} in rocm_pairs

--- a/uv.lock
+++ b/uv.lock
@@ -20,14 +20,14 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform == 'emscripten' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
     "python_full_version < '3.13' and sys_platform == 'darwin' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
     "python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
-    "python_full_version >= '3.14' and sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
-    "python_full_version < '3.14' and sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
-    "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
-    "python_full_version < '3.14' and sys_platform == 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
-    "python_full_version < '3.14' and sys_platform == 'emscripten' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
-    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version >= '3.14' and sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'extra-11-so101-nexus-warp' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version < '3.14' and sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'extra-11-so101-nexus-warp' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'extra-11-so101-nexus-warp' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'extra-11-so101-nexus-warp' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'extra-11-so101-nexus-warp' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version < '3.14' and sys_platform == 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'extra-11-so101-nexus-warp' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version < '3.14' and sys_platform == 'emscripten' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'extra-11-so101-nexus-warp' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'extra-11-so101-nexus-warp' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
     "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
     "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
     "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
@@ -50,6 +50,9 @@ conflicts = [[
 ], [
     { package = "so101-nexus", extra = "rocm" },
     { package = "so101-nexus", group = "dev" },
+], [
+    { package = "so101-nexus", extra = "rocm" },
+    { package = "so101-nexus", extra = "warp" },
 ]]
 
 [[package]]
@@ -72,7 +75,7 @@ dependencies = [
     { name = "psutil" },
     { name = "pyyaml" },
     { name = "safetensors" },
-    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "torch", version = "2.9.1", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ca/14/787e5498cd062640f0f3d92ef4ae4063174f76f9afd29d13fc52a319daae/accelerate-1.13.0.tar.gz", hash = "sha256:d631b4e0f5b3de4aff2d7e9e6857d164810dfc3237d54d017f075122d057b236", size = 402835, upload-time = "2026-03-04T19:34:12.359Z" }
 wheels = [
@@ -188,7 +191,7 @@ version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "frozenlist" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
@@ -219,7 +222,7 @@ version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
 wheels = [
@@ -337,11 +340,11 @@ dependencies = [
     { name = "narwhals" },
     { name = "numpy" },
     { name = "packaging" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
     { name = "pillow" },
     { name = "pyyaml" },
-    { name = "tornado", marker = "sys_platform != 'emscripten' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "tornado", marker = "sys_platform != 'emscripten' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
     { name = "xyzservices" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e4/31/7ee0c4dfd0255631b0624ce01be178704f91f763f02a1879368eb109befd/bokeh-3.8.2.tar.gz", hash = "sha256:8e7dcacc21d53905581b54328ad2705954f72f2997f99fc332c1de8da53aa3cc", size = 6529251, upload-time = "2026-01-06T00:20:06.568Z" }
@@ -401,7 +404,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -515,7 +518,7 @@ name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
 wheels = [
@@ -731,53 +734,20 @@ wheels = [
 ]
 
 [[package]]
-name = "cuda-bindings"
-version = "12.9.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cuda-pathfinder", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/c2/65bfd79292b8ff18be4dd7f7442cea37bcbc1a228c1886f1dea515c45b67/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:694ba35023846625ef471257e6b5a4bc8af690f961d197d77d34b1d1db393f56", size = 11760260, upload-time = "2025-10-21T14:51:40.79Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/c1/dabe88f52c3e3760d861401bb994df08f672ec893b8f7592dc91626adcf3/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fda147a344e8eaeca0c6ff113d2851ffca8f7dfc0a6c932374ee5c47caa649c8", size = 12151019, upload-time = "2025-10-21T14:51:43.167Z" },
-    { url = "https://files.pythonhosted.org/packages/df/6b/9c1b1a6c01392bfdd758e9486f52a1a72bc8f49e98f9355774ef98b5fb4e/cuda_bindings-12.9.4-cp312-cp312-win_amd64.whl", hash = "sha256:696ca75d249ddf287d01b9a698b8e2d8a05046495a9c051ca15659dc52d17615", size = 11586961, upload-time = "2025-10-21T14:51:45.394Z" },
-    { url = "https://files.pythonhosted.org/packages/05/8b/b4b2d1c7775fa403b64333e720cfcfccef8dcb9cdeb99947061ca5a77628/cuda_bindings-12.9.4-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf8bfaedc238f3b115d957d1fd6562b7e8435ba57f6d0e2f87d0e7149ccb2da5", size = 11570071, upload-time = "2025-10-21T14:51:47.472Z" },
-    { url = "https://files.pythonhosted.org/packages/63/56/e465c31dc9111be3441a9ba7df1941fe98f4aa6e71e8788a3fb4534ce24d/cuda_bindings-12.9.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:32bdc5a76906be4c61eb98f546a6786c5773a881f3b166486449b5d141e4a39f", size = 11906628, upload-time = "2025-10-21T14:51:49.905Z" },
-    { url = "https://files.pythonhosted.org/packages/05/d0/d0e4e2e047d8e899f023fa15ad5e9894ce951253f4c894f1cd68490fdb14/cuda_bindings-12.9.4-cp313-cp313-win_amd64.whl", hash = "sha256:a2e82c8985948f953c2be51df45c3fe11c812a928fca525154fb9503190b3e64", size = 11556719, upload-time = "2025-10-21T14:51:52.248Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/07/6aff13bc1e977e35aaa6b22f52b172e2890c608c6db22438cf7ed2bf43a6/cuda_bindings-12.9.4-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3adf4958dcf68ae7801a59b73fb00a8b37f8d0595060d66ceae111b1002de38d", size = 11566797, upload-time = "2025-10-21T14:51:54.581Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/84/1e6be415e37478070aeeee5884c2022713c1ecc735e6d82d744de0252eee/cuda_bindings-12.9.4-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56e0043c457a99ac473ddc926fe0dc4046694d99caef633e92601ab52cbe17eb", size = 11925991, upload-time = "2025-10-21T14:51:56.535Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/3c/972edfddb4ae8a9fccd3c3766ed47453b6f805b6026b32f10209dd4b8ad4/cuda_bindings-12.9.4-cp313-cp313t-win_amd64.whl", hash = "sha256:b32d8b685f0e66f5658bcf4601ef034e89fc2843582886f0a58784a4302da06c", size = 11894363, upload-time = "2025-10-21T14:51:58.633Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/b5/96a6696e20c4ffd2b327f54c7d0fde2259bdb998d045c25d5dedbbe30290/cuda_bindings-12.9.4-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1f53a7f453d4b2643d8663d036bafe29b5ba89eb904c133180f295df6dc151e5", size = 11624530, upload-time = "2025-10-21T14:52:01.539Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/af/6dfd8f2ed90b1d4719bc053ff8940e494640fe4212dc3dd72f383e4992da/cuda_bindings-12.9.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8b72ee72a9cc1b531db31eebaaee5c69a8ec3500e32c6933f2d3b15297b53686", size = 11922703, upload-time = "2025-10-21T14:52:03.585Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/87/652796522cc1a7af559460e1ce59b642e05c1468b9c08522a9a096b4cf04/cuda_bindings-12.9.4-cp314-cp314-win_amd64.whl", hash = "sha256:53a10c71fdbdb743e0268d07964e5a996dd00b4e43831cbfce9804515d97d575", size = 11517716, upload-time = "2025-10-21T14:52:06.013Z" },
-    { url = "https://files.pythonhosted.org/packages/39/73/d2fc40c043bac699c3880bf88d3cebe9d88410cd043795382826c93a89f0/cuda_bindings-12.9.4-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20f2699d61d724de3eb3f3369d57e2b245f93085cab44fd37c3bea036cea1a6f", size = 11565056, upload-time = "2025-10-21T14:52:08.338Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/19/90ac264acc00f6df8a49378eedec9fd2db3061bf9263bf9f39fd3d8377c3/cuda_bindings-12.9.4-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d80bffc357df9988dca279734bc9674c3934a654cab10cadeed27ce17d8635ee", size = 11924658, upload-time = "2025-10-21T14:52:10.411Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/52/a30f46e822bfa6b4a659d1e8de8c4a4adf908ea075dac568b55362541bd8/cuda_bindings-12.9.4-cp314-cp314t-win_amd64.whl", hash = "sha256:53e11991a92ff6f26a0c8a98554cd5d6721c308a6b7bfb08bebac9201e039e43", size = 12055608, upload-time = "2025-10-21T14:52:12.335Z" },
-]
-
-[[package]]
-name = "cuda-pathfinder"
-version = "1.3.4"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/5e/db279a3bfbd18d59d0598922a3b3c1454908d0969e8372260afec9736376/cuda_pathfinder-1.3.4-py3-none-any.whl", hash = "sha256:fb983f6e0d43af27ef486e14d5989b5f904ef45cedf40538bfdcbffa6bb01fb2", size = 30878, upload-time = "2026-02-11T18:50:31.008Z" },
-]
-
-[[package]]
 name = "datasets"
 version = "4.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dill" },
     { name = "filelock" },
-    { name = "fsspec", extra = ["http"], marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "fsspec", extra = ["http"], marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'extra-11-so101-nexus-warp' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
     { name = "httpx" },
     { name = "huggingface-hub" },
     { name = "multiprocess" },
     { name = "numpy" },
     { name = "packaging" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
     { name = "pyarrow" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -1176,8 +1146,8 @@ dependencies = [
     { name = "numpy" },
     { name = "orjson" },
     { name = "packaging" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
     { name = "pillow" },
     { name = "pydantic" },
     { name = "pydub" },
@@ -1354,7 +1324,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
     { name = "httpx" },
     { name = "packaging" },
     { name = "pyyaml" },
@@ -1585,7 +1555,7 @@ dependencies = [
     { name = "einops" },
     { name = "gymnasium" },
     { name = "huggingface-hub" },
-    { name = "imageio", extra = ["ffmpeg"], marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "imageio", extra = ["ffmpeg"], marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'extra-11-so101-nexus-warp' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
     { name = "jsonlines" },
     { name = "numpy" },
     { name = "opencv-python-headless" },
@@ -1595,7 +1565,7 @@ dependencies = [
     { name = "rerun-sdk" },
     { name = "setuptools" },
     { name = "termcolor" },
-    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "torch", version = "2.9.1", source = { registry = "https://pypi.org/simple" } },
     { name = "torchcodec", marker = "(platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l' and sys_platform == 'linux') or (platform_machine != 'x86_64' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')" },
     { name = "torchvision" },
     { name = "wandb" },
@@ -1798,7 +1768,7 @@ version = "3.9.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "absl-py" },
-    { name = "etils", extra = ["epath"] },
+    { name = "etils", extra = ["epath"], marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'extra-11-so101-nexus-warp' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
     { name = "mujoco" },
     { name = "numpy" },
     { name = "warp-lang" },
@@ -2034,7 +2004,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-cublas-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/41/e79269ce215c857c935fd86bcfe91a451a584dfc27f1e068f568b9ad1ab7/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c9132cc3f8958447b4910a1720036d9eff5928cc3179b0a51fb6d167c6cc87d8", size = 705026878, upload-time = "2025-06-06T21:52:51.348Z" },
@@ -2047,7 +2017,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/bc/7771846d3a0272026c416fbb7e5f4c1f146d6d80704534d0b187dd6f4800/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a", size = 193109211, upload-time = "2025-03-07T01:44:56.873Z" },
@@ -2079,9 +2049,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "nvidia-cusparse-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-cublas-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-cusparse-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/32/f7cd6ce8a7690544d084ea21c26e910a97e077c9b7f07bf5de623ee19981/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0", size = 267229841, upload-time = "2025-03-07T01:46:54.356Z" },
@@ -2094,7 +2064,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/f7/cd777c4109681367721b00a106f491e0d0d15cfa1fd59672ce580ce42a97/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc", size = 288117129, upload-time = "2025-03-07T01:47:40.407Z" },
@@ -2133,11 +2103,11 @@ wheels = [
 
 [[package]]
 name = "nvidia-nvshmem-cu12"
-version = "3.4.5"
+version = "3.3.20"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/6a/03aa43cc9bd3ad91553a88b5f6fb25ed6a3752ae86ce2180221962bc2aa5/nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0b48363fc6964dede448029434c6abed6c5e37f823cb43c3bcde7ecfc0457e15", size = 138936938, upload-time = "2025-09-06T00:32:05.589Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/09/6ea3ea725f82e1e76684f0708bbedd871fc96da89945adeba65c3835a64c/nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:042f2500f24c021db8a06c5eec2539027d57460e1c1a762055a6554f72c369bd", size = 139103095, upload-time = "2025-09-06T00:32:31.266Z" },
+    { url = "https://files.pythonhosted.org/packages/92/9d/3dd98852568fb845ec1f7902c90a22b240fe1cbabda411ccedf2fd737b7b/nvidia_nvshmem_cu12-3.3.20-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0b0b960da3842212758e4fa4696b94f129090b30e5122fea3c5345916545cff0", size = 124484616, upload-time = "2025-08-04T20:24:59.172Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/6c/99acb2f9eb85c29fc6f3a7ac4dccfd992e22666dd08a642b303311326a97/nvidia_nvshmem_cu12-3.3.20-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d00f26d3f9b2e3c3065be895e3059d6479ea5c638a3f38c9fec49b1b9dd7c1e5", size = 124657145, upload-time = "2025-08-04T20:25:19.995Z" },
 ]
 
 [[package]]
@@ -2286,10 +2256,10 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
     "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
     "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
-    "python_full_version >= '3.14' and sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
-    "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version >= '3.14' and sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'extra-11-so101-nexus-warp' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'extra-11-so101-nexus-warp' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'extra-11-so101-nexus-warp' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'extra-11-so101-nexus-warp' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
     "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
     "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
     "python_full_version >= '3.14' and sys_platform == 'darwin' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
@@ -2298,10 +2268,10 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version >= '3.14' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.14' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "pytz", marker = "python_full_version >= '3.14' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "tzdata", marker = "python_full_version >= '3.14' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "numpy", marker = "python_full_version >= '3.14' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.14' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "pytz", marker = "python_full_version >= '3.14' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "tzdata", marker = "python_full_version >= '3.14' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -2357,10 +2327,10 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform == 'emscripten' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
     "python_full_version < '3.13' and sys_platform == 'darwin' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
     "python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
-    "python_full_version < '3.14' and sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
-    "python_full_version < '3.14' and sys_platform == 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
-    "python_full_version < '3.14' and sys_platform == 'emscripten' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
-    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version < '3.14' and sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'extra-11-so101-nexus-warp' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version < '3.14' and sys_platform == 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'extra-11-so101-nexus-warp' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version < '3.14' and sys_platform == 'emscripten' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'extra-11-so101-nexus-warp' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'extra-11-so101-nexus-warp' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
     "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
     "python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
     "python_full_version < '3.14' and sys_platform == 'darwin' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
@@ -2369,9 +2339,9 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.14' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "python-dateutil", marker = "python_full_version < '3.14' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "tzdata", marker = "(python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test') or (sys_platform == 'emscripten' and extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (sys_platform == 'emscripten' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (sys_platform == 'emscripten' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test') or (sys_platform == 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (sys_platform == 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (sys_platform == 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "numpy", marker = "python_full_version < '3.14' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "python-dateutil", marker = "python_full_version < '3.14' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "tzdata", marker = "(python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test') or (sys_platform == 'emscripten' and extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (sys_platform == 'emscripten' and extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (sys_platform == 'emscripten' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (sys_platform == 'emscripten' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test') or (sys_platform == 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (sys_platform == 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (sys_platform == 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (sys_platform == 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/0c/b28ed414f080ee0ad153f848586d61d1878f91689950f037f976ce15f6c8/pandas-3.0.1.tar.gz", hash = "sha256:4186a699674af418f655dbd420ed87f50d56b4cd6603784279d9eef6627823c8", size = 4641901, upload-time = "2026-02-17T22:20:16.434Z" }
 wheels = [
@@ -2946,7 +2916,7 @@ name = "pytest-cov"
 version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "coverage", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "coverage", marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'extra-11-so101-nexus-warp' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
     { name = "pluggy" },
     { name = "pytest" },
 ]
@@ -3106,7 +3076,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "rpds-py" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
@@ -3534,7 +3504,7 @@ wheels = [
 
 [[package]]
 name = "so101-nexus"
-version = "0.5.3"
+version = "0.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "gymnasium" },
@@ -3559,15 +3529,15 @@ rocm = [
 ]
 teleop = [
     { name = "gradio" },
-    { name = "lerobot", extra = ["feetech"], marker = "extra == 'extra-11-so101-nexus-teleop' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "lerobot", extra = ["feetech"], marker = "extra == 'extra-11-so101-nexus-teleop' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
     { name = "opencv-python" },
     { name = "pillow" },
     { name = "plotly" },
 ]
 train = [
     { name = "tensorboard" },
-    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' or extra != 'extra-11-so101-nexus-rocm' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "torch", version = "2.13.0+rocm7.2", source = { registry = "https://download.pytorch.org/whl/rocm7.2" }, marker = "(sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "torch", version = "2.9.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' or extra != 'extra-11-so101-nexus-rocm' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "torch", version = "2.13.0+rocm7.2", source = { registry = "https://download.pytorch.org/whl/rocm7.2" }, marker = "(sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
     { name = "wandb", extra = ["media"] },
 ]
 viz = [
@@ -3575,28 +3545,32 @@ viz = [
 ]
 warp = [
     { name = "mujoco-warp" },
-    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' or extra != 'extra-11-so101-nexus-rocm' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "torch", version = "2.13.0+rocm7.2", source = { registry = "https://download.pytorch.org/whl/rocm7.2" }, marker = "(sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "torch", version = "2.9.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "warp-lang" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "hypothesis" },
-    { name = "imageio", extra = ["ffmpeg"], marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
-    { name = "lerobot", extra = ["feetech"], marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "imageio", extra = ["ffmpeg"], marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'extra-11-so101-nexus-warp' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "lerobot", extra = ["feetech"], marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'extra-11-so101-nexus-warp' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
     { name = "pillow" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "torch", version = "2.9.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "torchcodec" },
     { name = "ty" },
 ]
 test = [
     { name = "hypothesis" },
-    { name = "imageio", extra = ["ffmpeg"], marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
-    { name = "lerobot", extra = ["feetech"], marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "imageio", extra = ["ffmpeg"], marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'extra-11-so101-nexus-warp' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
+    { name = "lerobot", extra = ["feetech"], marker = "extra == 'extra-11-so101-nexus-teleop' or extra == 'extra-11-so101-nexus-warp' or extra == 'group-11-so101-nexus-dev' or extra == 'group-11-so101-nexus-test' or extra != 'extra-11-so101-nexus-rocm'" },
     { name = "pillow" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "torch", version = "2.9.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "torchcodec" },
 ]
 visual = [
     { name = "imageio", extra = ["ffmpeg"] },
@@ -3625,11 +3599,12 @@ requires-dist = [
     { name = "threadpoolctl", marker = "extra == 'decomp'", specifier = ">=3.1,<4" },
     { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'rocm'", index = "https://download.pytorch.org/whl/rocm7.2", conflict = { package = "so101-nexus", extra = "rocm" } },
     { name = "torch", marker = "extra == 'train'" },
-    { name = "torch", marker = "extra == 'warp'" },
+    { name = "torch", marker = "extra == 'warp'", specifier = "<2.10" },
     { name = "trimesh", specifier = "<5" },
     { name = "triton-rocm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'rocm'", index = "https://download.pytorch.org/whl/rocm7.2", conflict = { package = "so101-nexus", extra = "rocm" } },
     { name = "tyro", specifier = ">=0.9.0,<2" },
     { name = "wandb", extras = ["media"], marker = "extra == 'train'", specifier = ">=0.16.0" },
+    { name = "warp-lang", marker = "extra == 'warp'", specifier = ">=1.14,<1.16" },
 ]
 provides-extras = ["decomp", "viz", "teleop", "train", "warp", "rocm"]
 
@@ -3642,6 +3617,8 @@ dev = [
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff" },
+    { name = "torch", specifier = "<2.10" },
+    { name = "torchcodec", specifier = "<0.10" },
     { name = "ty" },
 ]
 test = [
@@ -3651,6 +3628,8 @@ test = [
     { name = "pillow" },
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "torch", specifier = "<2.10" },
+    { name = "torchcodec", specifier = "<0.10" },
 ]
 visual = [
     { name = "imageio", extras = ["ffmpeg"] },
@@ -3852,7 +3831,7 @@ wheels = [
 
 [[package]]
 name = "torch"
-version = "2.10.0"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
@@ -3873,12 +3852,12 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform == 'emscripten' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
     "python_full_version < '3.13' and sys_platform == 'darwin' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
     "python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop'",
-    "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
-    "python_full_version < '3.14' and sys_platform == 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
-    "python_full_version < '3.14' and sys_platform == 'emscripten' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
-    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version >= '3.14' and sys_platform == 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'extra-11-so101-nexus-warp' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'extra-11-so101-nexus-warp' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'extra-11-so101-nexus-warp' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version < '3.14' and sys_platform == 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'extra-11-so101-nexus-warp' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version < '3.14' and sys_platform == 'emscripten' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'extra-11-so101-nexus-warp' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
+    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop' and extra != 'extra-11-so101-nexus-warp' and extra != 'group-11-so101-nexus-dev' and extra != 'group-11-so101-nexus-test'",
     "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
     "python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
     "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
@@ -3893,59 +3872,51 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-11-so101-nexus-rocm' and extra != 'extra-11-so101-nexus-teleop'",
 ]
 dependencies = [
-    { name = "cuda-bindings", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "filelock", marker = "sys_platform != 'linux' or extra != 'extra-11-so101-nexus-rocm' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "fsspec", marker = "sys_platform != 'linux' or extra != 'extra-11-so101-nexus-rocm' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "jinja2", marker = "sys_platform != 'linux' or extra != 'extra-11-so101-nexus-rocm' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "networkx", marker = "sys_platform != 'linux' or extra != 'extra-11-so101-nexus-rocm' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "nvidia-cublas-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "nvidia-cudnn-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "nvidia-cufft-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "nvidia-cufile-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "nvidia-curand-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "nvidia-cusolver-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "nvidia-cusparse-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "nvidia-cusparselt-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "nvidia-nccl-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "nvidia-nvshmem-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "nvidia-nvtx-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "setuptools", marker = "sys_platform != 'linux' or extra != 'extra-11-so101-nexus-rocm' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "sympy", marker = "sys_platform != 'linux' or extra != 'extra-11-so101-nexus-rocm' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "triton", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "typing-extensions", marker = "sys_platform != 'linux' or extra != 'extra-11-so101-nexus-rocm' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "filelock", marker = "sys_platform != 'linux' or extra != 'extra-11-so101-nexus-rocm' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "fsspec", marker = "sys_platform != 'linux' or extra != 'extra-11-so101-nexus-rocm' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "jinja2", marker = "sys_platform != 'linux' or extra != 'extra-11-so101-nexus-rocm' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "networkx", marker = "sys_platform != 'linux' or extra != 'extra-11-so101-nexus-rocm' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-cublas-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-cudnn-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-cufft-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-cufile-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-curand-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-cusolver-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-cusparse-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-cusparselt-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-nccl-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-nvshmem-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "nvidia-nvtx-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "setuptools", marker = "sys_platform != 'linux' or extra != 'extra-11-so101-nexus-rocm' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "sympy", marker = "sys_platform != 'linux' or extra != 'extra-11-so101-nexus-rocm' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "triton", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "typing-extensions", marker = "sys_platform != 'linux' or extra != 'extra-11-so101-nexus-rocm' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/7a/abada41517ce0011775f0f4eacc79659bc9bc6c361e6bfe6f7052a6b9363/torch-2.10.0-3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:98c01b8bb5e3240426dcde1446eed6f40c778091c8544767ef1168fc663a05a6", size = 915622781, upload-time = "2026-03-11T14:17:11.354Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/c6/4dfe238342ffdcec5aef1c96c457548762d33c40b45a1ab7033bb26d2ff2/torch-2.10.0-3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:80b1b5bfe38eb0e9f5ff09f206dcac0a87aadd084230d4a36eea5ec5232c115b", size = 915627275, upload-time = "2026-03-11T14:16:11.325Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/f0/72bf18847f58f877a6a8acf60614b14935e2f156d942483af1ffc081aea0/torch-2.10.0-3-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:46b3574d93a2a8134b3f5475cfb98e2eb46771794c57015f6ad1fb795ec25e49", size = 915523474, upload-time = "2026-03-11T14:17:44.422Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/39/590742415c3030551944edc2ddc273ea1fdfe8ffb2780992e824f1ebee98/torch-2.10.0-3-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:b1d5e2aba4eb7f8e87fbe04f86442887f9167a35f092afe4c237dfcaaef6e328", size = 915632474, upload-time = "2026-03-11T14:15:13.666Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/8e/34949484f764dde5b222b7fe3fede43e4a6f0da9d7f8c370bb617d629ee2/torch-2.10.0-3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:0228d20b06701c05a8f978357f657817a4a63984b0c90745def81c18aedfa591", size = 915523882, upload-time = "2026-03-11T14:14:46.311Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/af/758e242e9102e9988969b5e621d41f36b8f258bb4a099109b7a4b4b50ea4/torch-2.10.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5fd4117d89ffd47e3dcc71e71a22efac24828ad781c7e46aaaf56bf7f2796acf", size = 145996088, upload-time = "2026-01-21T16:24:44.171Z" },
-    { url = "https://files.pythonhosted.org/packages/23/8e/3c74db5e53bff7ed9e34c8123e6a8bfef718b2450c35eefab85bb4a7e270/torch-2.10.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:787124e7db3b379d4f1ed54dd12ae7c741c16a4d29b49c0226a89bea50923ffb", size = 915711952, upload-time = "2026-01-21T16:23:53.503Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/01/624c4324ca01f66ae4c7cd1b74eb16fb52596dce66dbe51eff95ef9e7a4c/torch-2.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:2c66c61f44c5f903046cc696d088e21062644cbe541c7f1c4eaae88b2ad23547", size = 113757972, upload-time = "2026-01-21T16:24:39.516Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/5c/dee910b87c4d5c0fcb41b50839ae04df87c1cfc663cf1b5fca7ea565eeaa/torch-2.10.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:6d3707a61863d1c4d6ebba7be4ca320f42b869ee657e9b2c21c736bf17000294", size = 79498198, upload-time = "2026-01-21T16:24:34.704Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/6f/f2e91e34e3fcba2e3fc8d8f74e7d6c22e74e480bbd1db7bc8900fdf3e95c/torch-2.10.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:5c4d217b14741e40776dd7074d9006fd28b8a97ef5654db959d8635b2fe5f29b", size = 146004247, upload-time = "2026-01-21T16:24:29.335Z" },
-    { url = "https://files.pythonhosted.org/packages/98/fb/5160261aeb5e1ee12ee95fe599d0541f7c976c3701d607d8fc29e623229f/torch-2.10.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6b71486353fce0f9714ca0c9ef1c850a2ae766b409808acd58e9678a3edb7738", size = 915716445, upload-time = "2026-01-21T16:22:45.353Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/16/502fb1b41e6d868e8deb5b0e3ae926bbb36dab8ceb0d1b769b266ad7b0c3/torch-2.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:c2ee399c644dc92ef7bc0d4f7e74b5360c37cdbe7c5ba11318dda49ffac2bc57", size = 113757050, upload-time = "2026-01-21T16:24:19.204Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/0b/39929b148f4824bc3ad6f9f72a29d4ad865bcf7ebfc2fa67584773e083d2/torch-2.10.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:3202429f58309b9fa96a614885eace4b7995729f44beb54d3e4a47773649d382", size = 79851305, upload-time = "2026-01-21T16:24:09.209Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/14/21fbce63bc452381ba5f74a2c0a959fdf5ad5803ccc0c654e752e0dbe91a/torch-2.10.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:aae1b29cd68e50a9397f5ee897b9c24742e9e306f88a807a27d617f07adb3bd8", size = 146005472, upload-time = "2026-01-21T16:22:29.022Z" },
-    { url = "https://files.pythonhosted.org/packages/54/fd/b207d1c525cb570ef47f3e9f836b154685011fce11a2f444ba8a4084d042/torch-2.10.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:6021db85958db2f07ec94e1bc77212721ba4920c12a18dc552d2ae36a3eb163f", size = 915612644, upload-time = "2026-01-21T16:21:47.019Z" },
-    { url = "https://files.pythonhosted.org/packages/36/53/0197f868c75f1050b199fe58f9bf3bf3aecac9b4e85cc9c964383d745403/torch-2.10.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ff43db38af76fda183156153983c9a096fc4c78d0cd1e07b14a2314c7f01c2c8", size = 113997015, upload-time = "2026-01-21T16:23:00.767Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/13/e76b4d9c160e89fff48bf16b449ea324bda84745d2ab30294c37c2434c0d/torch-2.10.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:cdf2a523d699b70d613243211ecaac14fe9c5df8a0b0a9c02add60fb2a413e0f", size = 79498248, upload-time = "2026-01-21T16:23:09.315Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/93/716b5ac0155f1be70ed81bacc21269c3ece8dba0c249b9994094110bfc51/torch-2.10.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:bf0d9ff448b0218e0433aeb198805192346c4fd659c852370d5cc245f602a06a", size = 79464992, upload-time = "2026-01-21T16:23:05.162Z" },
-    { url = "https://files.pythonhosted.org/packages/69/2b/51e663ff190c9d16d4a8271203b71bc73a16aa7619b9f271a69b9d4a936b/torch-2.10.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:233aed0659a2503b831d8a67e9da66a62c996204c0bba4f4c442ccc0c68a3f60", size = 146018567, upload-time = "2026-01-21T16:22:23.393Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/cd/4b95ef7f293b927c283db0b136c42be91c8ec6845c44de0238c8c23bdc80/torch-2.10.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:682497e16bdfa6efeec8cde66531bc8d1fbbbb4d8788ec6173c089ed3cc2bfe5", size = 915721646, upload-time = "2026-01-21T16:21:16.983Z" },
-    { url = "https://files.pythonhosted.org/packages/56/97/078a007208f8056d88ae43198833469e61a0a355abc0b070edd2c085eb9a/torch-2.10.0-cp314-cp314-win_amd64.whl", hash = "sha256:6528f13d2a8593a1a412ea07a99812495bec07e9224c28b2a25c0a30c7da025c", size = 113752373, upload-time = "2026-01-21T16:22:13.471Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/94/71994e7d0d5238393df9732fdab607e37e2b56d26a746cb59fdb415f8966/torch-2.10.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f5ab4ba32383061be0fb74bda772d470140a12c1c3b58a0cfbf3dae94d164c28", size = 79850324, upload-time = "2026-01-21T16:22:09.494Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/65/1a05346b418ea8ccd10360eef4b3e0ce688fba544e76edec26913a8d0ee0/torch-2.10.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:716b01a176c2a5659c98f6b01bf868244abdd896526f1c692712ab36dbaf9b63", size = 146006482, upload-time = "2026-01-21T16:22:18.42Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/b9/5f6f9d9e859fc3235f60578fa64f52c9c6e9b4327f0fe0defb6de5c0de31/torch-2.10.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:d8f5912ba938233f86361e891789595ff35ca4b4e2ac8fe3670895e5976731d6", size = 915613050, upload-time = "2026-01-21T16:20:49.035Z" },
-    { url = "https://files.pythonhosted.org/packages/66/4d/35352043ee0eaffdeff154fad67cd4a31dbed7ff8e3be1cc4549717d6d51/torch-2.10.0-cp314-cp314t-win_amd64.whl", hash = "sha256:71283a373f0ee2c89e0f0d5f446039bdabe8dbc3c9ccf35f0f784908b0acd185", size = 113995816, upload-time = "2026-01-21T16:22:05.312Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/27/07c645c7673e73e53ded71705045d6cb5bae94c4b021b03aa8d03eee90ab/torch-2.9.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:da5f6f4d7f4940a173e5572791af238cb0b9e21b1aab592bd8b26da4c99f1cd6", size = 104126592, upload-time = "2025-11-12T15:20:41.62Z" },
+    { url = "https://files.pythonhosted.org/packages/19/17/e377a460603132b00760511299fceba4102bd95db1a0ee788da21298ccff/torch-2.9.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:27331cd902fb4322252657f3902adf1c4f6acad9dcad81d8df3ae14c7c4f07c4", size = 899742281, upload-time = "2025-11-12T15:22:17.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/1a/64f5769025db846a82567fa5b7d21dba4558a7234ee631712ee4771c436c/torch-2.9.1-cp312-cp312-win_amd64.whl", hash = "sha256:81a285002d7b8cfd3fdf1b98aa8df138d41f1a8334fd9ea37511517cedf43083", size = 110940568, upload-time = "2025-11-12T15:21:18.689Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ab/07739fd776618e5882661d04c43f5b5586323e2f6a2d7d84aac20d8f20bd/torch-2.9.1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:c0d25d1d8e531b8343bea0ed811d5d528958f1dcbd37e7245bc686273177ad7e", size = 74479191, upload-time = "2025-11-12T15:21:25.816Z" },
+    { url = "https://files.pythonhosted.org/packages/20/60/8fc5e828d050bddfab469b3fe78e5ab9a7e53dda9c3bdc6a43d17ce99e63/torch-2.9.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:c29455d2b910b98738131990394da3e50eea8291dfeb4b12de71ecf1fdeb21cb", size = 104135743, upload-time = "2025-11-12T15:21:34.936Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b7/6d3f80e6918213babddb2a37b46dbb14c15b14c5f473e347869a51f40e1f/torch-2.9.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:524de44cd13931208ba2c4bde9ec7741fd4ae6bfd06409a604fc32f6520c2bc9", size = 899749493, upload-time = "2025-11-12T15:24:36.356Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/47/c7843d69d6de8938c1cbb1eba426b1d48ddf375f101473d3e31a5fc52b74/torch-2.9.1-cp313-cp313-win_amd64.whl", hash = "sha256:545844cc16b3f91e08ce3b40e9c2d77012dd33a48d505aed34b7740ed627a1b2", size = 110944162, upload-time = "2025-11-12T15:21:53.151Z" },
+    { url = "https://files.pythonhosted.org/packages/28/0e/2a37247957e72c12151b33a01e4df651d9d155dd74d8cfcbfad15a79b44a/torch-2.9.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5be4bf7496f1e3ffb1dd44b672adb1ac3f081f204c5ca81eba6442f5f634df8e", size = 74830751, upload-time = "2025-11-12T15:21:43.792Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f7/7a18745edcd7b9ca2381aa03353647bca8aace91683c4975f19ac233809d/torch-2.9.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:30a3e170a84894f3652434b56d59a64a2c11366b0ed5776fab33c2439396bf9a", size = 104142929, upload-time = "2025-11-12T15:21:48.319Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/dd/f1c0d879f2863ef209e18823a988dc7a1bf40470750e3ebe927efdb9407f/torch-2.9.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:8301a7b431e51764629208d0edaa4f9e4c33e6df0f2f90b90e261d623df6a4e2", size = 899748978, upload-time = "2025-11-12T15:23:04.568Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/9f/6986b83a53b4d043e36f3f898b798ab51f7f20fdf1a9b01a2720f445043d/torch-2.9.1-cp313-cp313t-win_amd64.whl", hash = "sha256:2e1c42c0ae92bf803a4b2409fdfed85e30f9027a66887f5e7dcdbc014c7531db", size = 111176995, upload-time = "2025-11-12T15:22:01.618Z" },
+    { url = "https://files.pythonhosted.org/packages/40/60/71c698b466dd01e65d0e9514b5405faae200c52a76901baf6906856f17e4/torch-2.9.1-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:2c14b3da5df416cf9cb5efab83aa3056f5b8cd8620b8fde81b4987ecab730587", size = 74480347, upload-time = "2025-11-12T15:21:57.648Z" },
+    { url = "https://files.pythonhosted.org/packages/48/50/c4b5112546d0d13cc9eaa1c732b823d676a9f49ae8b6f97772f795874a03/torch-2.9.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1edee27a7c9897f4e0b7c14cfc2f3008c571921134522d5b9b5ec4ebbc69041a", size = 74433245, upload-time = "2025-11-12T15:22:39.027Z" },
+    { url = "https://files.pythonhosted.org/packages/81/c9/2628f408f0518b3bae49c95f5af3728b6ab498c8624ab1e03a43dd53d650/torch-2.9.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:19d144d6b3e29921f1fc70503e9f2fc572cde6a5115c0c0de2f7ca8b1483e8b6", size = 104134804, upload-time = "2025-11-12T15:22:35.222Z" },
+    { url = "https://files.pythonhosted.org/packages/28/fc/5bc91d6d831ae41bf6e9e6da6468f25330522e92347c9156eb3f1cb95956/torch-2.9.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:c432d04376f6d9767a9852ea0def7b47a7bbc8e7af3b16ac9cf9ce02b12851c9", size = 899747132, upload-time = "2025-11-12T15:23:36.068Z" },
+    { url = "https://files.pythonhosted.org/packages/63/5d/e8d4e009e52b6b2cf1684bde2a6be157b96fb873732542fb2a9a99e85a83/torch-2.9.1-cp314-cp314-win_amd64.whl", hash = "sha256:d187566a2cdc726fc80138c3cdb260970fab1c27e99f85452721f7759bbd554d", size = 110934845, upload-time = "2025-11-12T15:22:48.367Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/b2/2d15a52516b2ea3f414643b8de68fa4cb220d3877ac8b1028c83dc8ca1c4/torch-2.9.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cb10896a1f7fedaddbccc2017ce6ca9ecaaf990f0973bdfcf405439750118d2c", size = 74823558, upload-time = "2025-11-12T15:22:43.392Z" },
+    { url = "https://files.pythonhosted.org/packages/86/5c/5b2e5d84f5b9850cd1e71af07524d8cbb74cba19379800f1f9f7c997fc70/torch-2.9.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:0a2bd769944991c74acf0c4ef23603b9c777fdf7637f115605a4b2d8023110c7", size = 104145788, upload-time = "2025-11-12T15:23:52.109Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/8c/3da60787bcf70add986c4ad485993026ac0ca74f2fc21410bc4eb1bb7695/torch-2.9.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:07c8a9660bc9414c39cac530ac83b1fb1b679d7155824144a40a54f4a47bfa73", size = 899735500, upload-time = "2025-11-12T15:24:08.788Z" },
+    { url = "https://files.pythonhosted.org/packages/db/2b/f7818f6ec88758dfd21da46b6cd46af9d1b3433e53ddbb19ad1e0da17f9b/torch-2.9.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c88d3299ddeb2b35dcc31753305612db485ab6f1823e37fb29451c8b2732b87e", size = 111163659, upload-time = "2025-11-12T15:23:20.009Z" },
 ]
 
 [[package]]
@@ -3957,14 +3928,14 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "filelock", marker = "(sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "fsspec", marker = "(sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "jinja2", marker = "(sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "networkx", marker = "(sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "setuptools", marker = "(sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "sympy", marker = "(sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "triton-rocm", marker = "(python_full_version < '3.15' and sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm') or (python_full_version >= '3.15' and extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (python_full_version >= '3.15' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (python_full_version >= '3.15' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test') or (sys_platform != 'linux' and extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (sys_platform != 'linux' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (sys_platform != 'linux' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
-    { name = "typing-extensions", marker = "(sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "filelock", marker = "(sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "fsspec", marker = "(sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "jinja2", marker = "(sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "networkx", marker = "(sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "setuptools", marker = "(sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "sympy", marker = "(sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "triton-rocm", marker = "(python_full_version < '3.15' and sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm') or (python_full_version >= '3.15' and extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (python_full_version >= '3.15' and extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (python_full_version >= '3.15' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (python_full_version >= '3.15' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test') or (sys_platform != 'linux' and extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (sys_platform != 'linux' and extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (sys_platform != 'linux' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (sys_platform != 'linux' and extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "typing-extensions", marker = "(sys_platform == 'linux' and extra == 'extra-11-so101-nexus-rocm') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/rocm7.2/torch-2.13.0%2Brocm7.2-cp312-cp312-manylinux_2_28_x86_64.whl", upload-time = "2026-07-08T11:26:11Z" },
@@ -3977,50 +3948,50 @@ wheels = [
 
 [[package]]
 name = "torchcodec"
-version = "0.10.0"
+version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/ff/2b27797e039673156710e5a0febe87cafc203722acafa3d34db283b40cf9/torchcodec-0.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b35fa4061c5757f8d714187c040a90a11669de6470a644bb04e3cd335ff1c110", size = 4073213, upload-time = "2026-01-22T15:41:45.485Z" },
-    { url = "https://files.pythonhosted.org/packages/29/34/ccc711b6dc581e43b8d8d227e4173a8826994ee7b68d6b3d82291f307325/torchcodec-0.10.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6e43184d83ccced965b31cad5bb6200c779646fee2ec153a6d784b4def40c91b", size = 2083121, upload-time = "2026-01-22T15:41:37.947Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/6c/9af3bd945a610d6c757d898aa4624e0f5135cc8a6992d0a1d846f1084576/torchcodec-0.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:e4f022fa53d91b414b4177fe87b0afc40a806092da4595d24de4b245d6fb0fba", size = 2225338, upload-time = "2026-01-22T15:41:52.094Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/b6/b1041c8ccb175b08779b3e2d3e60f838bbcbfe2398d49e3673b6a66f0649/torchcodec-0.10.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:be3ce7cc667effecd06da9d0d6c5e9e347c5f376b705934e7b82378a65cf6eef", size = 4043681, upload-time = "2026-01-22T15:41:47.236Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/85/fc44f6d702dfd344e6859a9a4d713aaaa991578eb74677a80297d9ae8a07/torchcodec-0.10.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:71f25caf9ab89a434ae2008b1374fd98557a6864b8313b103bae53af3e6fd17f", size = 2088572, upload-time = "2026-01-22T15:41:39.203Z" },
-    { url = "https://files.pythonhosted.org/packages/df/9d/b73a0f47e11b66a1d23c7d867f12f8bb41b1b5e707d7e23d8f54793e3267/torchcodec-0.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:9e077146e894f373b805972da96aee42ff8bb87b1a3f3fb64d26925cd9e64184", size = 2225208, upload-time = "2026-01-22T15:41:53.233Z" },
-    { url = "https://files.pythonhosted.org/packages/90/c9/4b6242e3456bae148f4086337d3e43d98c4e79c04091de3462db9f5eb67a/torchcodec-0.10.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bb882c12ca07dcf6d82833db67e6b565693a4bccfeab6696697620e43e465556", size = 3821202, upload-time = "2026-01-22T15:41:48.627Z" },
-    { url = "https://files.pythonhosted.org/packages/96/a2/5fe0e62b208a367f741361881321c1b25de487318a44f870f326747585a1/torchcodec-0.10.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:bec2b938ad4b294bd71d0b0ab4976037c740be0c80be79e67803ebed4eff270e", size = 2089647, upload-time = "2026-01-22T15:41:40.711Z" },
-    { url = "https://files.pythonhosted.org/packages/93/71/0fc10230965e319552e064d66f1c8675b471d1b98c4a94c529e771b3c165/torchcodec-0.10.0-cp314-cp314-win_amd64.whl", hash = "sha256:4734eb82146516049e1070152eb3013d7b9689159ef35db7c0894d130d4e335d", size = 2226749, upload-time = "2026-01-22T15:41:54.393Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/60/3bfa459e09987af08e188811b191437c9d8215a74f4d418be6ff7df87b5c/torchcodec-0.9.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8996ec62b72c69545c30246df64df386d06d7ec7de0689be5d20dfc06aad6442", size = 4064264, upload-time = "2025-12-10T15:55:56.313Z" },
+    { url = "https://files.pythonhosted.org/packages/17/c8/bfb74babec98aff11ab4f239b0901f39e1a93338b3438e842d864dc46935/torchcodec-0.9.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a50568ce73b70395d113833fb07394c223f5546ef5d4fafe0fdcd91627fca270", size = 2061978, upload-time = "2025-12-10T15:55:33.415Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/12/c0bbf01b0ed52b69aaeed4af1043dc8308ccc522a47fcc082b34882e2ba2/torchcodec-0.9.1-cp312-cp312-win_amd64.whl", hash = "sha256:d9c8efe5845bde45a428f96493b4a041511f47f5bd53b333a0ad90426be4623a", size = 2187178, upload-time = "2025-12-10T15:56:16.968Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c7/67fc8417f9efa8a25c00a44f0d674761a0bad9c45e9725e3fd116b3c48ed/torchcodec-0.9.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5c9cdcba50c75be70ef6ec919ec1f7f14d9d5163d93cf6bd94403e134f03734c", size = 4034415, upload-time = "2025-12-10T15:56:02.04Z" },
+    { url = "https://files.pythonhosted.org/packages/68/05/06240f661e9aa08b20765305e3b88f60bff706bbe54ac35830af74612443/torchcodec-0.9.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:0643c5e9c3a51fdafdea87935d5b0a38e99626c664f47a150482d77ab370a877", size = 2067767, upload-time = "2025-12-10T15:55:37.27Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a2/d78cd65863fb805d9e35fe90ae7574eab86ff0ae63438208bd07d2cf1fd2/torchcodec-0.9.1-cp313-cp313-win_amd64.whl", hash = "sha256:df0b5a15998fd7457625c2af2a6276e0e710fac158d145045340dbbcd1cfdb65", size = 2186788, upload-time = "2025-12-10T15:56:20.204Z" },
+    { url = "https://files.pythonhosted.org/packages/01/02/f8ae9443d3bcbe8a8d6d0bbc3992296e5476e5afa1f244100a3a7967a36c/torchcodec-0.9.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b9bc5a5dff925df96d11bf90bd0ce964b8086bb11ae09adf353518192b5da483", size = 3812248, upload-time = "2025-12-10T15:56:06.382Z" },
+    { url = "https://files.pythonhosted.org/packages/59/a1/8462b55571286847ea31edb7634583125400824267db9ba8301f4ce3f137/torchcodec-0.9.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:65634bb28b3155cf99f980dac31ecedb414c07b8156f8473ec9fb74bedbd2a1f", size = 2068456, upload-time = "2025-12-10T15:55:40.577Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/752d0fc1c6e8f799ae880ca1087510def663a7f9aa1a70074ae334c6908f/torchcodec-0.9.1-cp314-cp314-win_amd64.whl", hash = "sha256:2d01c8b3685a3a38f050ed2b526808a2938dba6f56cb9f9e967884fd858bba15", size = 2188320, upload-time = "2025-12-10T15:56:24.63Z" },
 ]
 
 [[package]]
 name = "torchvision"
-version = "0.25.0"
+version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "pillow" },
-    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "torch", version = "2.9.1", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/3a/6ea0d73f49a9bef38a1b3a92e8dd455cea58470985d25635beab93841748/torchvision-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c2abe430c90b1d5e552680037d68da4eb80a5852ebb1c811b2b89d299b10573b", size = 1874920, upload-time = "2026-01-21T16:27:45.348Z" },
-    { url = "https://files.pythonhosted.org/packages/51/f8/c0e1ef27c66e15406fece94930e7d6feee4cb6374bbc02d945a630d6426e/torchvision-0.25.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:b75deafa2dfea3e2c2a525559b04783515e3463f6e830cb71de0fb7ea36fe233", size = 2344556, upload-time = "2026-01-21T16:27:40.125Z" },
-    { url = "https://files.pythonhosted.org/packages/68/2f/f24b039169db474e8688f649377de082a965fbf85daf4e46c44412f1d15a/torchvision-0.25.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:f25aa9e380865b11ea6e9d99d84df86b9cc959f1a007cd966fc6f1ab2ed0e248", size = 8072351, upload-time = "2026-01-21T16:27:21.074Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/16/8f650c2e288977cf0f8f85184b90ee56ed170a4919347fc74ee99286ed6f/torchvision-0.25.0-cp312-cp312-win_amd64.whl", hash = "sha256:f9c55ae8d673ab493325d1267cbd285bb94d56f99626c00ac4644de32a59ede3", size = 4303059, upload-time = "2026-01-21T16:27:11.08Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/5b/1562a04a6a5a4cf8cf40016a0cdeda91ede75d6962cff7f809a85ae966a5/torchvision-0.25.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:24e11199e4d84ba9c5ee7825ebdf1cd37ce8deec225117f10243cae984ced3ec", size = 1874918, upload-time = "2026-01-21T16:27:39.02Z" },
-    { url = "https://files.pythonhosted.org/packages/36/b1/3d6c42f62c272ce34fcce609bb8939bdf873dab5f1b798fd4e880255f129/torchvision-0.25.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:5f271136d2d2c0b7a24c5671795c6e4fd8da4e0ea98aeb1041f62bc04c4370ef", size = 2309106, upload-time = "2026-01-21T16:27:30.624Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/60/59bb9c8b67cce356daeed4cb96a717caa4f69c9822f72e223a0eae7a9bd9/torchvision-0.25.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:855c0dc6d37f462482da7531c6788518baedca1e0847f3df42a911713acdfe52", size = 8071522, upload-time = "2026-01-21T16:27:29.392Z" },
-    { url = "https://files.pythonhosted.org/packages/32/a5/9a9b1de0720f884ea50dbf9acb22cbe5312e51d7b8c4ac6ba9b51efd9bba/torchvision-0.25.0-cp313-cp313-win_amd64.whl", hash = "sha256:cef0196be31be421f6f462d1e9da1101be7332d91984caa6f8022e6c78a5877f", size = 4321911, upload-time = "2026-01-21T16:27:35.195Z" },
-    { url = "https://files.pythonhosted.org/packages/52/99/dca81ed21ebaeff2b67cc9f815a20fdaa418b69f5f9ea4c6ed71721470db/torchvision-0.25.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a8f8061284395ce31bcd460f2169013382ccf411148ceb2ee38e718e9860f5a7", size = 1896209, upload-time = "2026-01-21T16:27:32.159Z" },
-    { url = "https://files.pythonhosted.org/packages/28/cc/2103149761fdb4eaed58a53e8437b2d716d48f05174fab1d9fcf1e2a2244/torchvision-0.25.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:146d02c9876858420adf41f3189fe90e3d6a409cbfa65454c09f25fb33bf7266", size = 2310735, upload-time = "2026-01-21T16:27:22.327Z" },
-    { url = "https://files.pythonhosted.org/packages/76/ad/f4c985ad52ddd3b22711c588501be1b330adaeaf6850317f66751711b78c/torchvision-0.25.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:c4d395cb2c4a2712f6eb93a34476cdf7aae74bb6ea2ea1917f858e96344b00aa", size = 8089557, upload-time = "2026-01-21T16:27:27.666Z" },
-    { url = "https://files.pythonhosted.org/packages/63/cc/0ea68b5802e5e3c31f44b307e74947bad5a38cc655231d845534ed50ddb8/torchvision-0.25.0-cp313-cp313t-win_amd64.whl", hash = "sha256:5e6b449e9fa7d642142c0e27c41e5a43b508d57ed8e79b7c0a0c28652da8678c", size = 4344260, upload-time = "2026-01-21T16:27:17.018Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/1f/fa839532660e2602b7e704d65010787c5bb296258b44fa8b9c1cd6175e7d/torchvision-0.25.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:620a236288d594dcec7634c754484542dc0a5c1b0e0b83a34bda5e91e9b7c3a1", size = 1896193, upload-time = "2026-01-21T16:27:24.785Z" },
-    { url = "https://files.pythonhosted.org/packages/80/ed/d51889da7ceaf5ff7a0574fb28f9b6b223df19667265395891f81b364ab3/torchvision-0.25.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:0b5e7f50002a8145a98c5694a018e738c50e2972608310c7e88e1bd4c058f6ce", size = 2309331, upload-time = "2026-01-21T16:27:19.97Z" },
-    { url = "https://files.pythonhosted.org/packages/90/a5/f93fcffaddd8f12f9e812256830ec9c9ca65abbf1bc369379f9c364d1ff4/torchvision-0.25.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:632db02300e83793812eee4f61ae6a2686dab10b4cfd628b620dc47747aa9d03", size = 8088713, upload-time = "2026-01-21T16:27:15.281Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/eb/d0096eed5690d962853213f2ee00d91478dfcb586b62dbbb449fb8abc3a6/torchvision-0.25.0-cp314-cp314-win_amd64.whl", hash = "sha256:d1abd5ed030c708f5dbf4812ad5f6fbe9384b63c40d6bd79f8df41a4a759a917", size = 4325058, upload-time = "2026-01-21T16:27:26.165Z" },
-    { url = "https://files.pythonhosted.org/packages/97/36/96374a4c7ab50dea9787ce987815614ccfe988a42e10ac1a2e3e5b60319a/torchvision-0.25.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ad9a8a5877782944d99186e4502a614770fe906626d76e9cd32446a0ac3075f2", size = 1896207, upload-time = "2026-01-21T16:27:23.383Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/e2/7abb10a867db79b226b41da419b63b69c0bd5b82438c4a4ed50e084c552f/torchvision-0.25.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:40a122c3cf4d14b651f095e0f672b688dde78632783fc5cd3d4d5e4f6a828563", size = 2310741, upload-time = "2026-01-21T16:27:18.712Z" },
-    { url = "https://files.pythonhosted.org/packages/08/e6/0927784e6ffc340b6676befde1c60260bd51641c9c574b9298d791a9cda4/torchvision-0.25.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:846890161b825b38aa85fc37fb3ba5eea74e7091ff28bab378287111483b6443", size = 8089772, upload-time = "2026-01-21T16:27:14.048Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/37/e7ca4ec820d434c0f23f824eb29f0676a0c3e7a118f1514f5b949c3356da/torchvision-0.25.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f07f01d27375ad89d72aa2b3f2180f07da95dd9d2e4c758e015c0acb2da72977", size = 4425879, upload-time = "2026-01-21T16:27:12.579Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/af/18e2c6b9538a045f60718a0c5a058908ccb24f88fde8e6f0fc12d5ff7bd3/torchvision-0.24.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e48bf6a8ec95872eb45763f06499f87bd2fb246b9b96cb00aae260fda2f96193", size = 1891433, upload-time = "2025-11-12T15:25:03.232Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/43/600e5cfb0643d10d633124f5982d7abc2170dfd7ce985584ff16edab3e76/torchvision-0.24.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:7fb7590c737ebe3e1c077ad60c0e5e2e56bb26e7bccc3b9d04dbfc34fd09f050", size = 2386737, upload-time = "2025-11-12T15:25:08.288Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b1/db2941526ecddd84884132e2742a55c9311296a6a38627f9e2627f5ac889/torchvision-0.24.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:66a98471fc18cad9064123106d810a75f57f0838eee20edc56233fd8484b0cc7", size = 8049868, upload-time = "2025-11-12T15:25:13.058Z" },
+    { url = "https://files.pythonhosted.org/packages/69/98/16e583f59f86cd59949f59d52bfa8fc286f86341a229a9d15cbe7a694f0c/torchvision-0.24.1-cp312-cp312-win_amd64.whl", hash = "sha256:4aa6cb806eb8541e92c9b313e96192c6b826e9eb0042720e2fa250d021079952", size = 4302006, upload-time = "2025-11-12T15:25:16.184Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/97/ab40550f482577f2788304c27220e8ba02c63313bd74cf2f8920526aac20/torchvision-0.24.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:8a6696db7fb71eadb2c6a48602106e136c785642e598eb1533e0b27744f2cce6", size = 1891435, upload-time = "2025-11-12T15:25:28.642Z" },
+    { url = "https://files.pythonhosted.org/packages/30/65/ac0a3f9be6abdbe4e1d82c915d7e20de97e7fd0e9a277970508b015309f3/torchvision-0.24.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:db2125c46f9cb25dc740be831ce3ce99303cfe60439249a41b04fd9f373be671", size = 2338718, upload-time = "2025-11-12T15:25:26.19Z" },
+    { url = "https://files.pythonhosted.org/packages/10/b5/5bba24ff9d325181508501ed7f0c3de8ed3dd2edca0784d48b144b6c5252/torchvision-0.24.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:f035f0cacd1f44a8ff6cb7ca3627d84c54d685055961d73a1a9fb9827a5414c8", size = 8049661, upload-time = "2025-11-12T15:25:22.558Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ec/54a96ae9ab6a0dd66d4bba27771f892e36478a9c3489fa56e51c70abcc4d/torchvision-0.24.1-cp313-cp313-win_amd64.whl", hash = "sha256:16274823b93048e0a29d83415166a2e9e0bf4e1b432668357b657612a4802864", size = 4319808, upload-time = "2025-11-12T15:25:17.318Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f3/a90a389a7e547f3eb8821b13f96ea7c0563cdefbbbb60a10e08dda9720ff/torchvision-0.24.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e3f96208b4bef54cd60e415545f5200346a65024e04f29a26cd0006dbf9e8e66", size = 2005342, upload-time = "2025-11-12T15:25:11.871Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/fe/ff27d2ed1b524078164bea1062f23d2618a5fc3208e247d6153c18c91a76/torchvision-0.24.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:f231f6a4f2aa6522713326d0d2563538fa72d613741ae364f9913027fa52ea35", size = 2341708, upload-time = "2025-11-12T15:25:25.08Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b9/d6c903495cbdfd2533b3ef6f7b5643ff589ea062f8feb5c206ee79b9d9e5/torchvision-0.24.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:1540a9e7f8cf55fe17554482f5a125a7e426347b71de07327d5de6bfd8d17caa", size = 8177239, upload-time = "2025-11-12T15:25:18.554Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/2b/ba02e4261369c3798310483028495cf507e6cb3f394f42e4796981ecf3a7/torchvision-0.24.1-cp313-cp313t-win_amd64.whl", hash = "sha256:d83e16d70ea85d2f196d678bfb702c36be7a655b003abed84e465988b6128938", size = 4251604, upload-time = "2025-11-12T15:25:34.069Z" },
+    { url = "https://files.pythonhosted.org/packages/42/84/577b2cef8f32094add5f52887867da4c2a3e6b4261538447e9b48eb25812/torchvision-0.24.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:cccf4b4fec7fdfcd3431b9ea75d1588c0a8596d0333245dafebee0462abe3388", size = 2005319, upload-time = "2025-11-12T15:25:23.827Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/34/ecb786bffe0159a3b49941a61caaae089853132f3cd1e8f555e3621f7e6f/torchvision-0.24.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:1b495edd3a8f9911292424117544f0b4ab780452e998649425d1f4b2bed6695f", size = 2338844, upload-time = "2025-11-12T15:25:32.625Z" },
+    { url = "https://files.pythonhosted.org/packages/51/99/a84623786a6969504c87f2dc3892200f586ee13503f519d282faab0bb4f0/torchvision-0.24.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ab211e1807dc3e53acf8f6638df9a7444c80c0ad050466e8d652b3e83776987b", size = 8175144, upload-time = "2025-11-12T15:25:31.355Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ba/8fae3525b233e109317ce6a9c1de922ab2881737b029a7e88021f81e068f/torchvision-0.24.1-cp314-cp314-win_amd64.whl", hash = "sha256:18f9cb60e64b37b551cd605a3d62c15730c086362b40682d23e24b616a697d41", size = 4234459, upload-time = "2025-11-12T15:25:19.859Z" },
+    { url = "https://files.pythonhosted.org/packages/50/33/481602c1c72d0485d4b3a6b48c9534b71c2957c9d83bf860eb837bf5a620/torchvision-0.24.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec9d7379c519428395e4ffda4dbb99ec56be64b0a75b95989e00f9ec7ae0b2d7", size = 2005336, upload-time = "2025-11-12T15:25:27.225Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/7f/372de60bf3dd8f5593bd0d03f4aecf0d1fd58f5bc6943618d9d913f5e6d5/torchvision-0.24.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:af9201184c2712d808bd4eb656899011afdfce1e83721c7cb08000034df353fe", size = 2341704, upload-time = "2025-11-12T15:25:29.857Z" },
+    { url = "https://files.pythonhosted.org/packages/36/9b/0f3b9ff3d0225ee2324ec663de0e7fb3eb855615ca958ac1875f22f1f8e5/torchvision-0.24.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:9ef95d819fd6df81bc7cc97b8f21a15d2c0d3ac5dbfaab5cbc2d2ce57114b19e", size = 8177422, upload-time = "2025-11-12T15:25:37.357Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ab/e2bcc7c2f13d882a58f8b30ff86f794210b075736587ea50f8c545834f8a/torchvision-0.24.1-cp314-cp314t-win_amd64.whl", hash = "sha256:480b271d6edff83ac2e8d69bbb4cf2073f93366516a50d48f140ccfceedb002e", size = 4335190, upload-time = "2025-11-12T15:25:35.745Z" },
 ]
 
 [[package]]
@@ -4047,7 +4018,7 @@ name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-teleop') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'extra-11-so101-nexus-warp') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-dev') or (extra == 'extra-11-so101-nexus-rocm' and extra == 'group-11-so101-nexus-test')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
@@ -4068,19 +4039,19 @@ wheels = [
 
 [[package]]
 name = "triton"
-version = "3.6.0"
+version = "3.5.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/5d/08201db32823bdf77a0e2b9039540080b2e5c23a20706ddba942924ebcd6/triton-3.6.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:374f52c11a711fd062b4bfbb201fd9ac0a5febd28a96fb41b4a0f51dde3157f4", size = 176128243, upload-time = "2026-01-20T16:16:07.857Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/a8/cdf8b3e4c98132f965f88c2313a4b493266832ad47fb52f23d14d4f86bb5/triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74caf5e34b66d9f3a429af689c1c7128daba1d8208df60e81106b115c00d6fca", size = 188266850, upload-time = "2026-01-20T16:00:43.041Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/12/34d71b350e89a204c2c7777a9bba0dcf2f19a5bfdd70b57c4dbc5ffd7154/triton-3.6.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:448e02fe6dc898e9e5aa89cf0ee5c371e99df5aa5e8ad976a80b93334f3494fd", size = 176133521, upload-time = "2026-01-20T16:16:13.321Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/0b/37d991d8c130ce81a8728ae3c25b6e60935838e9be1b58791f5997b24a54/triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c7f76c6e72d2ef08df639e3d0d30729112f47a56b0c81672edc05ee5116ac9", size = 188289450, upload-time = "2026-01-20T16:00:49.136Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/4e/41b0c8033b503fd3cfcd12392cdd256945026a91ff02452bef40ec34bee7/triton-3.6.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1722e172d34e32abc3eb7711d0025bb69d7959ebea84e3b7f7a341cd7ed694d6", size = 176276087, upload-time = "2026-01-20T16:16:18.989Z" },
-    { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296, upload-time = "2026-01-20T16:00:56.042Z" },
-    { url = "https://files.pythonhosted.org/packages/49/55/5ecf0dcaa0f2fbbd4420f7ef227ee3cb172e91e5fede9d0ecaddc43363b4/triton-3.6.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef5523241e7d1abca00f1d240949eebdd7c673b005edbbce0aca95b8191f1d43", size = 176138577, upload-time = "2026-01-20T16:16:25.426Z" },
-    { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063, upload-time = "2026-01-20T16:01:07.278Z" },
-    { url = "https://files.pythonhosted.org/packages/48/db/56ee649cab5eaff4757541325aca81f52d02d4a7cd3506776cad2451e060/triton-3.6.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b3a97e8ed304dfa9bd23bb41ca04cdf6b2e617d5e782a8653d616037a5d537d", size = 176274804, upload-time = "2026-01-20T16:16:31.528Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994, upload-time = "2026-01-20T16:01:14.236Z" },
+    { url = "https://files.pythonhosted.org/packages/db/53/2bcc46879910991f09c063eea07627baef2bc62fe725302ba8f46a2c1ae5/triton-3.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:275a045b6ed670dd1bd005c3e6c2d61846c74c66f4512d6f33cc027b11de8fd4", size = 159940689, upload-time = "2025-11-11T17:51:55.938Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/50/9a8358d3ef58162c0a415d173cfb45b67de60176e1024f71fbc4d24c0b6d/triton-3.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d2c6b915a03888ab931a9fd3e55ba36785e1fe70cbea0b40c6ef93b20fc85232", size = 170470207, upload-time = "2025-11-11T17:41:00.253Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/ba/805684a992ee32d486b7948d36aed2f5e3c643fc63883bf8bdca1c3f3980/triton-3.5.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:56765ffe12c554cd560698398b8a268db1f616c120007bfd8829d27139abd24a", size = 159955460, upload-time = "2025-11-11T17:52:01.861Z" },
+    { url = "https://files.pythonhosted.org/packages/27/46/8c3bbb5b0a19313f50edcaa363b599e5a1a5ac9683ead82b9b80fe497c8d/triton-3.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3f4346b6ebbd4fad18773f5ba839114f4826037c9f2f34e0148894cd5dd3dba", size = 170470410, upload-time = "2025-11-11T17:41:06.319Z" },
+    { url = "https://files.pythonhosted.org/packages/84/1e/7df59baef41931e21159371c481c31a517ff4c2517343b62503d0cd2be99/triton-3.5.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02c770856f5e407d24d28ddc66e33cf026e6f4d360dcb8b2fabe6ea1fc758621", size = 160072799, upload-time = "2025-11-11T17:52:07.293Z" },
+    { url = "https://files.pythonhosted.org/packages/37/92/e97fcc6b2c27cdb87ce5ee063d77f8f26f19f06916aa680464c8104ef0f6/triton-3.5.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0b4d2c70127fca6a23e247f9348b8adde979d2e7a20391bfbabaac6aebc7e6a8", size = 170579924, upload-time = "2025-11-11T17:41:12.455Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f9/0430e879c1e63a1016cb843261528fd3187c872c3a9539132efc39514753/triton-3.5.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f617aa7925f9ea9968ec2e1adaf93e87864ff51549c8f04ce658f29bbdb71e2d", size = 159956163, upload-time = "2025-11-11T17:52:12.999Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/e6/c595c35e5c50c4bc56a7bac96493dad321e9e29b953b526bbbe20f9911d0/triton-3.5.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d0637b1efb1db599a8e9dc960d53ab6e4637db7d4ab6630a0974705d77b14b60", size = 170480488, upload-time = "2025-11-11T17:41:18.222Z" },
+    { url = "https://files.pythonhosted.org/packages/41/1e/63d367c576c75919e268e4fbc33c1cb33b6dc12bb85e8bfe531c2a8bd5d3/triton-3.5.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8932391d7f93698dfe5bc9bead77c47a24f97329e9f20c10786bb230a9083f56", size = 160073620, upload-time = "2025-11-11T17:52:18.403Z" },
+    { url = "https://files.pythonhosted.org/packages/16/b5/b0d3d8b901b6a04ca38df5e24c27e53afb15b93624d7fd7d658c7cd9352a/triton-3.5.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bac7f7d959ad0f48c0e97d6643a1cc0fd5786fe61cb1f83b537c6b2d54776478", size = 170582192, upload-time = "2025-11-11T17:41:23.963Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

- Constrained the `warp` extra to Warp 1.14 through 1.15 and Torch below 2.10.
- Pinned test Torch and TorchCodec versions to a compatible pair.
- Raised the documented Warp CUDA requirement to 12.8.
- Prepared the `0.5.4` changelog entry and package metadata.

## Why

- The published `0.5.3` Warp extra resolved incompatible upstream package versions.

## Validation

- `make format lint typecheck`
- `uv run pytest tests/test_rocm_extra.py tests/test_docs_consistency.py -q` (22 passed)
- `make test` (1,633 passed, 2 skipped)
- Built `so101_nexus-0.5.4` wheel and source distribution.
- Installed the built wheel with the Warp extra. CPU and CUDA `WarpTouch-v1` smoke checks passed.

## Checklist

- [x] Tests added or updated (regression test for a fix; happy path plus an edge case for new behavior).
- [x] `make format lint typecheck` and the relevant tests pass locally.
- [x] Documentation updated if the public API or behavior changed.
- [x] `CHANGELOG.md` `## [Unreleased]` entry added for any user-facing change.
- [x] No em dashes or emoji in prose, docs, or comments.