### PR TITLE
feat: configure primitive sizes in millimeters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ for the public-API and deprecation policy.
 
 ## [Unreleased]
 
+### Added
+
+- `CubeObject` and `PyramidObject` now accept float `side_length_mm` values.
+  `CylinderObject` and `SphereObject` now accept float `diameter_mm` values.
+  `PickAndPlaceConfig` and `StackCubeConfig` now accept
+  `cube_side_length_mm`. The meter-based `half_size` and `cube_half_size`
+  defaults remain unchanged.
+
 ## [0.5.4] - 2026-08-27
 
 ### Fixed

--- a/docs/content/docs/api/configs.mdx
+++ b/docs/content/docs/api/configs.mdx
@@ -359,6 +359,9 @@ from so101_nexus import PickAndPlaceConfig, YCBObject
 # Default cube path (carries a colored cube onto the disc):
 config = PickAndPlaceConfig(cube_colors="blue", target_colors="green")
 
+# Default cubes with a float millimeter side length:
+millimeter_config = PickAndPlaceConfig(cube_side_length_mm=25.4)
+
 # Object-pool path (carries a YCB object):
 config = PickAndPlaceConfig(objects=[YCBObject("009_gelatin_box")], target_colors="green")
 ```
@@ -374,7 +377,8 @@ These are in addition to all `EnvironmentConfig` parameters.
 | `target_disc_radius` | `float` | `0.05` | Radius of the target disc (meters) |
 | `min_object_target_separation` | `float \| None` | `None` | Minimum object/disc spawn separation (meters); `None` falls back to `min_cube_target_separation` |
 | `cube_colors` | `ColorConfig` | `"red"` | Color(s) for the default cube pool (compatibility sugar) |
-| `cube_half_size` | `float` | `0.0125` | Half-size of the default cube(s) (meters) |
+| `cube_half_size` | `float \| None` | `None` | Legacy half-size of the default cube(s) in meters. Defaults to `0.0125` when neither size input is set. |
+| `cube_side_length_mm` | `float \| None` | `None` | Full side length of the default cube(s) in millimeters. Do not combine with `cube_half_size`. |
 | `cube_mass` | `float` | `0.01` | Mass of the default cube(s) (kg) |
 | `min_cube_target_separation` | `float` | `0.0375` | Deprecated alias for `min_object_target_separation` |
 | `distractors` | `list[SceneObject] \| SceneObject \| None` | `None` | Pool of non-target objects distractors are drawn from. Defaults to green, yellow, and purple cubes sharing `cube_half_size` / `cube_mass` |
@@ -414,7 +418,8 @@ These are in addition to all `EnvironmentConfig` parameters.
 |-----------|------|---------|-------------|
 | `cube_a_colors` | `ColorConfig` | `"red"` | Color(s) for cube A, the cube that gets picked up and stacked |
 | `cube_b_colors` | `ColorConfig` | `"blue"` | Color(s) for cube B, the stationary stacking base |
-| `cube_half_size` | `float` | `0.0125` | Half-extent of each cube (meters); both cubes share the same size |
+| `cube_half_size` | `float \| None` | `None` | Legacy half-extent of each cube in meters. Defaults to `0.0125` when neither size input is set. |
+| `cube_side_length_mm` | `float \| None` | `None` | Full side length of each cube in millimeters. Do not combine with `cube_half_size`. |
 | `cube_mass` | `float` | `0.01` | Mass of each cube (kg); both cubes share the same mass |
 | `min_cube_separation` | `float` | `0.04` | Minimum spawn separation between the two cubes (meters), on top of their combined bounding radii |
 | `stack_alignment_margin` | `float` | `0.005` | Alignment tolerance (meters) for the stacked success check |

--- a/docs/content/docs/api/objects.mdx
+++ b/docs/content/docs/api/objects.mdx
@@ -25,18 +25,21 @@ Base class for all scene objects. Subclasses must implement `__repr__()`, which 
 
 ## CubeObject
 
-A solid-color cube with configurable size and mass.
+A solid-color cube with configurable size and mass. Set `side_length_mm` as a
+float in millimeters. The existing `half_size` argument remains available for
+meter-based code.
 
 ```python
 from so101_nexus import CubeObject
 
