### PR TITLE
docs: audit public documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ for the public-API and deprecation policy.
   `cube_side_length_mm`. The meter-based `half_size` and `cube_half_size`
   defaults remain unchanged.
 
+### Changed
+
+- The documentation now lists the `viz` extra and clarifies visual observations,
+  episode termination, PickAndPlace static thresholds, LookAt targets, LeRobot
+  wrapper requirements, and rollout-recorder camera setup.
+
 ## [0.5.4] - 2026-08-27
 
 ### Fixed

--- a/docs/content/docs/api/configs.mdx
+++ b/docs/content/docs/api/configs.mdx
@@ -157,7 +157,7 @@ reward = RewardConfig(reaching=0.25, grasping=0.25, task_objective=0.25, complet
 | `action_delta_penalty` | `float` | `0.0` | Penalty coefficient on L2 norm of consecutive action deltas |
 | `energy_penalty` | `float` | `0.0` | Penalty coefficient on L2 norm of the action vector |
 | `tanh_shaping_scale` | `float` | `5.0` | Scale factor for tanh reward shaping |
-| `velocity_shaping_scale` | `float` | `15.0` | Scale factor for tanh velocity shaping (only read by `PickAndPlaceConfig`'s task potential) |
+| `velocity_shaping_scale` | `float` | `15.0` | Scale factor for tanh velocity shaping in PickAndPlace and StackCube task potentials |
 
 A "potential-shaped delta" pays the *change* in progress since the previous
 step rather than the raw value, so dwelling at a fixed state (e.g. holding an
@@ -224,9 +224,10 @@ config = EnvironmentConfig(obs_mode="state")
 | `spawn_min_radius` | `float` | `0.10` | Minimum spawn distance from the robot base |
 | `spawn_max_radius` | `float` | `0.30` | Maximum spawn distance from the robot base |
 | `spawn_angle_half_range_deg` | `float` | `90.0` | Half-range of spawn angle in degrees |
-| `obs_mode` | `ObsMode` | `"state"` | Observation mode: `"state"` or `"visual"` |
+| `obs_mode` | `ObsMode` | `"state"` | Observation mode. `"state"` returns all selected components. `"visual"` returns cameras and joint positions. `info["privileged_state"]` has the full selected state. |
 | `robot_colors` | `ColorConfig` | `"yellow"` | Robot body color(s) |
 | `robot_init_qpos_noise` | `float` | `0.02` | Noise added to initial joint positions |
+| `terminate_on_success` | `bool` | `True` | End the episode when the success predicate becomes true. When `False`, only the step cap truncates the episode. |
 | `observations` | `list[Observation] \| None` | `None` | Observation components to include. Task-specific configs provide defaults when `None`. |
 
 ### Validation
@@ -381,6 +382,8 @@ These are in addition to all `EnvironmentConfig` parameters.
 | `cube_side_length_mm` | `float \| None` | `None` | Full side length of the default cube(s) in millimeters. Do not combine with `cube_half_size`. |
 | `cube_mass` | `float` | `0.01` | Mass of the default cube(s) (kg) |
 | `min_cube_target_separation` | `float` | `0.0375` | Deprecated alias for `min_object_target_separation` |
+| `object_static_lin_threshold` | `float` | `0.01` | Maximum carried-object linear speed (m/s) for success |
+| `object_static_ang_threshold` | `float` | `0.5` | Maximum carried-object angular speed (rad/s) for success |
 | `distractors` | `list[SceneObject] \| SceneObject \| None` | `None` | Pool of non-target objects distractors are drawn from. Defaults to green, yellow, and purple cubes sharing `cube_half_size` / `cube_mass` |
 | `n_distractors` | `int` | `0` | Number of distractor objects placed alongside the carried object each episode, sampled without replacement from `distractors` |
 | `min_object_separation` | `float` | `0.04` | Minimum spawn separation between the carried object and the distractors (meters), on top of their bounding radii |
@@ -482,7 +485,7 @@ config = LookAtConfig(
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `objects` | `list[SceneObject] \| SceneObject \| None` | `None` | Target object(s). Only `CubeObject` is supported. Defaults to `[CubeObject()]`. |
+| `objects` | `list[SceneObject] \| SceneObject \| None` | `None` | Target object(s). `CubeObject`, `CylinderObject`, `SphereObject`, and `PyramidObject` are supported. Defaults to `[CubeObject()]`. |
 | `fov_deg` | `float \| None` | `None` | Wrist-camera vertical FOV in degrees; success = target within `fov_deg / 2` of the optical axis. `None` reads the live camera FOV. |
 
 The `MuJoCoLookAt-v1` and `WarpLookAt-v1` registrations default `max_episode_steps` to 256; override it at construction via `gym.make(..., max_episode_steps=N)` (MuJoCo) or `gym.make_vec(..., max_episode_steps=N)` (Warp).

--- a/docs/content/docs/api/core-overview.mdx
+++ b/docs/content/docs/api/core-overview.mdx
@@ -1,9 +1,9 @@
 ---
 title: Core Package
-description: Environment registration plus the full export surface of so101_nexus.
+description: Environment registration and key top-level exports from so101_nexus.
 ---
 
-`so101_nexus` provides shared types, configuration classes, scene objects, observation components, asset helpers, and the environment registry. Backends live under `so101_nexus.mujoco` and `so101_nexus.warp` and are registered by importing them.
+`so101_nexus` provides shared types, configuration classes, scene objects, observation components, asset helpers, and environment registration. Backends live under `so101_nexus.mujoco` and `so101_nexus.warp` and are registered by importing them.
 
 ```python
 import so101_nexus
@@ -77,6 +77,7 @@ Returns the SO101-Nexus environment IDs for whichever backends are currently imp
 | `ObsMode` | `Literal["state", "visual"]` |
 | `MoveDirection` | `Literal["up", "down", "left", "right", "forward", "backward"]` |
 | `YcbModelId` | Literal union of 10 YCB object IDs (see [Scene Objects and Assets](/docs/api/objects)) |
+| `GsoModelId` | Literal union of 12 GSO object IDs (see [Scene Objects and Assets](/docs/api/objects)) |
 
 ### Constants
 
@@ -86,6 +87,8 @@ Returns the SO101-Nexus environment IDs for whichever backends are currently imp
 | `DIRECTION_VECTORS` | `dict[MoveDirection, tuple]` | Maps direction names to unit vectors |
 | `COLOR_MAP` | `dict[str, list[float]]` | Maps color names to RGBA values |
 | `YCB_OBJECTS` | `dict[str, str]` | Maps YCB model IDs to human-readable names |
+| `GSO_OBJECTS` | `dict[str, str]` | Maps GSO model IDs to human-readable names |
+| `GSO_MASSES` | `dict[str, float]` | Maps GSO model IDs to default mass estimates in kilograms |
 | `ROBOT_CAMERA_PRESETS` | `dict[str, RobotCameraPreset]` | Named camera mounting presets for SO-100 and SO-101 |
 | `ASSETS_DIR` | `Path` | Root directory for bundled assets |
 | `SO101_DIR` | `Path` | Asset directory for the SO-101 arm (URDF/XML retained for teleop calibration; the MuJoCo backend loads the menagerie MJCF) |
@@ -100,7 +103,7 @@ All configuration classes have sensible defaults. See [Configuration Classes](/d
 | `RobotConfig` | Rest pose, grasp force threshold, velocity threshold, end-effector solver knobs |
 | `RobotCameraPreset` | Named preset combining camera mounting parameters |
 | `RewardConfig` | Reward component weights with a `compute()` method |
-| `EnvironmentConfig` | Base environment parameters (spawn region, obs mode, episode length) |
+| `EnvironmentConfig` | Base environment parameters (spawn region, observation mode, reset settling, termination) |
 | `PickConfig` | Extends `EnvironmentConfig` for pick/lift tasks |
 | `PickAndPlaceConfig` | Extends `EnvironmentConfig` for pick-and-place tasks |
 | `StackCubeConfig` | Extends `EnvironmentConfig` for stack-cube tasks |
@@ -139,9 +142,15 @@ See [Scene Objects and Assets](/docs/api/objects) for full reference.
 | Class | Description |
 |-------|-------------|
 | `SceneObject` | Abstract base for all scene objects |
+| `PrimitiveObject` | Abstract base for solid-color geometric primitives |
 | `CubeObject` | A colored cube with configurable size and mass |
+| `CylinderObject` | A colored cylinder with configurable diameter and mass |
+| `SphereObject` | A colored sphere with configurable diameter and mass |
+| `PyramidObject` | A colored square pyramid with configurable size and mass |
 | `YCBObject` | A YCB benchmark object loaded from mesh assets |
+| `GSOObject` | A Google Scanned Object loaded from mesh assets |
 | `MeshObject` | A custom mesh object loaded from collision and visual mesh files |
+| `ScannedMeshObject` | A mesh-backed scanned object base class |
 
 ### Functions
 

--- a/docs/content/docs/api/lerobot-processors.mdx
+++ b/docs/content/docs/api/lerobot-processors.mdx
@@ -24,9 +24,9 @@ def make_lerobot_env(
 ) -> gym.Env
 ```
 
-Build a `LeRobotEnvWrapper` around a registered SO101-Nexus env id. Extra keyword arguments are forwarded to `gymnasium.make`.
+Build a `LeRobotEnvWrapper` around a registered `MuJoCo*-v1` environment ID. Extra keyword arguments are forwarded to `gymnasium.make`.
 
-The wrapped env must have a `Dict` observation space, which means at least one camera component (`WristCamera` or `OverheadCamera`) or another non-default observation must be configured. Wrapping the default state-only env raises `TypeError`.
+The wrapped env must have a `Dict` observation space. Configure at least one camera component (`WristCamera` or `OverheadCamera`). Wrapping the default state-only env raises `TypeError`.
 
 ```python
 import so101_nexus.mujoco  # noqa: F401

--- a/docs/content/docs/api/policies.mdx
+++ b/docs/content/docs/api/policies.mdx
@@ -28,7 +28,13 @@ one action per call, then clear the cache in `reset()`.
 import gymnasium as gym
 import numpy as np
 from lerobot.datasets.lerobot_dataset import LeRobotDataset
-from so101_nexus import SO101_JOINT_NAMES
+from so101_nexus import (
+    JointPositions,
+    OverheadCamera,
+    PickConfig,
+    SO101_JOINT_NAMES,
+    WristCamera,
+)
 from so101_nexus.policy_adapters import RolloutRecorder
 from so101_nexus.teleop.dataset import FieldSelection, build_features
 import so101_nexus.mujoco  # noqa: F401
@@ -43,10 +49,19 @@ class MyPolicy:
     def reset(self):
         pass
 
-
 policy = MyPolicy()
 
-env = gym.make("MuJoCoPickLift-v1", render_mode="rgb_array", control_mode="pd_joint_pos")
+
+config = PickConfig(
+    obs_mode="visual",
+    observations=[JointPositions(), WristCamera(), OverheadCamera()],
+)
+env = gym.make(
+    "MuJoCoPickLift-v1",
+    config=config,
+    render_mode="rgb_array",
+    control_mode="pd_joint_pos",
+)
 action_features = {f"{name}.pos": float for name in SO101_JOINT_NAMES}
 follower_features = {**action_features, "wrist": (480, 640, 3), "overhead": (480, 640, 3)}
 features = build_features(FieldSelection(), follower_features, action_features)

--- a/docs/content/docs/api/stability.mdx
+++ b/docs/content/docs/api/stability.mdx
@@ -10,7 +10,9 @@ SO101-Nexus follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html). 
 The public, supported surface is:
 
 - Every name exported from the top-level package, `so101_nexus.__all__` (configs, rewards, observation components, scene objects, asset helpers, and the LeRobot adapter helpers).
-- The documented Gymnasium environment IDs registered by `import so101_nexus.mujoco` (`MuJoCoTouch-v1`, `MuJoCoLookAt-v1`, `MuJoCoMove-v1`, `MuJoCoPickLift-v1`, `MuJoCoPickAndPlace-v1`, `MuJoCoStackCube-v1`) and their documented `gym.make` keyword arguments.
+- The documented Gymnasium environment IDs and construction keyword arguments:
+  - `import so101_nexus.mujoco` registers `MuJoCoTouch-v1`, `MuJoCoLookAt-v1`, `MuJoCoMove-v1`, `MuJoCoPickLift-v1`, `MuJoCoPickAndPlace-v1`, and `MuJoCoStackCube-v1`.
+  - `import so101_nexus.warp` registers `WarpTouch-v1`, `WarpLookAt-v1`, `WarpMove-v1`, `WarpPickLift-v1`, `WarpPickAndPlace-v1`, and `WarpStackCube-v1`.
 - `so101_nexus.__version__`.
 
 The following are internal and may change at any time without a major version bump:

--- a/docs/content/docs/concepts/customization.mdx
+++ b/docs/content/docs/concepts/customization.mdx
@@ -131,9 +131,7 @@ language-conditioned policies. Read it off `env.unwrapped.task_description`.
 
 ## Cameras and visual observations
 
-Add `WristCamera` or `OverheadCamera` to `observations` and the observation becomes a
-dictionary: a `"state"` key holding the flat vector from all state components, plus one
-key per camera.
+With the default `obs_mode="state"`, add `WristCamera` or `OverheadCamera` to `observations`. The observation becomes a dictionary. Its `"state"` key holds the selected state components. Each camera has a separate key.
 
 ```python
 import gymnasium as gym

--- a/docs/content/docs/concepts/lerobot.mdx
+++ b/docs/content/docs/concepts/lerobot.mdx
@@ -172,7 +172,7 @@ convention used by this library (synthetic calibration with `drive_mode=0`).
 
 ## Using LeRobot processors with SO101-Nexus envs
 
-`LeRobotEnvWrapper` requires a `Dict` observation space. Configure the env with at least one camera component (or pick another component beyond the default state-only set) before wrapping it.
+`LeRobotEnvWrapper` requires a `Dict` observation space. Configure at least one camera component before wrapping.
 
 ```python
 import so101_nexus.mujoco  # noqa: F401

--- a/docs/content/docs/concepts/observations.mdx
+++ b/docs/content/docs/concepts/observations.mdx
@@ -86,7 +86,7 @@ config = PickConfig(observations=[
 ])
 ```
 
-When the observation list contains only state components, the observation is a flat NumPy array. When it contains one or more camera components, the observation becomes a dictionary with a `"state"` key (flat vector from all state components) plus one key per camera (e.g. `"wrist_camera"`, `"overhead_camera"`).
+With `obs_mode="state"` (the default), a list with a camera component produces a dictionary. Its `"state"` key holds every selected state component. Each camera has a separate key, such as `"wrist_camera"` or `"overhead_camera"`.
 
 ## Default Observations by Task
 
@@ -117,6 +117,8 @@ The observation contains whatever components are listed in `observations`. This 
 ### `obs_mode="visual"`
 
 Designed for vision-based policies. Requires at least one camera component (e.g. `WristCamera()` or `OverheadCamera()`) in the `observations` list. Construction raises an error if no camera component is present.
+
+The returned dictionary contains the camera keys and a `"state"` key with `JointPositions` only. `info["privileged_state"]` contains the full selected state for a critic or diagnostic code, not as policy input.
 
 ```python
 from so101_nexus import PickConfig, JointPositions, WristCamera

--- a/docs/content/docs/environments/index.mdx
+++ b/docs/content/docs/environments/index.mdx
@@ -209,8 +209,7 @@ Default observation (23): `JointPositions` (6), `JointVelocities` (6), `EndEffec
 (7), `GazeDirection` (3), `GazeState` (1). `GazeDirection` is the unit vector from the
 wrist camera to the target; `GazeState` is the success predicate itself.
 
-Objects: `CubeObject` gaze targets only. There is nothing to grasp, so no grasp state is
-exposed.
+Objects: LookAt supports solid-color `CubeObject`, `CylinderObject`, `SphereObject`, and `PyramidObject` targets. There is nothing to grasp, so no grasp state is exposed.
 
 Task-specific field: `fov_deg`, the wrist camera's vertical field of view in degrees.
 Leave it at `None` (the default) to read the live camera FOV each step, so the success

--- a/docs/content/docs/getting-started/installation.mdx
+++ b/docs/content/docs/getting-started/installation.mdx
@@ -43,6 +43,7 @@ The base install ships the MuJoCo backend and the environment API. Everything el
 | --- | --- | --- |
 | `teleop` | Gradio demonstration recorder: `lerobot[feetech]`, `gradio`, `plotly`, `opencv-python` | `pip install "so101-nexus[teleop]"` |
 | `decomp` | Measured convex decomposition of YCB collision meshes (`coacd`, `rtree`, `threadpoolctl`). Without it YCB collision geometry falls back to a single convex hull. The packages ship wheels for the supported platforms | `pip install "so101-nexus[decomp]"` |
+| `viz` | Pillow image labels and high-quality resizing in visualization helpers | `pip install "so101-nexus[viz]"` |
 | `train` | Torch training dependencies for the PPO and BC examples | `pip install "so101-nexus[train]"` |
 | `warp` | GPU-parallel MuJoCo Warp backend. Needs an NVIDIA GPU and CUDA >= 12.8 | `pip install "so101-nexus[warp]"` |
 | `rocm` | PyTorch from AMD's ROCm 7.2 wheel index. See below | `uv sync --extra train --extra rocm --no-default-groups` |

--- a/tests/test_docs_consistency.py
+++ b/tests/test_docs_consistency.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import re
+import tomllib
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -370,3 +371,49 @@ def test_pick_and_place_baseline_matches_bc_ppo_docstring() -> None:
     assert "excluded until the environment is fixed" not in training, (
         "the PickAndPlace 'excluded' claim is stale: bc_ppo_warp.py solves it"
     )
+
+
+def test_installation_lists_every_package_extra() -> None:
+    """Installation docs must list every supported package extra."""
+    extras = tomllib.loads(_read(ROOT / "pyproject.toml"))["project"]["optional-dependencies"]
+    installation = _read(DOCS / "getting-started" / "installation.mdx")
+    documented = set(re.findall(r"^\| `([^`]+)` \|", installation, re.MULTILINE))
+
+    assert documented == set(extras), (
+        "installation docs extras differ from pyproject.toml: "
+        f"documented={sorted(documented)}, expected={sorted(extras)}"
+    )
+
+
+def test_policy_adapter_example_configures_default_cameras() -> None:
+    """The recorder example must provide each camera that it reads by default."""
+    policies = _read(DOCS / "api" / "policies.mdx")
+    match = re.search(r"## End-to-End Usage\n\n```python\n(.*?)```", policies, re.DOTALL)
+
+    assert match, "could not locate the policy adapter end-to-end example"
+    example = match.group(1)
+    assert re.search(
+        r"config = PickConfig\(\n"
+        r'    obs_mode="visual",\n'
+        r"    observations=\[JointPositions\(\), WristCamera\(\), OverheadCamera\(\)\],\n"
+        r"\)",
+        example,
+    )
+    assert re.search(
+        r"env = gym\.make\(\n"
+        r'    "MuJoCoPickLift-v1",\n'
+        r"    config=config,",
+        example,
+    )
+
+
+def test_lerobot_wrapper_docs_require_a_camera_component() -> None:
+    """The LeRobot wrapper docs must state the Dict observation requirement."""
+    pages = (
+        DOCS / "api" / "lerobot-processors.mdx",
+        DOCS / "concepts" / "lerobot.mdx",
+    )
+    for page in pages:
+        text = _read(page)
+        assert "at least one camera component" in text
+        assert "or another non-default observation" not in text


### PR DESCRIPTION
## Summary
- Audit public documentation against current implementation.
- Correct installation, visual observation, API, and LeRobot workflow guidance.
- Add regressions for package extras and policy-recorder camera setup.

## Validation
- uv run pytest tests/test_docs_consistency.py -q
- uv run pytest tests/core/test_rollout_recorder.py -q
- make format && make lint && make typecheck
- pnpm build