-cube = CubeObject(half_size=0.02, mass=0.015, color="blue")
+cube = CubeObject(side_length_mm=25.4, mass=0.015, color="blue")
 repr(cube)  # "blue cube"
 ```
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `half_size` | `float` | `0.0125` | Half the side length of the cube (meters) |
+| `half_size` | `float \| None` | `None` | Legacy half side length in meters. The default cube has `half_size=0.0125`. Do not combine with `side_length_mm`. |
+| `side_length_mm` | `float \| None` | `None` | Full cube side length in millimeters. |
 | `mass` | `float` | `0.01` | Mass of the cube (kg) |
 | `color` | `ColorName` | `"red"` | Color of the cube. Must be a valid `ColorName`. |
 
@@ -44,22 +47,23 @@ repr(cube)  # "blue cube"
 
 ## CylinderObject, SphereObject, and PyramidObject
 
-These solid-color primitives use the same `half_size`, `mass`, and `color`
-parameters as `CubeObject`. Each primitive fills the cube with side length
-`2 * half_size`: cylinders have that diameter and height, spheres have that
-diameter, and square pyramids have that base width and height.
+These solid-color primitives accept `mass` and `color` like `CubeObject`.
+`CylinderObject` and `SphereObject` use `diameter_mm`. `PyramidObject` uses
+`side_length_mm`. Each primitive keeps its existing `half_size` argument for
+meter-based code.
 
 ```python
 from so101_nexus import CylinderObject, PyramidObject, SphereObject
 
-cylinder = CylinderObject(half_size=0.02, color="blue")
-sphere = SphereObject(half_size=0.02, color="green")
-pyramid = PyramidObject(half_size=0.02, color="yellow")
+cylinder = CylinderObject(diameter_mm=25.4, color="blue")
+sphere = SphereObject(diameter_mm=12.7, color="green")
+pyramid = PyramidObject(side_length_mm=25.4, color="yellow")
 ```
 
-`__repr__()` returns `"{color} cylinder"`, `"{color} sphere"`, or
-`"{color} pyramid"`. The valid colors are the same `ColorName` values that
-`CubeObject` accepts.
+The cylinder height equals its diameter. The square pyramid height equals its
+base side length. `__repr__()` returns `"{color} cylinder"`, `"{color}
+sphere"`, or `"{color} pyramid"`. The valid colors are the same `ColorName`
+values that `CubeObject` accepts.
 
 ## YCBObject
 

--- a/src/so101_nexus/config.py
+++ b/src/so101_nexus/config.py
@@ -953,6 +953,18 @@ def _default_distractor_cubes(half_size: float, mass: float) -> list[SceneObject
     ]
 
 
+def _resolve_cube_half_size(
+    cube_half_size: float | None,
+    cube_side_length_mm: float | None,
+) -> float:
+    """Return a cube half-size in metres from one millimeter size input."""
+    if cube_side_length_mm is None:
+        return 0.0125 if cube_half_size is None else cube_half_size
+    if cube_half_size is not None:
+        raise ValueError("Specify either cube_half_size or cube_side_length_mm, not both")
+    return CubeObject(side_length_mm=cube_side_length_mm).half_size
+
+
 def _require_non_negative(**values: float) -> None:
     """Raise ``ValueError`` naming the first keyword whose value is negative."""
     for name, value in values.items():
@@ -1117,8 +1129,12 @@ class PickAndPlaceConfig(EnvironmentConfig):
         falls back to ``min_cube_target_separation``.
     cube_colors : ColorConfig
         Cube color(s) for the default cube pool (compatibility sugar).
-    cube_half_size : float
-        Half-size of the default cube(s) in metres (compatibility sugar).
+    cube_half_size : float, optional
+        Legacy half-size of the default cube(s) in metres. Defaults to 0.0125
+        when neither size input is set.
+    cube_side_length_mm : float, optional
+        Full side length of the default cube(s) in millimeters. Do not combine
+        with ``cube_half_size``.
     cube_mass : float
         Mass of the default cube(s) in kg (compatibility sugar).
     min_cube_target_separation : float
@@ -1152,12 +1168,13 @@ class PickAndPlaceConfig(EnvironmentConfig):
         self,
         cube_colors: ColorConfig = "red",
         target_colors: ColorConfig = "blue",
-        cube_half_size: float = 0.0125,
+        cube_half_size: float | None = None,
         cube_mass: float = 0.01,
         target_disc_radius: float = 0.05,
         min_cube_target_separation: float = 0.0375,
         *,
         objects: list[SceneObject] | SceneObject | None = None,
+        cube_side_length_mm: float | None = None,
         min_object_target_separation: float | None = None,
         object_static_lin_threshold: float = 0.01,
         object_static_ang_threshold: float = 0.5,
@@ -1167,12 +1184,14 @@ class PickAndPlaceConfig(EnvironmentConfig):
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
+        cube_half_size = _resolve_cube_half_size(cube_half_size, cube_side_length_mm)
         non_default_cube_sugar = [
             name
             for name, value, default in (
                 ("cube_colors", cube_colors, "red"),
                 ("cube_half_size", cube_half_size, 0.0125),
                 ("cube_mass", cube_mass, 0.01),
+                ("cube_side_length_mm", cube_side_length_mm, None),
             )
             if value != default
         ]
@@ -1187,6 +1206,7 @@ class PickAndPlaceConfig(EnvironmentConfig):
         self.cube_colors = cube_colors
         self.target_colors = target_colors
         self.cube_half_size = cube_half_size
+        self.cube_side_length_mm = cube_side_length_mm
         self.cube_mass = cube_mass
         self.target_disc_radius = target_disc_radius
         self.min_object_target_separation = (
@@ -1320,8 +1340,12 @@ class StackCubeConfig(EnvironmentConfig):
         Color(s) for cube A, the cube that gets picked up and stacked.
     cube_b_colors : ColorConfig
         Color(s) for cube B, the stationary stacking base.
-    cube_half_size : float
-        Half-extent of each cube in metres. Both cubes share the same size.
+    cube_half_size : float, optional
+        Legacy half-extent of each cube in metres. Defaults to 0.0125 when
+        neither size input is set.
+    cube_side_length_mm : float, optional
+        Full side length of each cube in millimeters. Do not combine with
+        ``cube_half_size``.
     cube_mass : float
         Mass of each cube in kg. Both cubes share the same mass.
     min_cube_separation : float
@@ -1358,7 +1382,7 @@ class StackCubeConfig(EnvironmentConfig):
         self,
         cube_a_colors: ColorConfig = "red",
         cube_b_colors: ColorConfig = "blue",
-        cube_half_size: float = 0.0125,
+        cube_half_size: float | None = None,
         cube_mass: float = 0.01,
         min_cube_separation: float = 0.04,
         stack_alignment_margin: float = 0.005,
@@ -1366,13 +1390,17 @@ class StackCubeConfig(EnvironmentConfig):
         cube_static_ang_threshold: float = 0.5,
         distractors: list[SceneObject] | SceneObject | None = None,
         n_distractors: int = 0,
+        *,
+        cube_side_length_mm: float | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
+        cube_half_size = _resolve_cube_half_size(cube_half_size, cube_side_length_mm)
         self.cube_a_colors = cube_a_colors
         self.cube_b_colors = cube_b_colors
         self.cube_half_size = cube_half_size
         self.cube_mass = cube_mass
+        self.cube_side_length_mm = cube_side_length_mm
         self.min_cube_separation = min_cube_separation
         self.stack_alignment_margin = stack_alignment_margin
         self.cube_static_lin_threshold = cube_static_lin_threshold

--- a/src/so101_nexus/objects.py
+++ b/src/so101_nexus/objects.py
@@ -15,6 +15,22 @@ from typing import ClassVar
 from so101_nexus.constants import COLOR_MAP, GSO_OBJECTS, YCB_OBJECTS, ColorName
 
 
+def _resolve_half_size(
+    half_size: float | None,
+    *,
+    length_mm: float | None,
+    length_name: str,
+) -> float:
+    """Return a half-size in metres from one millimeter size input."""
+    if half_size is not None and length_mm is not None:
+        raise ValueError(f"Specify either half_size or {length_name}, not both")
+    if length_mm is None:
+        return 0.0125 if half_size is None else half_size
+    if length_mm <= 0:
+        raise ValueError(f"{length_name} must be positive, got {length_mm}")
+    return length_mm / 2000.0
+
+
 class SceneObject(ABC):
     """Abstract base class for all scene objects.
 
@@ -74,11 +90,43 @@ class CubeObject(PrimitiveObject):
 
     shape_name = "cube"
 
+    def __init__(
+        self,
+        half_size: float | None = None,
+        mass: float = 0.01,
+        color: ColorName = "red",
+        *,
+        side_length_mm: float | None = None,
+    ) -> None:
+        super().__init__(
+            half_size=_resolve_half_size(
+                half_size, length_mm=side_length_mm, length_name="side_length_mm"
+            ),
+            mass=mass,
+            color=color,
+        )
+
 
 class CylinderObject(PrimitiveObject):
     """Cylinder that fills the same cube as a :class:`CubeObject`."""
 
     shape_name = "cylinder"
+
+    def __init__(
+        self,
+        half_size: float | None = None,
+        mass: float = 0.01,
+        color: ColorName = "red",
+        *,
+        diameter_mm: float | None = None,
+    ) -> None:
+        super().__init__(
+            half_size=_resolve_half_size(
+                half_size, length_mm=diameter_mm, length_name="diameter_mm"
+            ),
+            mass=mass,
+            color=color,
+        )
 
 
 class SphereObject(PrimitiveObject):
@@ -86,11 +134,43 @@ class SphereObject(PrimitiveObject):
 
     shape_name = "sphere"
 
+    def __init__(
+        self,
+        half_size: float | None = None,
+        mass: float = 0.01,
+        color: ColorName = "red",
+        *,
+        diameter_mm: float | None = None,
+    ) -> None:
+        super().__init__(
+            half_size=_resolve_half_size(
+                half_size, length_mm=diameter_mm, length_name="diameter_mm"
+            ),
+            mass=mass,
+            color=color,
+        )
+
 
 class PyramidObject(PrimitiveObject):
     """Square pyramid that fills the same cube as a :class:`CubeObject`."""
 
     shape_name = "pyramid"
+
+    def __init__(
+        self,
+        half_size: float | None = None,
+        mass: float = 0.01,
+        color: ColorName = "red",
+        *,
+        side_length_mm: float | None = None,
+    ) -> None:
+        super().__init__(
+            half_size=_resolve_half_size(
+                half_size, length_mm=side_length_mm, length_name="side_length_mm"
+            ),
+            mass=mass,
+            color=color,
+        )
 
 
 class ScannedMeshObject(SceneObject):

--- a/tests/core/test_objects.py
+++ b/tests/core/test_objects.py
@@ -70,6 +70,24 @@ class TestCubeObject:
         with pytest.raises(ValueError, match="color must be one of"):
             CubeObject(color="fuschia")
 
+    @pytest.mark.parametrize(
+        ("object_type", "dimension"),
+        [
+            (CubeObject, "side_length_mm"),
+            (CylinderObject, "diameter_mm"),
+            (SphereObject, "diameter_mm"),
+            (PyramidObject, "side_length_mm"),
+        ],
+    )
+    def test_converts_millimeter_dimensions(self, object_type, dimension):
+        obj = object_type(**{dimension: 25.4})
+
+        assert obj.half_size == pytest.approx(0.0127)
+
+    def test_rejects_ambiguous_size_inputs(self):
+        with pytest.raises(ValueError, match="either half_size or side_length_mm"):
+            CubeObject(half_size=0.0125, side_length_mm=25.0)
+
 
 @pytest.mark.parametrize(
     ("object_type", "shape_name"),

--- a/tests/mujoco/test_pick_and_place_config.py
+++ b/tests/mujoco/test_pick_and_place_config.py
@@ -39,6 +39,10 @@ class TestConstructionValidation:
         with pytest.raises(ValueError, match="cube_half_size"):
             PickAndPlaceConfig(cube_half_size=0.001)
 
+    def test_combined_cube_size_inputs_raise(self):
+        with pytest.raises(ValueError, match="either cube_half_size or cube_side_length_mm"):
+            PickAndPlaceConfig(cube_half_size=0.0125, cube_side_length_mm=25.4)
+
     def test_negative_object_static_lin_threshold(self):
         with pytest.raises(ValueError, match="object_static_lin_threshold"):
             PickAndPlaceConfig(object_static_lin_threshold=-0.01)
@@ -115,6 +119,18 @@ class TestSharedConstants:
         env = PickAndPlaceEnv()
         assert env.cube_half_size == _CFG.cube_half_size
         env.close()
+
+    def test_cube_side_length_reaches_environment(self):
+        config = PickAndPlaceConfig(cube_side_length_mm=25.4)
+        env = PickAndPlaceEnv(config=config)
+        try:
+            env.reset(seed=0)
+            slot = env._slots[env._target_slot_idx]
+            assert env.cube_half_size == pytest.approx(0.0127)
+            assert [obj.half_size for obj in config.object_pool()] == pytest.approx([0.0127])
+            assert env.model.geom_size[slot.geom_id] == pytest.approx([0.0127] * 3)
+        finally:
+            env.close()
 
     def test_disc_radius_matches_core(self):
         env = PickAndPlaceEnv()

--- a/tests/mujoco/test_stack_cube_config.py
+++ b/tests/mujoco/test_stack_cube_config.py
@@ -55,6 +55,10 @@ class TestConstructionValidation:
         with pytest.raises(ValueError, match="cube_half_size"):
             StackCubeConfig(cube_half_size=0.001)
 
+    def test_combined_cube_size_inputs_raise(self):
+        with pytest.raises(ValueError, match="either cube_half_size or cube_side_length_mm"):
+            StackCubeConfig(cube_half_size=0.0125, cube_side_length_mm=25.4)
+
     def test_invalid_cube_mass(self):
         with pytest.raises(ValueError, match="cube_mass"):
             StackCubeConfig(cube_mass=0.0)
@@ -135,6 +139,18 @@ class TestSharedConstants:
         env = StackCubeEnv()
         assert env.cube_half_size == _CFG.cube_half_size
         env.close()
+
+    def test_cube_side_length_reaches_environment(self):
+        config = StackCubeConfig(cube_side_length_mm=25.4)
+        env = StackCubeEnv(config=config)
+        try:
+            env.reset(seed=0)
+            assert env.cube_half_size == pytest.approx(0.0127)
+            assert [obj.half_size for obj in config.distractors] == pytest.approx([0.0127] * 3)
+            assert env.model.geom_size[env._slot_a.geom_id] == pytest.approx([0.0127] * 3)
+            assert env.model.geom_size[env._slot_b.geom_id] == pytest.approx([0.0127] * 3)
+        finally:
+            env.close()
 
 
 class TestGoalThreshConfig:

--- a/tests/warp/test_stack_cube_envs.py
+++ b/tests/warp/test_stack_cube_envs.py
@@ -34,6 +34,24 @@ def test_stack_cube_reset_obs_finite():
     assert "task_description" in info
 
 
+def test_stack_cube_side_length_reaches_compiled_geometry():
+    import mujoco
+
+    from so101_nexus.config import StackCubeConfig
+
+    env = _make_env(
+        num_envs=2,
+        config=StackCubeConfig(cube_side_length_mm=25.4),
+    )
+    try:
+        env.reset(seed=0)
+        for geom_name in ("cube_a_0_geom", "cube_b_0_geom"):
+            geom_id = mujoco.mj_name2id(env._mjm, mujoco.mjtObj.mjOBJ_GEOM, geom_name)
+            assert env._mjm.geom_size[geom_id] == pytest.approx([0.0127] * 3)
+    finally:
+        env.close()
+
+
 def test_stack_cube_default_colors_red_on_blue():
     """Out of the box every world stacks the red cube on the blue cube."""
     env = _make_env(num_envs=4)

--- a/tests/warp/test_warp_envs.py
+++ b/tests/warp/test_warp_envs.py
@@ -400,6 +400,26 @@ def test_pnp_target_varies_per_world_and_respects_separation():
     assert not info["success"].any()
 
 
+def test_pnp_cube_side_length_reaches_compiled_geometry():
+    import mujoco
+
+    from so101_nexus.config import PickAndPlaceConfig
+    from so101_nexus.warp.pick_and_place import WarpPickAndPlaceVectorEnv
+
+    env = WarpPickAndPlaceVectorEnv(
+        num_envs=2,
+        config=PickAndPlaceConfig(cube_side_length_mm=25.4),
+        device="cpu",
+        seed=0,
+    )
+    try:
+        env.reset(seed=0)
+        geom_id = mujoco.mj_name2id(env._mjm, mujoco.mjtObj.mjOBJ_GEOM, "pick_slot_0_geom")
+        assert env._mjm.geom_size[geom_id] == pytest.approx([0.0127] * 3)
+    finally:
+        env.close()
+
+
 def test_pnp_distractors_active_per_world_and_clear_of_the_disc():
     """Each world activates exactly ``n_distractors`` pool slots inside the spawn
     annulus, clear of the goal disc and the carried object, and target selection


### PR DESCRIPTION
## What changed

- Add float millimeter size fields for cubes, cylinders, spheres, and pyramids.
- Add `cube_side_length_mm` for pick-and-place and stack-cube configurations.
- Update MuJoCo and Warp geometry tests, API guides, and the changelog.

## Why

The prior API required meter-based half sizes. Explicit millimeter fields remove unit ambiguity while keeping legacy defaults.

## Validation

- `make format lint typecheck`
- `uv run pytest tests/core/test_objects.py tests/mujoco/test_pick_and_place_config.py tests/mujoco/test_stack_cube_config.py tests/warp/test_stack_cube_envs.py tests/warp/test_warp_envs.py tests/test_docs_consistency.py -q`
- 174 tests passed.

## Checklist

- [x] Tests added or updated.
- [x] `make format lint typecheck` and relevant tests pass locally.
- [x] Documentation updated.
- [x] `CHANGELOG.md` entry added.
- [x] No em dashes or emoji.